### PR TITLE
feat(graphql): Add support for ACL Interface Assignments

### DIFF
--- a/netbox_acls/graphql/schema.py
+++ b/netbox_acls/graphql/schema.py
@@ -6,6 +6,7 @@ import strawberry_django
 from .types import (
     AccessListType,
     ACLExtendedRuleType,
+    ACLInterfaceAssignmentType,
     ACLStandardRuleType,
 )
 
@@ -24,3 +25,6 @@ class NetBoxACLSQuery:
 
     acl_standard_rule: ACLStandardRuleType = strawberry_django.field()
     acl_standard_rule_list: List[ACLStandardRuleType] = strawberry_django.field()
+
+    acl_interface_assignment: ACLInterfaceAssignmentType = strawberry_django.field()
+    acl_interface_assignment_list: List[ACLInterfaceAssignmentType] = strawberry_django.field()

--- a/netbox_acls/graphql/types.py
+++ b/netbox_acls/graphql/types.py
@@ -23,6 +23,7 @@ class AccessListType(NetBoxObjectType):
     Defines the object type for the django model AccessList.
     """
 
+    # Model fields
     assigned_object_type: Annotated["ContentTypeType", strawberry.lazy("netbox.graphql.types")]
     assigned_object: Annotated[
         Union[
@@ -41,9 +42,10 @@ class AccessListType(NetBoxObjectType):
 )
 class ACLInterfaceAssignmentType(NetBoxObjectType):
     """
-    Defines the object type for the django model AccessList.
+    Defines the object type for the django model ACLInterfaceAssignment.
     """
 
+    # Model fields
     access_list: Annotated["AccessListType", strawberry.lazy("netbox_acls.graphql.types")]
     assigned_object_type: Annotated["ContentTypeType", strawberry.lazy("netbox.graphql.types")]
     assigned_object: Annotated[
@@ -51,7 +53,7 @@ class ACLInterfaceAssignmentType(NetBoxObjectType):
             Annotated["InterfaceType", strawberry.lazy("dcim.graphql.types")],
             Annotated["VMInterfaceType", strawberry.lazy("virtualization.graphql.types")],
         ],
-        strawberry.union("ACLInterfaceAssignmentType"),
+        strawberry.union("ACLInterfaceAssignedObjectType"),
     ]
 
 
@@ -65,6 +67,7 @@ class ACLStandardRuleType(NetBoxObjectType):
     Defines the object type for the django model ACLStandardRule.
     """
 
+    # Model fields
     access_list: Annotated["AccessListType", strawberry.lazy("netbox_acls.graphql.types")]
     source_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")] | None
 
@@ -79,6 +82,7 @@ class ACLExtendedRuleType(NetBoxObjectType):
     Defines the object type for the django model ACLExtendedRule.
     """
 
+    # Model fields
     access_list: Annotated["AccessListType", strawberry.lazy("netbox_acls.graphql.types")]
     source_prefix: Annotated["PrefixType", strawberry.lazy("ipam.graphql.types")] | None
     source_ports: List[int] | None


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `dev` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->
# Pull Request

## Related Issue

Fixes: #251 **[Feature]** Add ACL Interface Assignment to GraphQL

## New Behavior

- Adds `ACLInterfaceAssignmentType` to the GraphQL schema.
- Enables querying ACL Interface Assignments via the GraphQL API.
- Mirrors functionality available in the REST API for parity.

## Contrast to Current Behavior

- Previously, ACL Interface Assignments were only accessible via the REST API.
- This change allows full access through GraphQL for automation and integration purposes.

## Discussion: Benefits and Drawbacks

**Benefits:**
- Enables automation and scripting via GraphQL.
- Provides more flexibility for users depending on GraphQL endpoints.
- Aligns with NetBox’s API consistency goals.

**Drawbacks:**
- None known at this point.

## Changes to the Documentation

- GraphQL schema is self-documenting, no external documentation required.

## Proposed Release Note Entry

- Added GraphQL support for querying ACL Interface Assignments.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.
