### PR TITLE
#249 [Housekeeping]: Use NetBoxObjectType for GraphQL

### DIFF
--- a/netbox_acls/graphql/__init__.py
+++ b/netbox_acls/graphql/__init__.py
@@ -1,7 +1,3 @@
-from .schema import *
-from .types import *
+from .schema import NetBoxACLSQuery
 
-schema = [
-    schema.NetBoxACLSQuery
-]
-
+schema = [NetBoxACLSQuery]

--- a/netbox_acls/graphql/filters.py
+++ b/netbox_acls/graphql/filters.py
@@ -1,28 +1,33 @@
 import strawberry_django
+from netbox.graphql.filter_mixins import BaseFilterMixin, autotype_decorator
+
 from .. import filtersets, models
-from netbox.graphql.filter_mixins import autotype_decorator, BaseFilterMixin
 
 __all__ = (
-    'AccessListFilter',
-    'ACLInterfaceAssignmentFilter',
-    'ACLExtendedRuleFilter',
-    'ACLStandardRuleFilter',
+    "AccessListFilter",
+    "ACLInterfaceAssignmentFilter",
+    "ACLExtendedRuleFilter",
+    "ACLStandardRuleFilter",
 )
+
 
 @strawberry_django.filter(models.AccessList, lookups=True)
 @autotype_decorator(filtersets.AccessListFilterSet)
 class AccessListFilter(BaseFilterMixin):
     pass
 
+
 @strawberry_django.filter(models.ACLStandardRule, lookups=True)
 @autotype_decorator(filtersets.ACLStandardRuleFilterSet)
 class ACLStandardRuleFilter(BaseFilterMixin):
     pass
 
+
 @strawberry_django.filter(models.ACLExtendedRule, lookups=True)
 @autotype_decorator(filtersets.ACLExtendedRuleFilterSet)
 class ACLExtendedRuleFilter(BaseFilterMixin):
     pass
+
 
 @strawberry_django.filter(models.ACLInterfaceAssignment, lookups=True)
 @autotype_decorator(filtersets.ACLInterfaceAssignmentFilterSet)

--- a/netbox_acls/graphql/schema.py
+++ b/netbox_acls/graphql/schema.py
@@ -1,14 +1,21 @@
+from typing import List
+
 import strawberry
 import strawberry_django
-from .types import *
-from ..models import *
-from typing import List
+
+from .types import (
+    AccessListType,
+    ACLExtendedRuleType,
+    ACLStandardRuleType,
+)
+
 
 @strawberry.type(name="Query")
 class NetBoxACLSQuery:
     """
     Defines the queries available to this plugin via the graphql api.
     """
+
     access_list: AccessListType = strawberry_django.field()
     access_list_list: List[AccessListType] = strawberry_django.field()
 
@@ -17,4 +24,3 @@ class NetBoxACLSQuery:
 
     acl_standard_rule: ACLStandardRuleType = strawberry_django.field()
     acl_standard_rule_list: List[ACLStandardRuleType] = strawberry_django.field()
-

--- a/netbox_acls/graphql/types.py
+++ b/netbox_acls/graphql/types.py
@@ -6,7 +6,7 @@ from typing import Annotated, List, Union
 
 import strawberry
 import strawberry_django
-from netbox.graphql.types import OrganizationalObjectType
+from netbox.graphql.types import NetBoxObjectType
 
 from .. import models
 from . import filters
@@ -18,7 +18,7 @@ from . import filters
     exclude=["assigned_object_type", "assigned_object_id"],
     filters=filters.AccessListFilter,
 )
-class AccessListType(OrganizationalObjectType):
+class AccessListType(NetBoxObjectType):
     """
     Defines the object type for the django model AccessList.
     """
@@ -48,7 +48,7 @@ class AccessListType(OrganizationalObjectType):
     exclude=["assigned_object_type", "assigned_object_id"],
     filters=filters.ACLInterfaceAssignmentFilter,
 )
-class ACLInterfaceAssignmentType(OrganizationalObjectType):
+class ACLInterfaceAssignmentType(NetBoxObjectType):
     """
     Defines the object type for the django model AccessList.
     """
@@ -80,7 +80,7 @@ class ACLInterfaceAssignmentType(OrganizationalObjectType):
     fields="__all__",
     filters=filters.ACLExtendedRuleFilter,
 )
-class ACLExtendedRuleType(OrganizationalObjectType):
+class ACLExtendedRuleType(NetBoxObjectType):
     """
     Defines the object type for the django model ACLExtendedRule.
     """
@@ -108,7 +108,7 @@ class ACLExtendedRuleType(OrganizationalObjectType):
     fields="__all__",
     filters=filters.ACLStandardRuleFilter,
 )
-class ACLStandardRuleType(OrganizationalObjectType):
+class ACLStandardRuleType(NetBoxObjectType):
     """
     Defines the object type for the django model ACLStandardRule.
     """

--- a/netbox_acls/graphql/types.py
+++ b/netbox_acls/graphql/types.py
@@ -32,15 +32,6 @@ class AccessListType(NetBoxObjectType):
         strawberry.union("ACLAssignmentType"),
     ]
 
-    class Meta:
-        """
-        Associates the filterset, fields, and model for the django model AccessList.
-        """
-
-        @strawberry_django.field
-        def accesslists(self) -> List[Annotated["AccessList", strawberry.lazy("accesslists.graphql.types")]]:
-            return self.accesslists.all()
-
 
 @strawberry_django.type(
     models.ACLInterfaceAssignment,
@@ -63,17 +54,6 @@ class ACLInterfaceAssignmentType(NetBoxObjectType):
         strawberry.union("ACLInterfaceAssignmentType"),
     ]
 
-    class Meta:
-        """
-        Associates the filterset, fields, and model for the django model ACLInterfaceAssignment.
-        """
-
-        @strawberry_django.field
-        def aclinterfaceassignments(
-            self,
-        ) -> List[Annotated["ACLInterfaceAssignment", strawberry.lazy("aclinterfaceassignments.graphql.types")]]:
-            return self.aclinterfaceassignments.all()
-
 
 @strawberry_django.type(
     models.ACLExtendedRule,
@@ -91,17 +71,6 @@ class ACLExtendedRuleType(NetBoxObjectType):
     destination_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
     source_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
 
-    class Meta:
-        """
-        Associates the filterset, fields, and model for the django model ACLExtendedRule.
-        """
-
-        @strawberry_django.field
-        def aclextendedrules(
-            self,
-        ) -> List[Annotated["ACLExtendedRule", strawberry.lazy("aclextendedrule.graphql.types")]]:
-            return self.aclextendedrules.all()
-
 
 @strawberry_django.type(
     models.ACLStandardRule,
@@ -115,14 +84,3 @@ class ACLStandardRuleType(NetBoxObjectType):
 
     access_list: Annotated["AccessListType", strawberry.lazy("netbox_acls.graphql.types")]
     source_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
-
-    class Meta:
-        """
-        Associates the filterset, fields, and model for the django model ACLExtendedRule.
-        """
-
-        @strawberry_django.field
-        def aclstandardrules(
-            self,
-        ) -> List[Annotated["ACLStandardRule", strawberry.lazy("aclstandardrule.graphql.types")]]:
-            return self.aclstandardrules.all()

--- a/netbox_acls/graphql/types.py
+++ b/netbox_acls/graphql/types.py
@@ -1,80 +1,90 @@
 """
-Define the object types and queries availble via the graphql api.
+Define the object types and queries available via the graphql api.
 """
+
+from typing import Annotated, List, Union
 
 import strawberry
 import strawberry_django
-
-
-from typing import Annotated, List, Union
-from .filters import *
-from .. import models
 from netbox.graphql.types import OrganizationalObjectType
+
+from .. import models
+from . import filters
+
 
 @strawberry_django.type(
     models.AccessList,
-    fields='__all__',
-    filters=AccessListFilter,
-    exclude=('assigned_object_type', 'assigned_object_id')
+    fields="__all__",
+    exclude=["assigned_object_type", "assigned_object_id"],
+    filters=filters.AccessListFilter,
 )
-
 class AccessListType(OrganizationalObjectType):
     """
     Defines the object type for the django model AccessList.
     """
-    assigned_object_type: Annotated["ContentTypeType", strawberry.lazy("netbox.graphql.types")]
-    assigned_object: Annotated[Union[
-        Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')],
-        Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')],
-    ], strawberry.union("ACLAssignmentType")]
 
+    assigned_object_type: Annotated["ContentTypeType", strawberry.lazy("netbox.graphql.types")]
+    assigned_object: Annotated[
+        Union[
+            Annotated["DeviceType", strawberry.lazy("dcim.graphql.types")],
+            Annotated["VirtualMachineType", strawberry.lazy("virtualization.graphql.types")],
+        ],
+        strawberry.union("ACLAssignmentType"),
+    ]
 
     class Meta:
         """
         Associates the filterset, fields, and model for the django model AccessList.
         """
+
         @strawberry_django.field
-        def accesslists(self) -> List[Annotated["AccessList", strawberry.lazy('accesslists.graphql.types')]]:
+        def accesslists(self) -> List[Annotated["AccessList", strawberry.lazy("accesslists.graphql.types")]]:
             return self.accesslists.all()
-        
+
+
 @strawberry_django.type(
     models.ACLInterfaceAssignment,
-    fields='__all__',
-    exclude=('assigned_object_type', 'assigned_object_id'),
-    filters=ACLInterfaceAssignmentFilter
+    fields="__all__",
+    exclude=["assigned_object_type", "assigned_object_id"],
+    filters=filters.ACLInterfaceAssignmentFilter,
 )
 class ACLInterfaceAssignmentType(OrganizationalObjectType):
     """
     Defines the object type for the django model AccessList.
     """
+
     access_list: Annotated["AccessListType", strawberry.lazy("netbox_acls.graphql.types")]
     assigned_object_type: Annotated["ContentTypeType", strawberry.lazy("netbox.graphql.types")]
-    assigned_object: Annotated[Union[
-        Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')],
-        Annotated["VMInterfaceType", strawberry.lazy('virtualization.graphql.types')],
-    ], strawberry.union("ACLInterfaceAssignmentType")]
-
-    
-
+    assigned_object: Annotated[
+        Union[
+            Annotated["InterfaceType", strawberry.lazy("dcim.graphql.types")],
+            Annotated["VMInterfaceType", strawberry.lazy("virtualization.graphql.types")],
+        ],
+        strawberry.union("ACLInterfaceAssignmentType"),
+    ]
 
     class Meta:
         """
         Associates the filterset, fields, and model for the django model ACLInterfaceAssignment.
         """
+
         @strawberry_django.field
-        def aclinterfaceassignments(self) -> List[Annotated["ACLInterfaceAssignment", strawberry.lazy('aclinterfaceassignments.graphql.types')]]:
+        def aclinterfaceassignments(
+            self,
+        ) -> List[Annotated["ACLInterfaceAssignment", strawberry.lazy("aclinterfaceassignments.graphql.types")]]:
             return self.aclinterfaceassignments.all()
+
 
 @strawberry_django.type(
     models.ACLExtendedRule,
-    fields='__all__',
-    filters=ACLExtendedRuleFilter
+    fields="__all__",
+    filters=filters.ACLExtendedRuleFilter,
 )
-
 class ACLExtendedRuleType(OrganizationalObjectType):
     """
     Defines the object type for the django model ACLExtendedRule.
     """
+
     source_ports: List[int]
     destination_ports: List[int]
     access_list: Annotated["AccessListType", strawberry.lazy("netbox_acls.graphql.types")]
@@ -85,21 +95,24 @@ class ACLExtendedRuleType(OrganizationalObjectType):
         """
         Associates the filterset, fields, and model for the django model ACLExtendedRule.
         """
+
         @strawberry_django.field
-        def aclextendedrules(self) -> List[Annotated["ACLExtendedRule", strawberry.lazy('aclextendedrule.graphql.types')]]:
+        def aclextendedrules(
+            self,
+        ) -> List[Annotated["ACLExtendedRule", strawberry.lazy("aclextendedrule.graphql.types")]]:
             return self.aclextendedrules.all()
 
 
 @strawberry_django.type(
     models.ACLStandardRule,
-    fields='__all__',
-    filters=ACLStandardRuleFilter
+    fields="__all__",
+    filters=filters.ACLStandardRuleFilter,
 )
-
 class ACLStandardRuleType(OrganizationalObjectType):
     """
     Defines the object type for the django model ACLStandardRule.
     """
+
     access_list: Annotated["AccessListType", strawberry.lazy("netbox_acls.graphql.types")]
     source_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
 
@@ -107,7 +120,9 @@ class ACLStandardRuleType(OrganizationalObjectType):
         """
         Associates the filterset, fields, and model for the django model ACLExtendedRule.
         """
-        @strawberry_django.field
-        def aclstandardrules(self) -> List[Annotated["ACLStandardRule", strawberry.lazy('aclstandardrule.graphql.types')]]:
-            return self.aclstandardrules.all()
 
+        @strawberry_django.field
+        def aclstandardrules(
+            self,
+        ) -> List[Annotated["ACLStandardRule", strawberry.lazy("aclstandardrule.graphql.types")]]:
+            return self.aclstandardrules.all()

--- a/netbox_acls/graphql/types.py
+++ b/netbox_acls/graphql/types.py
@@ -66,7 +66,7 @@ class ACLStandardRuleType(NetBoxObjectType):
     """
 
     access_list: Annotated["AccessListType", strawberry.lazy("netbox_acls.graphql.types")]
-    source_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
+    source_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")] | None
 
 
 @strawberry_django.type(
@@ -80,7 +80,7 @@ class ACLExtendedRuleType(NetBoxObjectType):
     """
 
     access_list: Annotated["AccessListType", strawberry.lazy("netbox_acls.graphql.types")]
-    source_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
+    source_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")] | None
     source_ports: List[int] | None
-    destination_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
+    destination_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")] | None
     destination_ports: List[int] | None

--- a/netbox_acls/graphql/types.py
+++ b/netbox_acls/graphql/types.py
@@ -56,23 +56,6 @@ class ACLInterfaceAssignmentType(NetBoxObjectType):
 
 
 @strawberry_django.type(
-    models.ACLExtendedRule,
-    fields="__all__",
-    filters=filters.ACLExtendedRuleFilter,
-)
-class ACLExtendedRuleType(NetBoxObjectType):
-    """
-    Defines the object type for the django model ACLExtendedRule.
-    """
-
-    source_ports: List[int]
-    destination_ports: List[int]
-    access_list: Annotated["AccessListType", strawberry.lazy("netbox_acls.graphql.types")]
-    destination_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
-    source_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
-
-
-@strawberry_django.type(
     models.ACLStandardRule,
     fields="__all__",
     filters=filters.ACLStandardRuleFilter,
@@ -84,3 +67,20 @@ class ACLStandardRuleType(NetBoxObjectType):
 
     access_list: Annotated["AccessListType", strawberry.lazy("netbox_acls.graphql.types")]
     source_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
+
+
+@strawberry_django.type(
+    models.ACLExtendedRule,
+    fields="__all__",
+    filters=filters.ACLExtendedRuleFilter,
+)
+class ACLExtendedRuleType(NetBoxObjectType):
+    """
+    Defines the object type for the django model ACLExtendedRule.
+    """
+
+    access_list: Annotated["AccessListType", strawberry.lazy("netbox_acls.graphql.types")]
+    source_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
+    source_ports: List[int]
+    destination_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
+    destination_ports: List[int]

--- a/netbox_acls/graphql/types.py
+++ b/netbox_acls/graphql/types.py
@@ -81,6 +81,6 @@ class ACLExtendedRuleType(NetBoxObjectType):
 
     access_list: Annotated["AccessListType", strawberry.lazy("netbox_acls.graphql.types")]
     source_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
-    source_ports: List[int]
+    source_ports: List[int] | None
     destination_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")]
-    destination_ports: List[int]
+    destination_ports: List[int] | None


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `dev` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->
# Pull Request

## Related Issue

Fixes: #249 – **[Housekeeping]** Use `NetBoxObjectType` for GraphQL

## New Behavior

- Replaced `OrganizationalObjectType` with `NetBoxObjectType` in GraphQL.
- Removed the `Meta` class from GraphQL types.
- Cleaned up the GraphQL codebase to align with NetBox best practices.
- Allowed nullable **source** and **destination** ports in GraphQL.
- Allowed nullable **prefix** fields in GraphQL types.

## Contrast to Current Behavior

- **`source_ports` and `destination_ports`** now support `null` values, ensuring compatibility when no ports are specified.
- **`source_prefix` and `destination_prefix`** fields are now nullable, preventing errors when prefixes are not provided.

## Discussion: Benefits and Drawbacks

- The **AccessList** models inherit from `NetBoxModel`, which includes several feature mixins. These features were missing when using `OrganizationalObjectType` as the parent class in GraphQL. Switching to `NetBoxObjectType` ensures that all NetBox model features are properly available in GraphQL.

## Changes to the Documentation

**None required** (behavior remains consistent with expected NetBox GraphQL functionality).

## Proposed Release Note Entry

**None required** (internal improvement).

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.
