### PR TITLE
Closes #252 - Add related Rule Queries to AccessListType

### DIFF
--- a/netbox_acls/graphql/types.py
+++ b/netbox_acls/graphql/types.py
@@ -33,6 +33,20 @@ class AccessListType(NetBoxObjectType):
         strawberry.union("ACLAssignmentType"),
     ]
 
+    # Related models
+    aclstandardrules: List[
+        Annotated[
+            "ACLStandardRuleType",
+            strawberry.lazy("netbox_acls.graphql.types"),
+        ]
+    ]
+    aclextendedrules: List[
+        Annotated[
+            "ACLExtendedRuleType",
+            strawberry.lazy("netbox_acls.graphql.types"),
+        ]
+    ]
+
 
 @strawberry_django.type(
     models.ACLInterfaceAssignment,


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `dev` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->
# Pull Request

## Related Issue

Fixes: #252 **[Feature]** Allow Query for Related Rules of an AccessList in GraphQL

## New Behavior

- Enhances the GraphQL schema by introducing `aclstandardrules` and `aclextendedrules` as related fields to `AccessListType`.
- Enables querying Standard and Extended ACL Rules directly from an AccessList object.

## Contrast to Current Behavior

- Previously, the GraphQL API did not expose any related rule sets for an AccessList.
- With this change, related rules can be retrieved in a single GraphQL query, improving data accessibility and developer experience.

## Discussion: Benefits and Drawbacks

**Benefits:**
- Supports automation workflows that depend on a complete view of ACL configurations.
- Reduces the need for multiple queries or relying solely on the REST API.
- Aligns GraphQL capabilities with the existing REST functionality.

**Drawbacks:**
- Minimal risk of GraphQL schema complexity, but mitigated by consistent design and naming.

Yes, the change is fully backwards-compatible.

## Changes to the Documentation

- No documentation changes required.
- GraphQL schema will self-document via introspection.

## Proposed Release Note Entry

- Enhanced GraphQL schema to include related ACL rules (`aclstandardrules` and `aclextendedrules`) under `AccessListType`.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.
