### PR TITLE
Closes #296: Update greetings workflow for first-interaction v3

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,17 +1,30 @@
 ---
 name: Greetings
 
-on: [pull_request_target, issues]
+on:
+  pull_request_target:
+    types:
+      - opened
+  issues:
+    types:
+      - opened
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   greeting:
+    name: Greet First-Time Contributors
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
+
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: "Thanks for opening this Issue! We really appreciate the feedback & testing from users like you!"
-          pr-message: "🎉 Thanks for opening this pull request! We really appreciate contributors like you! 🙌"
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
+            Thanks for opening this Issue!
+            We really appreciate the feedback & testing from users like you!
+          pr_message: |
+            🎉 Thanks for opening this pull request!
+            We really appreciate contributors like you! 🙌


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #296

## New Behavior

This updates the **Greetings** GitHub Action to:

- use the correct `actions/first-interaction@v3` input names (`repo_token`, `issue_message`, `pr_message`)
- only run on `issues.opened` and `pull_request.opened` (instead of all events)
- format the greeting texts as multi-line blocks for easier reading/maintenance

## Contrast to Current Behavior

Previously the workflow used the older input syntax and broader triggers, which caused the job to fail and/or run more often than necessary. With this change, the greeting runs reliably and only when a new issue/PR is opened.

## Discussion: Benefits and Drawbacks

**Benefits:** restores the broken greeting workflow, reduces unnecessary runs, and makes the messages easier to edit.  
**Drawbacks:** greetings will only be posted when an issue/PR is first opened (no change on other events).  
This is CI-only and does not affect the NetBox ACL plugin code or runtime behavior.

## Changes to the Documentation

None.

## Proposed Release Note Entry

Fix Greetings GitHub Actions workflow for `actions/first-interaction@v3`.

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.
