### PR TITLE
Corrected target branch name in repo PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 Thank you for sharing your work and for opening a PR.
 
 (!) IMPORTANT (!):
-First make sure that you point your PR to the `devel` branch!
+First make sure that you point your PR to the `dev` branch!
 
 Now please read the comments carefully and try to provide information
 on all relevant titles.


### PR DESCRIPTION
# Pull Request

## Related Issue

#188 

## New Behavior
PR template correctly names `dev` as target branch

## Contrast to Current Behavior
Target branch name was `devel`, which does not exist

## Discussion: Benefits and Drawbacks
Benefits:
- Less confusion for first-time contributors

Drawbacks:
- None foreseen

## Changes to the Documentation
N/A

## Proposed Release Note Entry
Corrected the name of the suggested target branch name in the project's pull request template

## Double Check
* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.
