### PR TITLE
Closes #277 - Add support for NetBox v4.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NETBOX_VARIANT=v4.3
+ARG NETBOX_VARIANT=v4.4
 
 FROM netboxcommunity/netbox:${NETBOX_VARIANT}
 

--- a/netbox_acls/__init__.py
+++ b/netbox_acls/__init__.py
@@ -2,8 +2,10 @@
 Define the NetBox Plugin
 """
 
-from netbox.plugins import PluginConfig
 import importlib.metadata
+
+from netbox.plugins import PluginConfig
+
 
 class NetBoxACLsConfig(PluginConfig):
     """
@@ -12,11 +14,11 @@ class NetBoxACLsConfig(PluginConfig):
 
     name = "netbox_acls"
     verbose_name = "Access Lists"
-    version = importlib.metadata.version('netbox-acls')
+    version = importlib.metadata.version("netbox-acls")
     description = "Manage simple ACLs in NetBox"
     base_url = "access-lists"
     min_version = "4.3.0"
-    max_version = "4.3.99"
+    max_version = "4.4.99"
 
 
 config = NetBoxACLsConfig

--- a/netbox_acls/tests/api/test_access_list_rules.py
+++ b/netbox_acls/tests/api/test_access_list_rules.py
@@ -3,8 +3,13 @@ from ipam.models import Prefix
 from utilities.testing import APIViewTestCases
 from virtualization.models import Cluster, ClusterType, VirtualMachine
 
-from netbox_acls.choices import *
-from netbox_acls.models import *
+from netbox_acls.choices import (
+    ACLActionChoices,
+    ACLProtocolChoices,
+    ACLRuleActionChoices,
+    ACLTypeChoices,
+)
+from netbox_acls.models import AccessList, ACLExtendedRule, ACLStandardRule
 
 
 class ACLStandardRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):

--- a/netbox_acls/tests/api/test_access_lists.py
+++ b/netbox_acls/tests/api/test_access_lists.py
@@ -4,8 +4,12 @@ from django.contrib.contenttypes.models import ContentType
 from utilities.testing import APIViewTestCases
 from virtualization.models import Cluster, ClusterType, VirtualMachine, VMInterface
 
-from netbox_acls.choices import *
-from netbox_acls.models import *
+from netbox_acls.choices import (
+    ACLActionChoices,
+    ACLAssignmentDirectionChoices,
+    ACLTypeChoices,
+)
+from netbox_acls.models import AccessList, ACLInterfaceAssignment
 
 
 class AccessListAPIViewTestCase(APIViewTestCases.APIViewTestCase):
@@ -116,7 +120,7 @@ class AccessListAPIViewTestCase(APIViewTestCases.APIViewTestCase):
             },
         ]
         cls.bulk_update_data = {
-            "default_action": ACLActionChoices.ACTION_PERMIT,
+            "comments": "Rule bulk update",
         }
 
 


### PR DESCRIPTION
<!--

Closes #277 - Add support for NetBox v4.4

#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `dev` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->
# Pull Request

## Related Issue

Closes #277 

NetBox 4.4.0 release: https://github.com/netbox-community/netbox/releases/tag/v4.4.0

## New Behavior

This PR declares and verifies compatibility with **NetBox v4.4** and aligns our tests with 4.4’s changelog expectations.

Included changes:

- **tests**: Switch the bulk‑update field in AccessList API tests from `default_action` to `comments` so the operation yields **three changelog entries**, matching NetBox 4.4’s API test case.
- **plugin**: Bump `max_version` to **4.4.99** to advertise and enforce compatibility with the 4.4 line.
- **docker/dev**: Update the NetBox base image from **v4.3 → v4.4** for local/dev and CI runs.


## Contrast to Current Behavior

Previously the plugin targeted **NetBox 4.3**, and the bulk‑update test didn’t align with **4.4**’s changelog comparison rules. After these changes:

- CI/dev now run on **4.4**.
- The bulk‑update API test reliably produces the three expected changelog records.
- Compatibility is explicitly capped at **≤ 4.4.x**.

## Discussion: Benefits and Drawbacks

**Benefits**

- Official 4.4 support, allowing users to upgrade with confidence.
- Test stability: changelog comparisons now mirror NetBox 4.4 behavior.
- No functional changes to the plugin itself; maintenance‑only.

**Drawbacks**

- None anticipated; changes are limited to tests, version bounds, and dev/CI plumbing.

**Backwards Compatibility**

- Yes. No DB schema or user‑facing changes.

## Changes to the Documentation

- Update the README compatibility matrix to include **NetBox 4.4.x**.  

## Proposed Release Note Entry

Add official compatibility with **NetBox 4.4**

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.