### PR TITLE
Closes #281: Add search indices for ACL models

### DIFF
--- a/netbox_acls/search.py
+++ b/netbox_acls/search.py
@@ -1,0 +1,80 @@
+"""
+Search definitions for models in the application.
+
+This module defines search indices for models, enabling advanced search
+functionalities and configurations for the corresponding models.
+"""
+
+from netbox.search import SearchIndex, register_search
+
+from .models.access_list_rules import ACLExtendedRule, ACLStandardRule
+from .models.access_lists import AccessList
+
+
+@register_search
+class AccessListIndex(SearchIndex):
+    """
+    NetBox search definition for the AccessList model.
+    """
+
+    model = AccessList
+
+    fields: tuple = (
+        ("name", 100),
+        ("comments", 5000),
+    )
+    display_attrs: tuple = (
+        "name",
+        "type",
+        "default_action",
+    )
+
+
+@register_search
+class ACLStandardRuleIndex(SearchIndex):
+    """
+    NetBox search definition for the ACLStandardRule model.
+    """
+
+    model = ACLStandardRule
+
+    fields: tuple = (
+        ("remark", 400),
+        ("description", 500),
+    )
+    display_attrs: tuple = (
+        "access_list",
+        "index",
+        "description",
+        "action",
+        "remark",
+        "source_type",
+        "source",
+    )
+
+
+@register_search
+class ACLExtendedRuleIndex(SearchIndex):
+    """
+    NetBox search definition for the ACLExtendedRule model.
+    """
+
+    model = ACLExtendedRule
+
+    fields: tuple = (
+        ("remark", 400),
+        ("description", 500),
+    )
+    display_attrs: tuple = (
+        "access_list",
+        "index",
+        "action",
+        "remark",
+        "protocol",
+        "source_type",
+        "source",
+        "source_ports",
+        "destination",
+        "destination_type",
+        "destination_ports",
+    )


### PR DESCRIPTION
# Pull Request

## Related Issue

Related to #281

## New Behavior

This PR adds search indices for `AccessList`, `ACLStandardRule`, and `ACLExtendedRule`. It makes these existing models discoverable through NetBox global search and uses weighted fields and display attributes to improve result relevance and presentation.

## Contrast to Current Behavior

At the moment, ACLs and ACL rules are not included in NetBox global search. With this change, users can find these objects directly from the global search bar using the indexed fields on the current models.

## Discussion: Benefits and Drawbacks

This improves discoverability and makes troubleshooting easier by allowing ACL-related objects to be found more quickly. The change is backwards-compatible and does not modify existing data or workflows. The scope is intentionally limited to the current models and fields, so it does not add a new comment field for rules or include related-object search.

## Changes to the Documentation

No documentation changes are required for this PR. This is an additive improvement to the existing search behavior.

## Proposed Release Note Entry

Added global search support for Access Lists, Standard ACL Rules, and Extended ACL Rules.

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.