### PR TITLE
Added a short explanation how to run devcontainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ PLUGINS_CONFIG = {
 }
 ```
 
+## Developing
+
+### VSCode + Docker + Dev Containers
+
+To develop this plugin further one can use the included .devcontainer configuration. This configuration creates a docker container which includes a fully working netbox installation. Currently it should work when using WSL 2. For this to work make sure you have Docker Desktop installed and the WSL 2 integrations activated.
+
+1.) In the WSL terminal, enter `code` to run Visual studio code.
+2.) Install the devcontainer extension "ms-vscode-remote.remote-containers"
+3.) Press Ctrl+Shift+P and use the "Dev Container: Clone Repository in Container Volume" function to clone this repository. This will take a while depending on your computer
+4.) If you'd like the netbox instance to be prepopulated run `make Makefile example_initializers` and `make Makefile load_initializers`
+5.) Start the netbox instance using `make Makefile all`
+
+Your netbox instance will be served under 0.0.0.0:8000 so it should now be available under localhost:8000.
+
 ## Screenshots
 
 Access List - List View

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ PLUGINS_CONFIG = {
 
 To develop this plugin further one can use the included .devcontainer configuration. This configuration creates a docker container which includes a fully working netbox installation. Currently it should work when using WSL 2. For this to work make sure you have Docker Desktop installed and the WSL 2 integrations activated.
 
-1.) In the WSL terminal, enter `code` to run Visual studio code.
-2.) Install the devcontainer extension "ms-vscode-remote.remote-containers"
-3.) Press Ctrl+Shift+P and use the "Dev Container: Clone Repository in Container Volume" function to clone this repository. This will take a while depending on your computer
-4.) If you'd like the netbox instance to be prepopulated run `make Makefile example_initializers` and `make Makefile load_initializers`
-5.) Start the netbox instance using `make Makefile all`
+1. In the WSL terminal, enter `code` to run Visual studio code.
+1. Install the devcontainer extension "ms-vscode-remote.remote-containers"
+1. Press Ctrl+Shift+P and use the "Dev Container: Clone Repository in Container Volume" function to clone this repository. This will take a while depending on your computer
+1. If you'd like the netbox instance to be prepopulated run `make Makefile example_initializers` and `make Makefile load_initializers`
+1. Start the netbox instance using `make Makefile all`
 
 Your netbox instance will be served under 0.0.0.0:8000 so it should now be available under localhost:8000.
 


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `devel` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->
# Pull Request

## Related Issue

#75

## Discussion: Benefits and Drawbacks

No Drawbacks. The project/community will benefit from the change as it shows how to use the included tooling, which will only run when installed in a specific way.

## Changes to the Documentation

The READMEshould contain a short snippet explaining how to use the .devcontainer setup included in the repository. It should also contain a short explanation on how to use the makefile to this end


## Proposed Release Note Entry

None

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.
