### PR TITLE
Add ACL card to device page

### DIFF
--- a/.devcontainer/configuration/plugins.py
+++ b/.devcontainer/configuration/plugins.py
@@ -5,9 +5,11 @@
 # See https://github.com/netbox-community/netbox-docker/wiki/Using-Netbox-Plugins
 
 PLUGINS = [
-    "netbox_access_lists"
+    "netbox_access_lists",
+    "netbox_secretstore"
     ]
 
 PLUGINS_CONFIG = {
-    "netbox_access_lists":{}
+    "netbox_access_lists": {},
+    "netbox_secretstore": {}
 }

--- a/netbox_access_lists/template_content.py
+++ b/netbox_access_lists/template_content.py
@@ -1,0 +1,34 @@
+
+from django.contrib.contenttypes.models import ContentType
+
+from extras.plugins import PluginTemplateExtension
+from .models import AccessList
+
+
+class AccessLists(PluginTemplateExtension):
+
+    def right_page(self):
+        obj = self.context['object']
+
+        access_lists = None
+        ctype = ContentType.objects.get_for_model(obj)
+        if ctype.model == 'device':
+            access_lists = AccessList.objects.filter(device=obj.pk)
+        #elif ctype.model == 'virtualmachine':
+        #    access_lists = AccessList.objects.filter(device=obj.pk)
+
+        return self.render('inc/device_access_lists.html', extra_context={
+            'access_lists': access_lists,
+            'type': ctype.model if ctype.model == 'device' else ctype.name.replace(' ', '_'),
+        })
+
+
+class DeviceAccessLists(AccessLists):
+    model = 'dcim.device'
+
+
+#class VMAccessLists(AccessLists):
+#    model = 'virtualization.virtualmachine'
+
+
+template_extensions = [DeviceAccessLists]

--- a/netbox_access_lists/templates/inc/assigned_access_lists.html
+++ b/netbox_access_lists/templates/inc/assigned_access_lists.html
@@ -1,0 +1,23 @@
+{% if access_lists %}
+
+<table class="table table-hover">
+    <tr>
+        <th>Name</th>
+        <th>Type</th>
+        <th>Default Action</th>
+        <th>Rule Count</th>
+    </tr>
+    {% for access_list in access_lists %}
+        <tr>
+            <td>{{ access_list|linkify }}</td>
+            <td>{{ access_list.type|title }}</td>
+            <td>{{ access_list.default_action|title }}</td>
+            <td>{{ access_list.rules.count }}</td>
+        </tr>
+    {% endfor %}
+</table>
+{% else %}
+<div class="text-muted">
+    None found
+</div>
+{% endif %}

--- a/netbox_access_lists/templates/inc/device_access_lists.html
+++ b/netbox_access_lists/templates/inc/device_access_lists.html
@@ -1,0 +1,13 @@
+    <div class="card">
+        <h5 class="card-header">
+            Access Lists
+        </h5>
+        <div class="card-body">
+            {% include 'inc/assigned_access_lists.html' %}
+        </div>
+        <div class="card-footer text-end noprint">
+            <a href="{% url 'plugins:netbox_access_lists:accesslist_add' %}?{{ type }}={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-sm btn-primary">
+                <i class="mdi mdi-plus-thick"></i> Add Access List
+            </a>
+        </div>
+    </div>


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #37

## New Behavior

Add ACL card to device page

## Contrast to Current Behavior

No ACL card to device page

## Discussion: Benefits and Drawbacks

Gives you a view of ACLs per device.

## Changes to the Documentation

TBD

## Proposed Release Note Entry

- Added ACL card on device page.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the `dev` branch.
