### PR TITLE
Closes #241 - Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-docstring-first
       - id: check-merge-conflict
@@ -14,14 +14,14 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
       - id: isort
         args:
           - "--profile=black"
         exclude: ^.devcontainer/
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 25.1.0
     hooks:
       - id: black
         language_version: python3
@@ -33,22 +33,22 @@ repos:
         args:
           - "--py36-plus"
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.2.0
     hooks:
       - id: flake8
         exclude: ^.devcontainer/
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         args:
-          - "--py39-plus"
+          - "--py310-plus"
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.32.0
+    rev: v1.37.1
     hooks:
       - id: yamllint
   - repo: https://github.com/econchick/interrogate
-    rev: 1.5.0
+    rev: 1.7.0
     hooks:
       - id: interrogate
         args: [--fail-under=90, --verbose]
@@ -59,13 +59,17 @@ repos:
   #    - id: htmlhint
   #      args: [--config, .htmlhintrc]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.37.0
+    rev: v0.44.0
     hooks:
       - id: markdownlint
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.292
+    rev: v0.11.10
     hooks:
+      # Run the linter.
       - id: ruff
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format
   #- repo: local
   #  hooks:
   #    - id: wily
@@ -84,3 +88,4 @@ repos:
   #      args:
   #        - --diff=git diff HEAD
   #        - --no-summary
+...

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,64 @@
+# Ruff configuration
+####################
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Enforce line length and indent-width
+line-length = 120
+indent-width = 4
+
+# Always generate Python 3.10-compatible code.
+target-version = "py310"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Enforce UNIX line ending
+line-ending = "lf"


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `dev` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->
# Pull Request

## Related Issue

Fixes #241 [Housekeeping]: Update pre-commit hooks

## New Behavior

Upgrade multiple pre-commit hooks to their latest versions for improved compatibility. Adjusted arguments where necessary to align with updated features or requirements.

- `pre-commit-hooks`: `v5.0.0`
- `isort`: `6.0.1`
- `black`: `25.1.0`
- `add-trailing-comma`: `v3.1.0`
- `flake8`: `7.2.0`
- `pyupgrade`: `v3.19.1`
- `yamllint`: `v1.37.1`
- `interrogate`: `1.7.0`
- `markdownlint-cli`: `v0.44.0`
- `ruff-pre-commit`: `v0.11.10`

## Contrast to Current Behavior

This update follows the latest best practices and adds support for newer language features.

## Discussion: Benefits and Drawbacks

Adds support for newer language features.

## Changes to the Documentation

None

## Proposed Release Note Entry

None

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.
