### PR TITLE
Closes #142: Add IP protocol support

### DIFF
--- a/netbox_acls/choices.py
+++ b/netbox_acls/choices.py
@@ -97,11 +97,13 @@ class ACLProtocolChoices(ChoiceSet):
     """
 
     PROTOCOL_ICMP = "icmp"
+    PROTOCOL_IP = "ip"
     PROTOCOL_TCP = "tcp"
     PROTOCOL_UDP = "udp"
 
     CHOICES = [
         (PROTOCOL_ICMP, "ICMP", "purple"),
+        (PROTOCOL_IP, "IP", "cyan"),
         (PROTOCOL_TCP, "TCP", "blue"),
         (PROTOCOL_UDP, "UDP", "orange"),
     ]

--- a/netbox_acls/forms/models.py
+++ b/netbox_acls/forms/models.py
@@ -44,6 +44,10 @@ __all__ = (
 help_text_acl_rule_logic = mark_safe(
     "<b>*Note:</b> CANNOT be set if action is set to remark.",
 )
+# Sets a standard mark_safe help_text value to be used by the various classes
+help_text_acl_rule_port_logic = mark_safe(
+    "<b>*Note:</b> CANNOT be set if action is set to remark. Only valid when protocol is TCP or UDP."
+)
 # Sets a standard help_text value to be used by the various classes for acl action
 help_text_acl_action = "Action the rule will take (remark, deny, or allow)."
 # Sets a standard help_text value to be used by the various classes for acl index
@@ -448,13 +452,13 @@ class ACLExtendedRuleForm(NetBoxModelForm):
 
         help_texts = {
             "action": help_text_acl_action,
-            "destination_ports": help_text_acl_rule_logic,
+            "destination_ports": help_text_acl_rule_port_logic,
             "index": help_text_acl_rule_index,
             "protocol": help_text_acl_rule_logic,
             "remark": mark_safe(
                 "<b>*Note:</b> CANNOT be set if action is not set to remark.",
             ),
-            "source_ports": help_text_acl_rule_logic,
+            "source_ports": help_text_acl_rule_port_logic,
         }
 
     def __init__(self, *args, **kwargs) -> None:

--- a/netbox_acls/models/access_list_rules.py
+++ b/netbox_acls/models/access_list_rules.py
@@ -42,6 +42,16 @@ ERROR_MESSAGE_ACTION_REMARK_PROTOCOL_SET = _("When the action is 'remark', Proto
 # Error message when a remark is provided, but the action is not set to 'remark'.
 ERROR_MESSAGE_REMARK_WITHOUT_ACTION_REMARK = _("A remark cannot be set unless the action is 'remark'.")
 
+# Error message when the protocol is not 'TCP' or 'UDP', but the source ports are set.
+ERROR_MESSAGE_PROTOCOL_NOT_TCP_OR_UDP_WITH_SOURCE_PORTS_SET = _(
+    "Source Ports can only be set when the protocol is TCP or UDP."
+)
+
+# Error message when the protocol is not 'TCP' or 'UDP', but the destination ports are set.
+ERROR_MESSAGE_PROTOCOL_NOT_TCP_OR_UDP_WITH_DESTINATION_PORTS_SET = _(
+    "Destination Ports can only be set when the protocol is TCP or UDP."
+)
+
 
 class ACLRule(NetBoxModel):
     """
@@ -417,6 +427,12 @@ class ACLExtendedRule(ACLRule):
         # Validate that the action is "remark", when the remark field is provided
         elif self.remark:
             errors["remark"] = ERROR_MESSAGE_REMARK_WITHOUT_ACTION_REMARK
+        # Validate that the source or destination ports are only set when the protocol is TCP or UDP
+        elif self.protocol not in [ACLProtocolChoices.PROTOCOL_TCP, ACLProtocolChoices.PROTOCOL_UDP]:
+            if self.source_ports:
+                errors["source_ports"] = ERROR_MESSAGE_PROTOCOL_NOT_TCP_OR_UDP_WITH_SOURCE_PORTS_SET
+            if self.destination_ports:
+                errors["destination_ports"] = ERROR_MESSAGE_PROTOCOL_NOT_TCP_OR_UDP_WITH_DESTINATION_PORTS_SET
 
         if errors:
             raise ValidationError(errors)

--- a/netbox_acls/tests/models/test_extendedrules.py
+++ b/netbox_acls/tests/models/test_extendedrules.py
@@ -68,7 +68,7 @@ class TestACLExtendedRule(BaseTestCase):
         self.assertEqual(created_rule.protocol, None)
         self.assertEqual(
             created_rule.description,
-            ("Created rule with any source, any source port, any destination, any destination port, and any protocol."),
+            "Created rule with any source, any source port, any destination, any destination port, and any protocol.",
         )
         self.assertEqual(isinstance(created_rule.access_list, AccessList), True)
         self.assertEqual(created_rule.access_list.type, self.acl_type)
@@ -383,6 +383,37 @@ class TestACLExtendedRule(BaseTestCase):
         self.assertEqual(isinstance(created_rule.access_list, AccessList), True)
         self.assertEqual(created_rule.access_list.type, self.acl_type)
 
+    def test_acl_extended_rule_ip_protocol_creation_success(self):
+        """
+        Test that ACLExtendedRule with IP protocol creation passes validation.
+        """
+        created_rule = ACLExtendedRule(
+            access_list=self.extended_acl1,
+            index=140,
+            action="permit",
+            remark="",
+            source=self.prefix1,
+            source_ports=None,
+            destination=self.prefix2,
+            destination_ports=None,
+            protocol=ACLProtocolChoices.PROTOCOL_IP,
+            description="Created rule with IP protocol",
+        )
+        created_rule.full_clean()
+
+        self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
+        self.assertEqual(created_rule.index, 140)
+        self.assertEqual(created_rule.action, "permit")
+        self.assertEqual(created_rule.remark, "")
+        self.assertEqual(created_rule.source, self.prefix1)
+        self.assertEqual(created_rule.source_ports, None)
+        self.assertEqual(created_rule.destination, self.prefix2)
+        self.assertEqual(created_rule.destination_ports, None)
+        self.assertEqual(created_rule.protocol, ACLProtocolChoices.PROTOCOL_IP)
+        self.assertEqual(created_rule.description, "Created rule with IP protocol")
+        self.assertEqual(isinstance(created_rule.access_list, AccessList), True)
+        self.assertEqual(created_rule.access_list.type, self.acl_type)
+
     def test_acl_extended_rule_icmp_protocol_creation_success(self):
         """
         Test that ACLExtendedRule with ICMP protocol creation passes validation.
@@ -650,6 +681,44 @@ class TestACLExtendedRule(BaseTestCase):
         with self.assertRaises(ValidationError):
             invalid_rule.full_clean()
 
+    def test_acl_extended_rule_protocol_ip_with_source_ports_fail(self):
+        """
+        Test that ACLExtendedRule with protocol 'ip' and source ports fails validation.
+        """
+        invalid_rule = ACLExtendedRule(
+            access_list=self.extended_acl1,
+            index=10,
+            action="permit",
+            remark="",
+            source=None,
+            source_ports=[4000, 5000],
+            destination=None,
+            destination_ports=None,
+            protocol=ACLProtocolChoices.PROTOCOL_IP,
+            description="Invalid rule with protocol 'ip' and source ports set",
+        )
+        with self.assertRaises(ValidationError):
+            invalid_rule.full_clean()
+
+    def test_acl_extended_rule_protocol_icmp_with_destination_ports_fail(self):
+        """
+        Test that ACLExtendedRule with protocol 'icmp' and destination ports fails validation.
+        """
+        invalid_rule = ACLExtendedRule(
+            access_list=self.extended_acl1,
+            index=10,
+            action="permit",
+            remark="",
+            source=None,
+            source_ports=None,
+            destination=None,
+            destination_ports=[22, 443],
+            protocol=ACLProtocolChoices.PROTOCOL_ICMP,
+            description="Invalid rule with protocol 'icmp' and destination ports set",
+        )
+        with self.assertRaises(ValidationError):
+            invalid_rule.full_clean()
+
     def test_invalid_aci_extended_rule_source_object(self):
         """
         Test ACLExtendedRule source object validation.
@@ -724,7 +793,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         Test ACLExtendedRule protocol choices using VALID choices.
         """
-        valid_acl_rule_protocol_choices = ["icmp", "tcp", "udp"]
+        valid_acl_rule_protocol_choices = ["icmp", "ip", "tcp", "udp"]
 
         for protocol_choice in valid_acl_rule_protocol_choices:
             valid_acl_rule_protocol = ACLExtendedRule(


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `dev` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->
# Pull Request

Thanks for maintaining **netbox-acls**! This PR adds support for the generic **IP** protocol in ACL rules, so L3-only entries (e.g. Cisco-style `permit ip ...`) can be documented cleanly and reused for things like NAT statements or route-maps.

## Related Issue

Closes #142 - [Feature]: Add IP to the protocol list

## New Behavior

Introduces support for the **"IP"** protocol in ACL rules and updates validation to restrict **source** and **destination** ports to **TCP**/**UDP** protocols only. Adds test coverage for the new protocol and the related validation scenarios.

## Contrast to Current Behavior

Previously, the available protocol choices did not include a generic **IP** option, which made it awkward/impossible to represent rules that match *any* IP traffic (common for broad L3 policy, NAT, and route-map use cases). Additionally, port fields could be set even when the selected protocol wasn’t **TCP** or **UDP**, despite ports not being applicable in those cases.

## Discussion: Benefits and Drawbacks

**Benefits**
- Enables vendor-neutral modeling of common “match all IP traffic” rules (e.g. `permit ip 10.0.0.0/8 any`).
- Improves data quality by preventing invalid combinations (ports on non-TCP/UDP rules).
- Backwards-compatible from a data model perspective (adds a new choice; no schema changes required).

**Drawbacks**
- Stricter validation may surface existing rules that have ports set with non-TCP/UDP protocols; those fields will need to be cleared before editing/saving those rules.

## Changes to the Documentation

No documentation changes included. The new protocol appears in the UI/API automatically; happy to add a short note to the docs/README if you’d prefer it called out explicitly.

## Proposed Release Note Entry

Add support for the **IP** protocol in ACL rules and restrict port fields to **TCP/UDP** protocols only.

## Double Check

* [x] I have explained my PR according to the information in the comments
  or in a linked issue.
* [x] My PR targets the `dev` branch.
