### PR TITLE
Closes #127: Add ACL Assignment ChildrenView to Access Lists

### DIFF
--- a/netbox_acls/templates/inc/view_acl_assignments_tab.html
+++ b/netbox_acls/templates/inc/view_acl_assignments_tab.html
@@ -4,7 +4,7 @@
 
 {% block extra_controls %}
   {% if perms.netbox_acls.add_accesslist %}
-    <a href="{% url add_url %}?&assigned_object={{ object.pk }}&assigned_object_type={{ content_type_id }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary">
+    <a href="{% url add_url %}?&access_list={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary">
       <i class="mdi mdi-plus-thick" aria-hidden="true"></i> {% trans "Assign an ACL" %}
     </a>
   {% endif %}

--- a/netbox_acls/templates/inc/view_object_assignments_tab.html
+++ b/netbox_acls/templates/inc/view_object_assignments_tab.html
@@ -1,0 +1,11 @@
+{% extends 'generic/object_children.html' %}
+{% load helpers %}
+{% load i18n %}
+
+{% block extra_controls %}
+  {% if perms.netbox_acls.add_aclassignment %}
+    <a href="{% url add_url %}?&assigned_object={{ object.pk }}&assigned_object_type={{ content_type_id }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary">
+      <i class="mdi mdi-plus-thick" aria-hidden="true"></i> {% trans "Assign an ACL" %}
+    </a>
+  {% endif %}
+{% endblock extra_controls %}

--- a/netbox_acls/views.py
+++ b/netbox_acls/views.py
@@ -3,10 +3,10 @@ Defines the business logic for the plugin.
 Specifically, all the various interactions with a client.
 """
 
-from django.contrib.contenttypes.models import ContentType
-from django.utils.translation import gettext_lazy as _
 from dcim.models import Device, Interface, VirtualChassis
+from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count
+from django.utils.translation import gettext_lazy as _
 from netbox.views import generic
 from utilities.views import ViewTab, register_model_view
 from virtualization.models import VirtualMachine, VMInterface
@@ -53,6 +53,7 @@ class ACLAssignmentChildrenView(generic.ObjectChildrenView):
         weight=1100,
     )
     table = tables.ACLAssignmentTable
+    template_name = "inc/view_tab.html"
 
     def get_children(self, request, parent):
         """
@@ -152,6 +153,38 @@ class AccessListBulkDeleteView(generic.BulkDeleteView):
     queryset = models.AccessList.objects.prefetch_related("tags")
     filterset = filtersets.AccessListFilterSet
     table = tables.AccessListTable
+
+
+@register_model_view(models.AccessList, "aclassignments", path="assignments")
+class AccessListACLAssignmentView(ACLAssignmentChildrenView):
+    """
+    Children view of ACL Assignment of AccessLists.
+    """
+
+    queryset = models.AccessList.objects.all()
+    tab = ViewTab(
+        label=_("Assignments"),
+        badge=lambda obj: obj.aclassignments.count(),
+        permission="netbox_acls.view_aclassignment",
+        weight=1100,
+    )
+
+    def get_children(self, request, parent):
+        """Return all children objects to the current parent object."""
+        return super().get_children(request, parent).filter(access_list=parent.pk)
+
+    def get_table(self, *args, **kwargs):
+        """Return the table with the assigned object colum hidden."""
+        table = super().get_table(*args, **kwargs)
+
+        # Hide the access list column
+        table.columns.hide("access_list")
+        # Hide the type column
+        table.columns.hide("type")
+        # Hide the default action column
+        table.columns.hide("default_action")
+
+        return table
 
 
 #
@@ -266,7 +299,6 @@ class InterfaceACLAssignmentView(ACLAssignmentChildrenView):
     """
 
     queryset = Interface.objects.all()
-    template_name = "inc/view_tab.html"
 
     def get_children(self, request, parent):
         """Return all children objects to the current parent object."""
@@ -291,7 +323,6 @@ class VirtualChassisACLAssignmentView(ACLAssignmentChildrenView):
     """
 
     queryset = VirtualChassis.objects.all()
-    template_name = "inc/view_tab.html"
 
     def get_children(self, request, parent):
         """Return all children objects to the current parent object."""
@@ -318,7 +349,6 @@ class VirtualMachineACLAssignmentView(ACLAssignmentChildrenView):
     """
 
     queryset = VirtualMachine.objects.all()
-    template_name = "inc/view_tab.html"
 
     def get_children(self, request, parent):
         """Return all children objects to the current parent object."""
@@ -345,7 +375,6 @@ class VMInterfaceACLAssignmentView(ACLAssignmentChildrenView):
     """
 
     queryset = VMInterface.objects.all()
-    template_name = "inc/view_tab.html"
 
     def get_children(self, request, parent):
         """Return all children objects to the current parent object."""

--- a/netbox_acls/views.py
+++ b/netbox_acls/views.py
@@ -53,7 +53,6 @@ class ACLAssignmentChildrenView(generic.ObjectChildrenView):
         weight=1100,
     )
     table = tables.ACLAssignmentTable
-    template_name = "inc/view_tab.html"
 
     def get_children(self, request, parent):
         """
@@ -168,6 +167,7 @@ class AccessListACLAssignmentView(ACLAssignmentChildrenView):
         permission="netbox_acls.view_aclassignment",
         weight=1100,
     )
+    template_name = "inc/view_acl_assignments_tab.html"
 
     def get_children(self, request, parent):
         """Return all children objects to the current parent object."""
@@ -272,7 +272,7 @@ class DeviceACLAssignmentView(ACLAssignmentChildrenView):
     """
 
     queryset = Device.objects.all()
-    template_name = "inc/view_tab.html"
+    template_name = "inc/view_object_assignments_tab.html"
 
     def get_children(self, request, parent):
         """Return all children objects to the current parent object."""
@@ -299,6 +299,7 @@ class InterfaceACLAssignmentView(ACLAssignmentChildrenView):
     """
 
     queryset = Interface.objects.all()
+    template_name = "inc/view_object_assignments_tab.html"
 
     def get_children(self, request, parent):
         """Return all children objects to the current parent object."""
@@ -323,6 +324,7 @@ class VirtualChassisACLAssignmentView(ACLAssignmentChildrenView):
     """
 
     queryset = VirtualChassis.objects.all()
+    template_name = "inc/view_object_assignments_tab.html"
 
     def get_children(self, request, parent):
         """Return all children objects to the current parent object."""
@@ -349,6 +351,7 @@ class VirtualMachineACLAssignmentView(ACLAssignmentChildrenView):
     """
 
     queryset = VirtualMachine.objects.all()
+    template_name = "inc/view_object_assignments_tab.html"
 
     def get_children(self, request, parent):
         """Return all children objects to the current parent object."""
@@ -375,6 +378,7 @@ class VMInterfaceACLAssignmentView(ACLAssignmentChildrenView):
     """
 
     queryset = VMInterface.objects.all()
+    template_name = "inc/view_object_assignments_tab.html"
 
     def get_children(self, request, parent):
         """Return all children objects to the current parent object."""


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `dev` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->
# Pull Request

## Related Issue

Fixes #127 - [Feature]: List all interfaces an acl is applied to on the acl page

> Note: This PR builds on / depends on the refactor work in #72.

## New Behavior

This PR adds an **ACL assignments** view to the ACL (AccessList) detail page.

Users can now see a list of all **interfaces** the ACL is currently applied to (via the related `ACLAssignment` objects) directly on the ACL page, using a familiar list/table layout. An **"Assign an ACL"** button is also provided from the ACL view to streamline adding new assignments.

## Contrast to Current Behavior

Currently, the ACL detail page does not provide a way to see where the ACL is applied. To answer “where is this ACL used?”, users have to navigate from the interface side (or search/filter assignments elsewhere).

With this PR, the ACL page includes an assignment tab/view that surfaces the related interface assignments in one place, making it much easier to audit usage and confirm the ACL’s scope.

## Discussion: Benefits and Drawbacks

**Benefits**
- Improves usability and visibility: you can immediately see which interfaces are affected by a given ACL.
- Aligns with existing UI patterns (list/table views similar to other object relationships), so it feels consistent.
- Reduces navigation overhead for common troubleshooting/auditing workflows.

**Drawbacks / trade-offs**
- Adds another relationship list to render on the ACL detail page, which may introduce additional DB queries if not carefully prefetched/paginated (the view uses the existing assignment model/table and hides non-essential columns to keep it readable).
- Depends on #72 due to the larger refactor (review/merge order matters).

**Backwards compatibility**
- This change is additive from a data/model perspective.
- Template/view changes are contained to the ACL detail UI and related assignment tab structure, so existing objects/assignments remain unchanged.

## Changes to the Documentation

No documentation changes included yet.

If desired, I can add a short note to the docs/wiki describing the new **Assignments** tab on ACLs (and include a screenshot), once the UI direction is confirmed.

## Proposed Release Note Entry

Add an ACL assignments view on the ACL (AccessList) detail page to show all interfaces the ACL is applied to.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.
