### PR TITLE
fix(table): Disable sorting for host column

### DIFF
--- a/netbox_acls/tables.py
+++ b/netbox_acls/tables.py
@@ -3,6 +3,7 @@ Define the object lists / table view for each of the plugin models.
 """
 
 import django_tables2 as tables
+from django.utils.translation import gettext_lazy as _
 from netbox.tables import ChoiceFieldColumn, NetBoxTable, columns
 
 from .models import AccessList, ACLExtendedRule, ACLInterfaceAssignment, ACLStandardRule
@@ -34,9 +35,9 @@ class AccessListTable(NetBoxTable):
         linkify=True,
     )
     assigned_object = tables.Column(
-        linkify=True,
+        verbose_name=_("Assigned Host"),
         orderable=False,
-        verbose_name="Assigned Host",
+        linkify=True,
     )
     name = tables.Column(
         linkify=True,
@@ -47,7 +48,7 @@ class AccessListTable(NetBoxTable):
     type = ChoiceFieldColumn()
     default_action = ChoiceFieldColumn()
     rule_count = tables.Column(
-        verbose_name="Rule Count",
+        verbose_name=_("Rule Count"),
     )
     tags = columns.TagColumn(
         url_name="plugins:netbox_acls:accesslist_list",
@@ -92,11 +93,12 @@ class ACLInterfaceAssignmentTable(NetBoxTable):
     direction = ChoiceFieldColumn()
     host = tables.TemplateColumn(
         template_code=COL_HOST_ASSIGNMENT,
+        orderable=False,
     )
     assigned_object = tables.Column(
-        linkify=True,
+        verbose_name=_("Assigned Interface"),
         orderable=False,
-        verbose_name="Assigned Interface",
+        linkify=True,
     )
     tags = columns.TagColumn(
         url_name="plugins:netbox_acls:aclinterfaceassignment_list",


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `dev` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->
# Pull Request

## Related Issue

Fixes: #245 [Bug]: Sorting the host column of interface assignment leads to an error

## New Behavior

Prevent FieldError by disabling sorting for the "Host" column, which is a TemplateColumn without a direct database field.

## Contrast to Current Behavior

This fix disables sorting for the column to prevent errors.

## Discussion: Benefits and Drawbacks

Sorting the "Host" column in the Interface Assignments view caused a FieldError because the column is a TemplateColumn without a direct database field.

## Changes to the Documentation

None required.

## Proposed Release Note Entry

Fixed a FieldError when sorting the 'Host' column in the Interface Assignment table by disabling sorting for this column.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.
