### PR TITLE
feat(api): Use JSONField for assigned_object serializer

### DIFF
--- a/netbox_acls/api/serializers.py
+++ b/netbox_acls/api/serializers.py
@@ -73,13 +73,13 @@ class AccessListSerializer(NetBoxModelSerializer):
             "last_updated",
             "rule_count",
         )
-        brief_fields = ("id", "url", "name", "display")
+        brief_fields = ("id", "url", "display", "name")
 
-    @extend_schema_field(serializers.DictField())
+    @extend_schema_field(serializers.JSONField(allow_null=True))
     def get_assigned_object(self, obj):
-        serializer = get_serializer_for_model(
-            obj.assigned_object,
-        )
+        if obj.assigned_object is None:
+            return None
+        serializer = get_serializer_for_model(obj.assigned_object)
         context = {"request": self.context["request"]}
         return serializer(obj.assigned_object, nested=True, context=context).data
 
@@ -126,6 +126,7 @@ class ACLInterfaceAssignmentSerializer(NetBoxModelSerializer):
         fields = (
             "id",
             "url",
+            "display",
             "access_list",
             "direction",
             "assigned_object_type",
@@ -137,10 +138,12 @@ class ACLInterfaceAssignmentSerializer(NetBoxModelSerializer):
             "created",
             "last_updated",
         )
-        brief_fields = ("id", "url", "access_list")
+        brief_fields = ("id", "url", "display", "access_list")
 
-    @extend_schema_field(serializers.DictField())
+    @extend_schema_field(serializers.JSONField(allow_null=True))
     def get_assigned_object(self, obj):
+        if obj.assigned_object is None:
+            return None
         serializer = get_serializer_for_model(obj.assigned_object)
         context = {"request": self.context["request"]}
         return serializer(obj.assigned_object, nested=True, context=context).data
@@ -203,15 +206,15 @@ class ACLStandardRuleSerializer(NetBoxModelSerializer):
             "access_list",
             "index",
             "action",
-            "tags",
-            "description",
             "remark",
+            "source_prefix",
+            "description",
+            "tags",
             "created",
             "custom_fields",
             "last_updated",
-            "source_prefix",
         )
-        brief_fields = ("id", "url", "display")
+        brief_fields = ("id", "url", "display", "access_list", "index")
 
     def validate(self, data):
         """
@@ -274,19 +277,19 @@ class ACLExtendedRuleSerializer(NetBoxModelSerializer):
             "access_list",
             "index",
             "action",
-            "tags",
-            "description",
-            "created",
-            "custom_fields",
-            "last_updated",
+            "remark",
+            "protocol",
             "source_prefix",
             "source_ports",
             "destination_prefix",
             "destination_ports",
-            "protocol",
-            "remark",
+            "description",
+            "tags",
+            "created",
+            "custom_fields",
+            "last_updated",
         )
-        brief_fields = ("id", "url", "display")
+        brief_fields = ("id", "url", "display", "access_list", "index")
 
     def validate(self, data):
         """

--- a/netbox_acls/models/access_lists.py
+++ b/netbox_acls/models/access_lists.py
@@ -28,7 +28,7 @@ alphanumeric_plus = RegexValidator(
 
 class AccessList(NetBoxModel):
     """
-    Model defintion for Access Lists.
+    Model definition for Access Lists.
     """
 
     name = models.CharField(
@@ -89,10 +89,9 @@ class AccessList(NetBoxModel):
 
 class ACLInterfaceAssignment(NetBoxModel):
     """
-    Model defintion for Access Lists associations with other Host interfaces:
+    Model definition for Access Lists associations with other Host interfaces:
       - VM interfaces
       - device interface
-      - tbd on more
     """
 
     access_list = models.ForeignKey(
@@ -119,6 +118,7 @@ class ACLInterfaceAssignment(NetBoxModel):
     )
 
     clone_fields = ("access_list", "direction")
+    prerequisite_models = ("netbox_acls.AccessList",)
 
     class Meta:
         unique_together = [
@@ -136,6 +136,9 @@ class ACLInterfaceAssignment(NetBoxModel):
         verbose_name = "ACL Interface Assignment"
         verbose_name_plural = "ACL Interface Assignments"
 
+    def __str__(self):
+        return f"{self.access_list}: Interface {self.assigned_object}"
+
     def get_absolute_url(self):
         """
         The method is a Django convention; although not strictly required,
@@ -145,10 +148,6 @@ class ACLInterfaceAssignment(NetBoxModel):
             "plugins:netbox_acls:aclinterfaceassignment",
             args=[self.pk],
         )
-
-    @classmethod
-    def get_prerequisite_models(cls):
-        return [AccessList]
 
     def get_direction_color(self):
         return ACLAssignmentDirectionChoices.colors.get(self.direction)


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `dev` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->
# Pull Request

## Related Issue

Fixes: #247 [Housekeeping]: Use JSONField for assigned_object serializer

## New Behavior

- Replaces `DictField` with `JSONField` for `assigned_object` to align with NetBox best practices.
- Ensures missing `assigned_object` returns `None` without errors.
- Adds `display` to `brief_fields` for `ACLInterfaceAssignment` and improves its string representation.

## Contrast to Current Behavior

- Uses `JSONField`, which is the preferred approach in NetBox core.
- Adds the `display` attribute to `ACLInterfaceAssignment`, ensuring consistency with other NetBox API objects.

## Discussion: Benefits and Drawbacks

- **Benefits**: Improves adherence to best practices, enhances consistency, and simplifies data handling.
- **Drawbacks**: Minimal, as this is mostly a **code cleanup**.

## Changes to the Documentation

- **None required** (behavior remains functionally similar).

## Proposed Release Note Entry

- **None required** (internal improvement).

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.
