### PR TITLE
[Docs]: Specify that it's necessary to run manage.py migrate #186

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ PLUGINS_CONFIG = {
 }
 ```
 
+To add the required `netbox-acls` tables to your NetBox database, run the `migrate` manager subcommand in your NetBox directory:
+```
+./manage.py migrate
+```
+
 ## Developing
 
 ### VSCode + Docker + Dev Containers

--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ PLUGINS_CONFIG = {
 }
 ```
 
-To add the required `netbox-acls` tables to your NetBox database, run the `migrate` manager subcommand in your NetBox directory:
+To add the required `netbox-acls` tables to your NetBox database, run the `migrate` manager subcommand in the NetBox virtual environment:
 ```
-./manage.py migrate
+cd /opt/netbox
+sudo ./venv/bin/python3 netbox/manage.py migrate
 ```
 
 ## Developing


### PR DESCRIPTION
# Pull Request

## Related Issue

#186

## New Behavior

Update top-level README.md to specify that running `manage.py migrate` is necessary to achieve a working installation

## Contrast to Current Behavior

The current top-level README.md omits this important instruction.

## Discussion: Benefits and Drawbacks

Benefits:
- New users with limited prior plugin experience won't end up with an installed but nonfunctional plugin

Drawbacks:
- None perceived

## Changes to the Documentation

This PR is a documentation PR.

## Proposed Release Note Entry

Document the necessity of running `manage.py migrate` in README

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.
