### PR TITLE
refactor(views): Streamline view registrations

### DIFF
--- a/netbox_acls/urls.py
+++ b/netbox_acls/urls.py
@@ -5,32 +5,13 @@ Map Views to URLs.
 from django.urls import include, path
 from utilities.urls import get_model_urls
 
-from . import views
+from . import views  # noqa F401
 
 urlpatterns = (
     # Access Lists
-    path("access-lists/", views.AccessListListView.as_view(), name="accesslist_list"),
     path(
-        "access-lists/add/",
-        views.AccessListEditView.as_view(),
-        name="accesslist_add",
-    ),
-    # path('access-lists/edit/', views.AccessListBulkEditView.as_view(), name='accesslist_bulk_edit'),
-    path(
-        "access-lists/delete/",
-        views.AccessListBulkDeleteView.as_view(),
-        name="accesslist_bulk_delete",
-    ),
-    path("access-lists/<int:pk>/", views.AccessListView.as_view(), name="accesslist"),
-    path(
-        "access-lists/<int:pk>/edit/",
-        views.AccessListEditView.as_view(),
-        name="accesslist_edit",
-    ),
-    path(
-        "access-lists/<int:pk>/delete/",
-        views.AccessListDeleteView.as_view(),
-        name="accesslist_delete",
+        "access-lists/",
+        include(get_model_urls("netbox_acls", "accesslist", detail=False)),
     ),
     path(
         "access-lists/<int:pk>/",
@@ -39,38 +20,7 @@ urlpatterns = (
     # Access List Interface Assignments
     path(
         "interface-assignments/",
-        views.ACLInterfaceAssignmentListView.as_view(),
-        name="aclinterfaceassignment_list",
-    ),
-    path(
-        "interface-assignments/add/",
-        views.ACLInterfaceAssignmentEditView.as_view(),
-        name="aclinterfaceassignment_add",
-    ),
-    # path(
-    #    "interface-assignments/edit/",
-    #    views.ACLInterfaceAssignmentBulkEditView.as_view(),
-    #    name="aclinterfaceassignment_bulk_edit"
-    # ),
-    path(
-        "interface-assignments/delete/",
-        views.ACLInterfaceAssignmentBulkDeleteView.as_view(),
-        name="aclinterfaceassignment_bulk_delete",
-    ),
-    path(
-        "interface-assignments/<int:pk>/",
-        views.ACLInterfaceAssignmentView.as_view(),
-        name="aclinterfaceassignment",
-    ),
-    path(
-        "interface-assignments/<int:pk>/edit/",
-        views.ACLInterfaceAssignmentEditView.as_view(),
-        name="aclinterfaceassignment_edit",
-    ),
-    path(
-        "interface-assignments/<int:pk>/delete/",
-        views.ACLInterfaceAssignmentDeleteView.as_view(),
-        name="aclinterfaceassignment_delete",
+        include(get_model_urls("netbox_acls", "aclinterfaceassignment", detail=False)),
     ),
     path(
         "interface-assignments/<int:pk>/",
@@ -79,33 +29,7 @@ urlpatterns = (
     # Standard Access List Rules
     path(
         "standard-rules/",
-        views.ACLStandardRuleListView.as_view(),
-        name="aclstandardrule_list",
-    ),
-    path(
-        "standard-rules/add/",
-        views.ACLStandardRuleEditView.as_view(),
-        name="aclstandardrule_add",
-    ),
-    path(
-        "standard-rules/delete/",
-        views.ACLStandardRuleBulkDeleteView.as_view(),
-        name="aclstandardrule_bulk_delete",
-    ),
-    path(
-        "standard-rules/<int:pk>/",
-        views.ACLStandardRuleView.as_view(),
-        name="aclstandardrule",
-    ),
-    path(
-        "standard-rules/<int:pk>/edit/",
-        views.ACLStandardRuleEditView.as_view(),
-        name="aclstandardrule_edit",
-    ),
-    path(
-        "standard-rules/<int:pk>/delete/",
-        views.ACLStandardRuleDeleteView.as_view(),
-        name="aclstandardrule_delete",
+        include(get_model_urls("netbox_acls", "aclstandardrule", detail=False)),
     ),
     path(
         "standard-rules/<int:pk>/",
@@ -114,33 +38,7 @@ urlpatterns = (
     # Extended Access List Rules
     path(
         "extended-rules/",
-        views.ACLExtendedRuleListView.as_view(),
-        name="aclextendedrule_list",
-    ),
-    path(
-        "extended-rules/add/",
-        views.ACLExtendedRuleEditView.as_view(),
-        name="aclextendedrule_add",
-    ),
-    path(
-        "extended-rules/delete/",
-        views.ACLExtendedRuleBulkDeleteView.as_view(),
-        name="aclextendedrule_bulk_delete",
-    ),
-    path(
-        "extended-rules/<int:pk>/",
-        views.ACLExtendedRuleView.as_view(),
-        name="aclextendedrule",
-    ),
-    path(
-        "extended-rules/<int:pk>/edit/",
-        views.ACLExtendedRuleEditView.as_view(),
-        name="aclextendedrule_edit",
-    ),
-    path(
-        "extended-rules/<int:pk>/delete/",
-        views.ACLExtendedRuleDeleteView.as_view(),
-        name="aclextendedrule_delete",
+        include(get_model_urls("netbox_acls", "aclextendedrule", detail=False)),
     ),
     path(
         "extended-rules/<int:pk>/",

--- a/netbox_acls/views.py
+++ b/netbox_acls/views.py
@@ -71,6 +71,7 @@ class AccessListView(generic.ObjectView):
         return {}
 
 
+@register_model_view(models.AccessList, "list", path="", detail=False)
 class AccessListListView(generic.ObjectListView):
     """
     Defines the list view for the AccessLists django model.
@@ -84,6 +85,7 @@ class AccessListListView(generic.ObjectListView):
     filterset_form = forms.AccessListFilterForm
 
 
+@register_model_view(models.AccessList, "add", detail=False)
 @register_model_view(models.AccessList, "edit")
 class AccessListEditView(generic.ObjectEditView):
     """
@@ -103,6 +105,7 @@ class AccessListDeleteView(generic.ObjectDeleteView):
     queryset = models.AccessList.objects.prefetch_related("tags")
 
 
+@register_model_view(models.AccessList, "bulk_delete", path="delete", detail=False)
 class AccessListBulkDeleteView(generic.BulkDeleteView):
     queryset = models.AccessList.objects.prefetch_related("tags")
     filterset = filtersets.AccessListFilterSet
@@ -194,6 +197,7 @@ class ACLInterfaceAssignmentView(generic.ObjectView):
     )
 
 
+@register_model_view(models.ACLInterfaceAssignment, "list", path="", detail=False)
 class ACLInterfaceAssignmentListView(generic.ObjectListView):
     """
     Defines the list view for the ACLInterfaceAssignments django model.
@@ -208,6 +212,7 @@ class ACLInterfaceAssignmentListView(generic.ObjectListView):
     filterset_form = forms.ACLInterfaceAssignmentFilterForm
 
 
+@register_model_view(models.ACLInterfaceAssignment, "add", detail=False)
 @register_model_view(models.ACLInterfaceAssignment, "edit")
 class ACLInterfaceAssignmentEditView(generic.ObjectEditView):
     """
@@ -243,6 +248,7 @@ class ACLInterfaceAssignmentDeleteView(generic.ObjectDeleteView):
     )
 
 
+@register_model_view(models.ACLInterfaceAssignment, "bulk_delete", path="delete", detail=False)
 class ACLInterfaceAssignmentBulkDeleteView(generic.BulkDeleteView):
     queryset = models.ACLInterfaceAssignment.objects.prefetch_related(
         "access_list",
@@ -288,9 +294,7 @@ class InterfaceACLInterfaceAssignmentView(ACLInterfaceAssignmentChildView):
 
 
 @register_model_view(VMInterface, "acl_interface_assignments")
-class VirtualMachineInterfaceACLInterfaceAssignmentView(
-    ACLInterfaceAssignmentChildView,
-):
+class VirtualMachineInterfaceACLInterfaceAssignmentView(ACLInterfaceAssignmentChildView):
     queryset = VMInterface.objects.prefetch_related("virtual_machine", "tags")
     tab = ViewTab(
         label="ACL Interface Assignments",
@@ -324,6 +328,7 @@ class ACLStandardRuleView(generic.ObjectView):
     )
 
 
+@register_model_view(models.ACLStandardRule, "list", path="", detail=False)
 class ACLStandardRuleListView(generic.ObjectListView):
     """
     Defines the list view for the ACLStandardRule django model.
@@ -339,6 +344,7 @@ class ACLStandardRuleListView(generic.ObjectListView):
     filterset_form = forms.ACLStandardRuleFilterForm
 
 
+@register_model_view(models.ACLStandardRule, "add", detail=False)
 @register_model_view(models.ACLStandardRule, "edit")
 class ACLStandardRuleEditView(generic.ObjectEditView):
     """
@@ -375,6 +381,7 @@ class ACLStandardRuleDeleteView(generic.ObjectDeleteView):
     )
 
 
+@register_model_view(models.ACLStandardRule, "bulk_delete", path="delete", detail=False)
 class ACLStandardRuleBulkDeleteView(generic.BulkDeleteView):
     queryset = models.ACLStandardRule.objects.prefetch_related(
         "access_list",
@@ -404,6 +411,7 @@ class ACLExtendedRuleView(generic.ObjectView):
     )
 
 
+@register_model_view(models.ACLExtendedRule, "list", path="", detail=False)
 class ACLExtendedRuleListView(generic.ObjectListView):
     """
     Defines the list view for the ACLExtendedRule django model.
@@ -420,6 +428,7 @@ class ACLExtendedRuleListView(generic.ObjectListView):
     filterset_form = forms.ACLExtendedRuleFilterForm
 
 
+@register_model_view(models.ACLExtendedRule, "add", detail=False)
 @register_model_view(models.ACLExtendedRule, "edit")
 class ACLExtendedRuleEditView(generic.ObjectEditView):
     """
@@ -458,6 +467,7 @@ class ACLExtendedRuleDeleteView(generic.ObjectDeleteView):
     )
 
 
+@register_model_view(models.ACLExtendedRule, "bulk_delete", path="delete", detail=False)
 class ACLExtendedRuleBulkDeleteView(generic.BulkDeleteView):
     queryset = models.ACLExtendedRule.objects.prefetch_related(
         "access_list",


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `dev` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->
# Pull Request

## Related Issue

Fixes: #253 **[Housekeeping]** Refactor View Registrations

## New Behavior

- Utilizes `get_model_urls` to reduce repetition in URL patterns and improve extensibility.

## Contrast to Current Behavior

- Replaces manual view registration with the `@register_view` decorator for consistency and maintainability.

## Discussion: Benefits and Drawbacks

- Simplifies plugin model view management by adopting the unified routing mechanism introduced in **NetBox v4.2**.
- Improves code maintainability and reduces duplication.

## Changes to the Documentation

**None required** (internal refactor with no impact on functionality).

## Proposed Release Note Entry

**None required** (code cleanup only). 

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.
