### PR TITLE
Add ACL group model and update related components

### DIFF
--- a/netbox_acls/api/nested_serializers.py
+++ b/netbox_acls/api/nested_serializers.py
@@ -11,6 +11,7 @@ from ..models import (
     ACLExtendedRule,
     ACLInterfaceAssignment,
     ACLStandardRule,
+    ACLGroup,
 )
 
 __all__ = [
@@ -18,6 +19,7 @@ __all__ = [
     "NestedACLInterfaceAssignmentSerializer",
     "NestedACLStandardRuleSerializer",
     "NestedACLExtendedRuleSerializer",
+    "NestedACLGroupSerializer",
 ]
 
 
@@ -36,7 +38,7 @@ class NestedAccessListSerializer(WritableNestedSerializer):
         """
 
         model = AccessList
-        fields = ("id", "url", "display", "name")
+        fields = ("id", "url", "display", "name", "acl_group")
 
 
 class NestedACLInterfaceAssignmentSerializer(WritableNestedSerializer):
@@ -91,3 +93,21 @@ class NestedACLExtendedRuleSerializer(WritableNestedSerializer):
 
         model = ACLExtendedRule
         fields = ("id", "url", "display", "index")
+
+
+class NestedACLGroupSerializer(WritableNestedSerializer):
+    """
+    Defines the nested serializer for the django ACLGroup model & associates it to a view.
+    """
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_acls-api:aclgroup-detail",
+    )
+
+    class Meta:
+        """
+        Associates the django model ACLGroup & fields to the nested serializer.
+        """
+
+        model = ACLGroup
+        fields = ("id", "url", "display", "name")

--- a/netbox_acls/api/serializers.py
+++ b/netbox_acls/api/serializers.py
@@ -17,14 +17,16 @@ from ..models import (
     ACLExtendedRule,
     ACLInterfaceAssignment,
     ACLStandardRule,
+    ACLGroup,
 )
-from .nested_serializers import NestedAccessListSerializer
+from .nested_serializers import NestedAccessListSerializer, NestedACLGroupSerializer
 
 __all__ = [
     "AccessListSerializer",
     "ACLInterfaceAssignmentSerializer",
     "ACLStandardRuleSerializer",
     "ACLExtendedRuleSerializer",
+    "ACLGroupSerializer",
 ]
 
 # Sets a standard error message for ACL rules with an action of remark, but no remark set.
@@ -50,6 +52,7 @@ class AccessListSerializer(NetBoxModelSerializer):
         queryset=ContentType.objects.filter(ACL_HOST_ASSIGNMENT_MODELS),
     )
     assigned_object = serializers.SerializerMethodField(read_only=True)
+    acl_group = NestedACLGroupSerializer(required=False, allow_null=True)
 
     class Meta:
         """
@@ -73,6 +76,7 @@ class AccessListSerializer(NetBoxModelSerializer):
             "created",
             "last_updated",
             "rule_count",
+            "acl_group",
         )
         brief_fields = ("id", "url", "name", "display")
 
@@ -337,3 +341,29 @@ class ACLExtendedRuleSerializer(NetBoxModelSerializer):
             raise serializers.ValidationError(error_message)
 
         return super().validate(data)
+
+
+class ACLGroupSerializer(NetBoxModelSerializer):
+    """
+    Defines the serializer for the django ACLGroup model & associates it to a view.
+    """
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_acls-api:aclgroup-detail",
+    )
+
+    class Meta:
+        """
+        Associates the django model ACLGroup & fields to the serializer.
+        """
+
+        model = ACLGroup
+        fields = (
+            "id",
+            "url",
+            "name",
+            "devices",
+            "virtual_chassis",
+            "virtual_machines",
+        )
+        brief_fields = ("id", "url", "name")

--- a/netbox_acls/graphql/filters.py
+++ b/netbox_acls/graphql/filters.py
@@ -7,6 +7,7 @@ __all__ = (
     'ACLInterfaceAssignmentFilter',
     'ACLExtendedRuleFilter',
     'ACLStandardRuleFilter',
+    'ACLGroupFilter',
 )
 
 @strawberry_django.filter(models.AccessList, lookups=True)
@@ -27,4 +28,9 @@ class ACLExtendedRuleFilter(BaseFilterMixin):
 @strawberry_django.filter(models.ACLInterfaceAssignment, lookups=True)
 @autotype_decorator(filtersets.ACLInterfaceAssignmentFilterSet)
 class ACLInterfaceAssignmentFilter(BaseFilterMixin):
+    pass
+
+@strawberry_django.filter(models.ACLGroup, lookups=True)
+@autotype_decorator(filtersets.ACLGroupFilterSet)
+class ACLGroupFilter(BaseFilterMixin):
     pass

--- a/netbox_acls/graphql/schema.py
+++ b/netbox_acls/graphql/schema.py
@@ -18,3 +18,5 @@ class NetBoxACLSQuery:
     acl_standard_rule: ACLStandardRuleType = strawberry_django.field()
     acl_standard_rule_list: List[ACLStandardRuleType] = strawberry_django.field()
 
+    acl_group: ACLGroupType = strawberry_django.field()
+    acl_group_list: List[ACLGroupType] = strawberry_django.field()

--- a/netbox_acls/graphql/types.py
+++ b/netbox_acls/graphql/types.py
@@ -27,7 +27,7 @@ class AccessListType(OrganizationalObjectType):
         Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')],
         Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')],
     ], strawberry.union("ACLAssignmentType")]
-
+    acl_group: Annotated["ACLGroupType", strawberry.lazy("netbox_acls.graphql.types")]
 
     class Meta:
         """
@@ -53,9 +53,6 @@ class ACLInterfaceAssignmentType(OrganizationalObjectType):
         Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')],
         Annotated["VMInterfaceType", strawberry.lazy('virtualization.graphql.types')],
     ], strawberry.union("ACLInterfaceAssignmentType")]
-
-    
-
 
     class Meta:
         """
@@ -111,3 +108,23 @@ class ACLStandardRuleType(OrganizationalObjectType):
         def aclstandardrules(self) -> List[Annotated["ACLStandardRule", strawberry.lazy('aclstandardrule.graphql.types')]]:
             return self.aclstandardrules.all()
 
+@strawberry_django.type(
+    models.ACLGroup,
+    fields='__all__',
+    filters=ACLGroupFilter
+)
+class ACLGroupType(OrganizationalObjectType):
+    """
+    Defines the object type for the django model ACLGroup.
+    """
+    devices: List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]
+    virtual_chassis: List[Annotated["VirtualChassisType", strawberry.lazy('dcim.graphql.types')]]
+    virtual_machines: List[Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')]]
+
+    class Meta:
+        """
+        Associates the filterset, fields, and model for the django model ACLGroup.
+        """
+        @strawberry_django.field
+        def aclgroups(self) -> List[Annotated["ACLGroup", strawberry.lazy('aclgroup.graphql.types')]]:
+            return self.aclgroups.all()

--- a/netbox_acls/tables.py
+++ b/netbox_acls/tables.py
@@ -5,13 +5,14 @@ Define the object lists / table view for each of the plugin models.
 import django_tables2 as tables
 from netbox.tables import ChoiceFieldColumn, NetBoxTable, columns
 
-from .models import AccessList, ACLExtendedRule, ACLInterfaceAssignment, ACLStandardRule
+from .models import AccessList, ACLExtendedRule, ACLInterfaceAssignment, ACLStandardRule, ACLGroup
 
 __all__ = (
     "AccessListTable",
     "ACLInterfaceAssignmentTable",
     "ACLStandardRuleTable",
     "ACLExtendedRuleTable",
+    "ACLGroupTable",
 )
 
 
@@ -49,6 +50,10 @@ class AccessListTable(NetBoxTable):
     rule_count = tables.Column(
         verbose_name="Rule Count",
     )
+    acl_group = tables.Column(
+        linkify=True,
+        verbose_name="ACL Group",
+    )
     tags = columns.TagColumn(
         url_name="plugins:netbox_acls:accesslist_list",
     )
@@ -66,6 +71,7 @@ class AccessListTable(NetBoxTable):
             "comments",
             "action",
             "tags",
+            "acl_group",
         )
         default_columns = (
             "name",
@@ -74,6 +80,7 @@ class AccessListTable(NetBoxTable):
             "rule_count",
             "default_action",
             "tags",
+            "acl_group",
         )
 
 
@@ -207,4 +214,52 @@ class ACLExtendedRuleTable(NetBoxTable):
             "destination_prefix",
             "destination_ports",
             "protocol",
+        )
+
+
+class ACLGroupTable(NetBoxTable):
+    """
+    Defines the table view for the ACLGroup model.
+    """
+
+    pk = columns.ToggleColumn()
+    id = tables.Column(
+        linkify=True,
+    )
+    name = tables.Column(
+        linkify=True,
+    )
+    devices = tables.ManyToManyColumn(
+        linkify_item=True,
+        verbose_name="Devices",
+    )
+    virtual_chassis = tables.ManyToManyColumn(
+        linkify_item=True,
+        verbose_name="Virtual Chassis",
+    )
+    virtual_machines = tables.ManyToManyColumn(
+        linkify_item=True,
+        verbose_name="Virtual Machines",
+    )
+    tags = columns.TagColumn(
+        url_name="plugins:netbox_acls:aclgroup_list",
+    )
+
+    class Meta(NetBoxTable.Meta):
+        model = ACLGroup
+        fields = (
+            "pk",
+            "id",
+            "name",
+            "devices",
+            "virtual_chassis",
+            "virtual_machines",
+            "tags",
+        )
+        default_columns = (
+            "name",
+            "devices",
+            "virtual_chassis",
+            "virtual_machines",
+            "tags",
         )

--- a/netbox_acls/views.py
+++ b/netbox_acls/views.py
@@ -32,6 +32,11 @@ __all__ = (
     "ACLExtendedRuleEditView",
     "ACLExtendedRuleDeleteView",
     "ACLExtendedRuleBulkDeleteView",
+    "ACLGroupView",
+    "ACLGroupListView",
+    "ACLGroupEditView",
+    "ACLGroupDeleteView",
+    "ACLGroupBulkDeleteView",
 )
 
 
@@ -469,3 +474,53 @@ class ACLExtendedRuleBulkDeleteView(generic.BulkDeleteView):
     )
     filterset = filtersets.ACLExtendedRuleFilterSet
     table = tables.ACLExtendedRuleTable
+
+
+#
+# ACLGroup views
+#
+
+
+@register_model_view(models.ACLGroup)
+class ACLGroupView(generic.ObjectView):
+    """
+    Defines the view for the ACLGroup django model.
+    """
+
+    queryset = models.ACLGroup.objects.prefetch_related("tags")
+
+
+class ACLGroupListView(generic.ObjectListView):
+    """
+    Defines the list view for the ACLGroup django model.
+    """
+
+    queryset = models.ACLGroup.objects.prefetch_related("tags")
+    table = tables.ACLGroupTable
+    filterset = filtersets.ACLGroupFilterSet
+    filterset_form = forms.ACLGroupFilterForm
+
+
+@register_model_view(models.ACLGroup, "edit")
+class ACLGroupEditView(generic.ObjectEditView):
+    """
+    Defines the edit view for the ACLGroup django model.
+    """
+
+    queryset = models.ACLGroup.objects.prefetch_related("tags")
+    form = forms.ACLGroupForm
+
+
+@register_model_view(models.ACLGroup, "delete")
+class ACLGroupDeleteView(generic.ObjectDeleteView):
+    """
+    Defines delete view for the ACLGroup django model.
+    """
+
+    queryset = models.ACLGroup.objects.prefetch_related("tags")
+
+
+class ACLGroupBulkDeleteView(generic.BulkDeleteView):
+    queryset = models.ACLGroup.objects.prefetch_related("tags")
+    filterset = filtersets.ACLGroupFilterSet
+    table = tables.ACLGroupTable


### PR DESCRIPTION
Add support for assigning an ACL to multiple devices and interfaces within the plugin.

* **Models**: Add a new model `ACLGroup` to represent a group of devices or interfaces. Update `AccessList` model to include a foreign key to `ACLGroup`.
* **Serializers**: Add a serializer for the new `ACLGroup` model. Update `AccessListSerializer` to include `ACLGroup`.
* **Nested Serializers**: Add a nested serializer for the new `ACLGroup` model. Update `NestedAccessListSerializer` to include `ACLGroup`.
* **Views**: Update views to handle ACL assignments to `ACLGroup`. Add views for the new `ACLGroup` model.
* **Forms**: Add a form for the new `ACLGroup` model. Update `AccessListForm` to include `ACLGroup`.
* **Tables**: Add a table view for the new `ACLGroup` model. Update `AccessListTable` to include `ACLGroup`.
* **Filtersets**: Add a filter set for the new `ACLGroup` model. Update `AccessListFilterSet` to include `ACLGroup`.
* **GraphQL**: Add a type for the new `ACLGroup` model. Update `AccessListType` to include `ACLGroup`. Add queries for the new `ACLGroup` model. Add a filter for the new `ACLGroup` model.

