### PR TITLE
Feature 16

### DIFF
--- a/netbox_access_lists/navigation.py
+++ b/netbox_access_lists/navigation.py
@@ -26,9 +26,10 @@ menu_items = (
         link_text='Access Lists',
         buttons=accesslist_buttons
     ),
-    PluginMenuItem(
-        link='plugins:netbox_access_lists:accesslistrule_list',
-        link_text='Access List Rules',
-        buttons=accesslistrule_butons
-    ),
+    # # Comment out Access List Rule to force creation in the ACL view
+    # PluginMenuItem(
+    #     link='plugins:netbox_access_lists:accesslistrule_list',
+    #     link_text='Access List Rules',
+    #     buttons=accesslistrule_butons
+    # ),
 )

--- a/netbox_access_lists/templates/netbox_access_lists/accesslist.html
+++ b/netbox_access_lists/templates/netbox_access_lists/accesslist.html
@@ -1,6 +1,43 @@
 {% extends 'generic/object.html' %}
 {% load render_table from django_tables2 %}
 
+{% block breadcrumbs %}
+<li class="breadcrumb-item"><a href="{% url 'plugins:netbox_access_lists:accesslist_list' %}">Access Lists</a></li>
+{% endblock %}
+{% block controls %}
+<div class="pull-right noprint">
+    {% if perms.netbox_access_lists.change_policy %}
+    <a href="{% url 'plugins:netbox_access_lists:accesslistrule_add' %}?access_list={{ object.pk }}" class="btn btn-success">
+        <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Rule
+    </a>
+    {% endif %}
+    {% if perms.netbox_access_lists.change_policy %}
+    <a href="{% url 'plugins:netbox_access_lists:accesslist_edit' pk=object.pk %}" class="btn btn-warning">
+        <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit
+    </a>
+    {% endif %}
+    {% if perms.netbox_access_lists.delete_policy %}
+    <a href="{% url 'plugins:netbox_access_lists:accesslist_delete' pk=object.pk %}" class="btn btn-danger">
+        <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete
+    </a>
+    {% endif %}
+</div>
+{% endblock controls %}
+{% block tabs %}
+<ul class="nav nav-tabs px-3">
+    {% block tab_items %}
+    <li class="nav-item" role="presentation">
+        <a class="nav-link{% if not active_tab %} active{% endif %}" href="{{ object.get_absolute_url }}">{{ object|meta:"verbose_name"|bettertitle }}</a>
+    </li>
+    {% endblock tab_items %}
+    {% if perms.extras.view_objectchange %}
+    <li role="presentation" class="nav-item">
+        <a href="{% url 'plugins:netbox_access_lists:accesslist_changelog' pk=object.pk %}" class="nav-link{% if active_tab == 'changelog'%} active{% endif %}">Change Log</a>
+    </li>
+    {% endif %}
+</ul>
+{% endblock tabs %}
+
 {% block content %}
   <div class="row mb-3">
     <div class="col col-md-6">

--- a/netbox_access_lists/templates/netbox_access_lists/routingpolicy.html
+++ b/netbox_access_lists/templates/netbox_access_lists/routingpolicy.html
@@ -1,0 +1,94 @@
+{% extends 'generic/object.html' %}
+{% load buttons %}
+{% load custom_links %}
+{% load helpers %}
+{% load plugins %}
+{% load render_table from django_tables2 %}
+
+{% block breadcrumbs %}
+<li class="breadcrumb-item"><a href="{% url 'plugins:netbox_bgp:routingpolicy_list' %}">Routing Policies</a></li>
+{% endblock %}
+{% block controls %}
+<div class="pull-right noprint">
+    {% if perms.netbox_bgp.change_policy %}
+    <a href="{% url 'plugins:netbox_bgp:routingpolicyrule_add' %}?routing_policy={{ object.pk }}" class="btn btn-success">
+        <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Rule
+    </a>
+    {% endif %}
+    {% if perms.netbox_bgp.change_policy %}
+    <a href="{% url 'plugins:netbox_bgp:routingpolicy_edit' pk=object.pk %}" class="btn btn-warning">
+        <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit
+    </a>
+    {% endif %}
+    {% if perms.netbox_bgp.delete_policy %}
+    <a href="{% url 'plugins:netbox_bgp:routingpolicy_delete' pk=object.pk %}" class="btn btn-danger">
+        <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete
+    </a>
+    {% endif %}
+</div>
+{% endblock controls %}
+{% block tabs %}
+<ul class="nav nav-tabs px-3">
+    {% block tab_items %}
+    <li class="nav-item" role="presentation">
+        <a class="nav-link{% if not active_tab %} active{% endif %}" href="{{ object.get_absolute_url }}">{{ object|meta:"verbose_name"|bettertitle }}</a>
+    </li>
+    {% endblock tab_items %}
+    {% if perms.extras.view_objectchange %}
+    <li role="presentation" class="nav-item">
+        <a href="{% url 'plugins:netbox_bgp:routingpolicy_changelog' pk=object.pk %}" class="nav-link{% if active_tab == 'changelog'%} active{% endif %}">Change Log</a>
+    </li>
+    {% endif %}
+</ul>
+{% endblock tabs %}
+
+{% block content %}
+<div class="row mb-3">
+    <div class="col-md-4">
+        <div class="card">
+            <h5 class="card-header">
+                Routing Policy
+            </h5>
+            <div class="card-body">
+                <table class="table table-hover attr-table">
+                    <tr>
+                        <td>name</td>
+                        <td>{{ object.name }}</td>
+                    </tr>
+                    <tr>
+                        <td>Description</td>
+                        <td>{{ object.description|placeholder }}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        {% include 'inc/panels/custom_fields.html' %}
+        {% include 'inc/panels/tags.html' %}
+        {% plugin_left_page object %}
+    </div>
+    <div class="col-md-8">
+        <div class="card">
+            <h5 class="card-header">
+                Related BGP Sessions
+            </h5>
+            <div class="card-body">
+                {% render_table related_session_table 'inc/table.html' %}
+            </div>
+            {% plugin_right_page object %}
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <h5 class="card-header">
+                Rules
+            </h5>
+            <div class="card-body">
+                {% render_table rules_table 'inc/table.html' %}
+            </div>
+            {% plugin_full_width_page object %}
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #16 

## New Behavior

Similar to netbox-bgp's single routing policy view where you can only add a policy rule to a policy from within the policy;s UI view, I enabled a UI workflow for ACL rules to be only addable via the UI using the ACL's view.

...

## Contrast to Current Behavior

ACL Rule and ACL are 2 separate UI pages and workflows

...

## Discussion: Benefits and Drawbacks

Pros:

- Be able add a rule to the list in the same view you can see all rules for an ACL

Cons:

- Harder to search all ACL rules (no matter the ACL)

...

## Changes to the Documentation

To be handled in a future feature.

...

## Proposed Release Note Entry

Simplified & consolidate UI workflow for adding rules to an ACL

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the `dev` branch.
