### PR TITLE
Add ACL group functionality

### DIFF
--- a/netbox_acls/api/nested_serializers.py
+++ b/netbox_acls/api/nested_serializers.py
@@ -11,6 +11,8 @@ from ..models import (
     ACLExtendedRule,
     ACLInterfaceAssignment,
     ACLStandardRule,
+    ACLGroup,
+    ACLGroupInterfaceAssignment,
 )
 
 __all__ = [
@@ -18,6 +20,8 @@ __all__ = [
     "NestedACLInterfaceAssignmentSerializer",
     "NestedACLStandardRuleSerializer",
     "NestedACLExtendedRuleSerializer",
+    "NestedACLGroupSerializer",
+    "NestedACLGroupInterfaceAssignmentSerializer",
 ]
 
 
@@ -91,3 +95,39 @@ class NestedACLExtendedRuleSerializer(WritableNestedSerializer):
 
         model = ACLExtendedRule
         fields = ("id", "url", "display", "index")
+
+
+class NestedACLGroupSerializer(WritableNestedSerializer):
+    """
+    Defines the nested serializer for the django ACLGroup model & associates it to a view.
+    """
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_acls-api:aclgroup-detail",
+    )
+
+    class Meta:
+        """
+        Associates the django model ACLGroup & fields to the nested serializer.
+        """
+
+        model = ACLGroup
+        fields = ("id", "url", "display", "name")
+
+
+class NestedACLGroupInterfaceAssignmentSerializer(WritableNestedSerializer):
+    """
+    Defines the nested serializer for the django ACLGroupInterfaceAssignment model & associates it to a view.
+    """
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_acls-api:aclgroupinterfaceassignment-detail",
+    )
+
+    class Meta:
+        """
+        Associates the django model ACLGroupInterfaceAssignment & fields to the nested serializer.
+        """
+
+        model = ACLGroupInterfaceAssignment
+        fields = ("id", "url", "display", "acl_group", "interface")

--- a/netbox_acls/api/serializers.py
+++ b/netbox_acls/api/serializers.py
@@ -17,6 +17,8 @@ from ..models import (
     ACLExtendedRule,
     ACLInterfaceAssignment,
     ACLStandardRule,
+    ACLGroup,
+    ACLGroupInterfaceAssignment,
 )
 from .nested_serializers import NestedAccessListSerializer
 
@@ -25,6 +27,8 @@ __all__ = [
     "ACLInterfaceAssignmentSerializer",
     "ACLStandardRuleSerializer",
     "ACLExtendedRuleSerializer",
+    "ACLGroupSerializer",
+    "ACLGroupInterfaceAssignmentSerializer",
 ]
 
 # Sets a standard error message for ACL rules with an action of remark, but no remark set.
@@ -50,6 +54,11 @@ class AccessListSerializer(NetBoxModelSerializer):
         queryset=ContentType.objects.filter(ACL_HOST_ASSIGNMENT_MODELS),
     )
     assigned_object = serializers.SerializerMethodField(read_only=True)
+    group = serializers.PrimaryKeyRelatedField(
+        queryset=ACLGroup.objects.all(),
+        required=False,
+        allow_null=True,
+    )
 
     class Meta:
         """
@@ -73,6 +82,7 @@ class AccessListSerializer(NetBoxModelSerializer):
             "created",
             "last_updated",
             "rule_count",
+            "group",
         )
         brief_fields = ("id", "url", "name", "display")
 
@@ -337,3 +347,63 @@ class ACLExtendedRuleSerializer(NetBoxModelSerializer):
             raise serializers.ValidationError(error_message)
 
         return super().validate(data)
+
+
+class ACLGroupSerializer(NetBoxModelSerializer):
+    """
+    Defines the serializer for the django ACLGroup model & associates it to a view.
+    """
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_acls-api:aclgroup-detail",
+    )
+
+    class Meta:
+        """
+        Associates the django model ACLGroup & fields to the serializer.
+        """
+
+        model = ACLGroup
+        fields = (
+            "id",
+            "url",
+            "name",
+            "description",
+            "created",
+            "last_updated",
+        )
+        brief_fields = ("id", "url", "name")
+
+
+class ACLGroupInterfaceAssignmentSerializer(NetBoxModelSerializer):
+    """
+    Defines the serializer for the django ACLGroupInterfaceAssignment model & associates it to a view.
+    """
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_acls-api:aclgroupinterfaceassignment-detail",
+    )
+    acl_group = serializers.PrimaryKeyRelatedField(
+        queryset=ACLGroup.objects.all(),
+    )
+    interface = serializers.PrimaryKeyRelatedField(
+        queryset=Interface.objects.all(),
+    )
+
+    class Meta:
+        """
+        Associates the django model ACLGroupInterfaceAssignment & fields to the serializer.
+        """
+
+        model = ACLGroupInterfaceAssignment
+        fields = (
+            "id",
+            "url",
+            "acl_group",
+            "interface",
+            "direction",
+            "comments",
+            "created",
+            "last_updated",
+        )
+        brief_fields = ("id", "url", "acl_group", "interface")

--- a/netbox_acls/api/views.py
+++ b/netbox_acls/api/views.py
@@ -13,6 +13,8 @@ from .serializers import (
     ACLExtendedRuleSerializer,
     ACLInterfaceAssignmentSerializer,
     ACLStandardRuleSerializer,
+    ACLGroupSerializer,
+    ACLGroupInterfaceAssignmentSerializer,
 )
 
 __all__ = [
@@ -20,6 +22,8 @@ __all__ = [
     "ACLStandardRuleViewSet",
     "ACLInterfaceAssignmentViewSet",
     "ACLExtendedRuleViewSet",
+    "ACLGroupViewSet",
+    "ACLGroupInterfaceAssignmentViewSet",
 ]
 
 
@@ -79,3 +83,27 @@ class ACLExtendedRuleViewSet(NetBoxModelViewSet):
     )
     serializer_class = ACLExtendedRuleSerializer
     filterset_class = filtersets.ACLExtendedRuleFilterSet
+
+
+class ACLGroupViewSet(NetBoxModelViewSet):
+    """
+    Defines the view set for the django ACLGroup model & associates it to a view.
+    """
+
+    queryset = models.ACLGroup.objects.prefetch_related("tags")
+    serializer_class = ACLGroupSerializer
+    filterset_class = filtersets.ACLGroupFilterSet
+
+
+class ACLGroupInterfaceAssignmentViewSet(NetBoxModelViewSet):
+    """
+    Defines the view set for the django ACLGroupInterfaceAssignment model & associates it to a view.
+    """
+
+    queryset = models.ACLGroupInterfaceAssignment.objects.prefetch_related(
+        "acl_group",
+        "interface",
+        "tags",
+    )
+    serializer_class = ACLGroupInterfaceAssignmentSerializer
+    filterset_class = filtersets.ACLGroupInterfaceAssignmentFilterSet

--- a/netbox_acls/forms/filtersets.py
+++ b/netbox_acls/forms/filtersets.py
@@ -29,6 +29,8 @@ from ..models import (
     ACLExtendedRule,
     ACLInterfaceAssignment,
     ACLStandardRule,
+    ACLGroup,
+    ACLGroupInterfaceAssignment,
 )
 
 __all__ = (
@@ -36,6 +38,8 @@ __all__ = (
     "ACLInterfaceAssignmentFilterForm",
     "ACLStandardRuleFilterForm",
     "ACLExtendedRuleFilterForm",
+    "ACLGroupFilterForm",
+    "ACLGroupInterfaceAssignmentFilterForm",
 )
 
 
@@ -88,11 +92,16 @@ class AccessListFilterForm(NetBoxModelFilterSetForm):
         required=False,
         label="Default Action",
     )
+    group = DynamicModelChoiceField(
+        queryset=ACLGroup.objects.all(),
+        required=False,
+        label="ACL Group",
+    )
     tag = TagFilterField(model)
 
     fieldsets = (
         FieldSet("region", "site_group", "site", "device_id", "virtual_chassis_id", "virtual_machine_id", name=_("Host Details")),
-        FieldSet("type", "default_action", name=_('ACL Details')),
+        FieldSet("type", "default_action", "group", name=_('ACL Details')),
         FieldSet("q", "tag",name=None)
     )
 
@@ -226,4 +235,50 @@ class ACLExtendedRuleFilterForm(NetBoxModelFilterSetForm):
     fieldsets = (
         FieldSet("access_list", "action", "source_prefix", "desintation_prefix", "protocol", name=_('Rule Details')),
         FieldSet("q", "tag",name=None)
+    )
+
+
+class ACLGroupFilterForm(NetBoxModelFilterSetForm):
+    """
+    GUI filter form to search the django ACLGroup model.
+    """
+
+    model = ACLGroup
+    tag = TagFilterField(model)
+    name = forms.CharField(
+        required=False,
+        label="Name",
+    )
+
+    fieldsets = (
+        FieldSet("name", name=_('ACL Group Details')),
+        FieldSet("q", "tag", name=None)
+    )
+
+
+class ACLGroupInterfaceAssignmentFilterForm(NetBoxModelFilterSetForm):
+    """
+    GUI filter form to search the django ACLGroupInterfaceAssignment model.
+    """
+
+    model = ACLGroupInterfaceAssignment
+    tag = TagFilterField(model)
+    acl_group = DynamicModelChoiceField(
+        queryset=ACLGroup.objects.all(),
+        required=False,
+        label="ACL Group",
+    )
+    interface = DynamicModelChoiceField(
+        queryset=Interface.objects.all(),
+        required=False,
+        label="Interface",
+    )
+    direction = forms.ChoiceField(
+        choices=add_blank_choice(ACLAssignmentDirectionChoices),
+        required=False,
+    )
+
+    fieldsets = (
+        FieldSet("acl_group", "interface", "direction", name=_('ACL Group Interface Assignment Details')),
+        FieldSet("q", "tag", name=None)
     )

--- a/netbox_acls/templates/netbox_acls/accesslist_edit.html
+++ b/netbox_acls/templates/netbox_acls/accesslist_edit.html
@@ -11,6 +11,7 @@
   {% render_field form.name %}
   {% render_field form.type %}
   {% render_field form.default_action %}
+  {% render_field form.group %}
   {% render_field form.tags %}
 </div>
 <div class="field-group">

--- a/netbox_acls/tests/test_api.py
+++ b/netbox_acls/tests/test_api.py
@@ -1,4 +1,4 @@
-from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site, Interface
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from rest_framework import status
@@ -93,5 +93,115 @@ class ACLTestCase(
                 "assigned_object_id": device.id,
                 "type": ACLTypeChoices.TYPE_STANDARD,
                 "default_action": ACLActionChoices.ACTION_DENY,
+            },
+        ]
+
+
+class ACLGroupTestCase(
+    APIViewTestCases.APIViewTestCase,
+):
+    """Test the ACLGroup Test"""
+
+    model = ACLGroup
+    view_namespace = "plugins-api:netbox_acls"
+    brief_fields = ["display", "id", "name", "url"]
+
+    @classmethod
+    def setUpTestData(cls):
+        acl_groups = (
+            ACLGroup(
+                name="testgroup1",
+                description="Test Group 1",
+            ),
+            ACLGroup(
+                name="testgroup2",
+                description="Test Group 2",
+            ),
+            ACLGroup(
+                name="testgroup3",
+                description="Test Group 3",
+            ),
+        )
+        ACLGroup.objects.bulk_create(acl_groups)
+
+        cls.create_data = [
+            {
+                "name": "testgroup4",
+                "description": "Test Group 4",
+            },
+            {
+                "name": "testgroup5",
+                "description": "Test Group 5",
+            },
+            {
+                "name": "testgroup6",
+                "description": "Test Group 6",
+            },
+        ]
+
+
+class ACLGroupInterfaceAssignmentTestCase(
+    APIViewTestCases.APIViewTestCase,
+):
+    """Test the ACLGroupInterfaceAssignment Test"""
+
+    model = ACLGroupInterfaceAssignment
+    view_namespace = "plugins-api:netbox_acls"
+    brief_fields = ["display", "id", "acl_group", "interface", "url"]
+
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.create(name="Site 1", slug="site-1")
+        manufacturer = Manufacturer.objects.create(
+            name="Manufacturer 1",
+            slug="manufacturer-1",
+        )
+        devicetype = DeviceType.objects.create(
+            manufacturer=manufacturer,
+            model="Device Type 1",
+        )
+        devicerole = DeviceRole.objects.create(
+            name="Device Role 1",
+            slug="device-role-1",
+        )
+        device = Device.objects.create(
+            name="Device 1",
+            site=site,
+            device_type=devicetype,
+            role=devicerole,
+        )
+        interface = Interface.objects.create(
+            device=device,
+            name="Interface 1",
+        )
+        acl_group = ACLGroup.objects.create(
+            name="testgroup1",
+            description="Test Group 1",
+        )
+
+        acl_group_interface_assignments = (
+            ACLGroupInterfaceAssignment(
+                acl_group=acl_group,
+                interface=interface,
+                direction=ACLAssignmentDirectionChoices.DIRECTION_IN,
+            ),
+            ACLGroupInterfaceAssignment(
+                acl_group=acl_group,
+                interface=interface,
+                direction=ACLAssignmentDirectionChoices.DIRECTION_OUT,
+            ),
+        )
+        ACLGroupInterfaceAssignment.objects.bulk_create(acl_group_interface_assignments)
+
+        cls.create_data = [
+            {
+                "acl_group": acl_group.id,
+                "interface": interface.id,
+                "direction": ACLAssignmentDirectionChoices.DIRECTION_IN,
+            },
+            {
+                "acl_group": acl_group.id,
+                "interface": interface.id,
+                "direction": ACLAssignmentDirectionChoices.DIRECTION_OUT,
             },
         ]


### PR DESCRIPTION
Add support for assigning ACLs to multiple devices and interfaces.

* Add `ACLGroup` and `ACLGroupInterfaceAssignment` models in `netbox_acls/models/access_lists.py`.
* Update serializers in `netbox_acls/api/serializers.py` and `netbox_acls/api/nested_serializers.py` to support `ACLGroup` and `ACLGroupInterfaceAssignment`.
* Create views for `ACLGroup` and `ACLGroupInterfaceAssignment` in `netbox_acls/api/views.py`.
* Update forms in `netbox_acls/forms/models.py` to include `ACLGroup` and `ACLGroupInterfaceAssignment`.
* Add filters in `netbox_acls/filtersets.py` and `netbox_acls/forms/filtersets.py` for `ACLGroup` and `ACLGroupInterfaceAssignment`.
* Update templates in `netbox_acls/templates/netbox_acls/` to include `ACLGroup` and `ACLGroupInterfaceAssignment`.
* Modify existing `AccessList` and `ACLInterfaceAssignment` models in `netbox_acls/models/access_lists.py` to support grouping.
* Add test cases for `ACLGroup` and `ACLGroupInterfaceAssignment` models in `netbox_acls/tests/test_api.py`.

