### PR TITLE
Closes #282: Add IPv4/IPv6/Dual family support for ACLs and assignments

### DIFF
--- a/netbox_acls/api/serializers.py
+++ b/netbox_acls/api/serializers.py
@@ -48,7 +48,7 @@ class AccessListSerializer(NetBoxModelSerializer):
 
     class Meta:
         """
-        Associates the django model AccessList & fields to the serializer.
+        Associates the django model AccessList & fields with the serializer.
         """
 
         model = AccessList
@@ -58,6 +58,7 @@ class AccessListSerializer(NetBoxModelSerializer):
             "display",
             "name",
             "type",
+            "family",
             "default_action",
             "comments",
             "tags",
@@ -71,16 +72,27 @@ class AccessListSerializer(NetBoxModelSerializer):
     def validate(self, data):
         """
         Validates api inputs before processing:
-          - Check that the GFK object is valid.
-          - Check if Access List has no existing rules before change the Access List's type.
+          - Check if Access List has no existing rules before changing the Access List's family.
+          - Check if Access List has no existing rules before changing the Access List's type.
         """
         error_message = {}
 
-        # Check if Access List has no existing rules before change the Access List's type.
-        if self.instance and self.instance.type != data.get("type") and self.instance.rule_count > 0:
-            error_message["type"] = [
-                _("This ACL has ACL rules associated, CANNOT change ACL type."),
-            ]
+        if self.instance:
+            target_family = data.get("family", self.instance.family)
+            target_type = data.get("type", self.instance.type)
+            has_rules = getattr(self.instance, "rule_count", 0) > 0
+
+            # Check if Access List has no existing rules before change the Access List's family.
+            if self.instance.family != target_family and has_rules:
+                error_message["family"] = [
+                    _("This ACL has ACL rules associated, CANNOT change ACL family."),
+                ]
+
+            # Check if Access List has no existing rules before change the Access List's type.
+            if self.instance.type != target_type and has_rules:
+                error_message["type"] = [
+                    _("This ACL has ACL rules associated, CANNOT change ACL type."),
+                ]
 
         if error_message:
             raise serializers.ValidationError(error_message)
@@ -102,9 +114,12 @@ class ACLAssignmentSerializer(NetBoxModelSerializer):
     )
     assigned_object = serializers.SerializerMethodField(read_only=True)
 
+    # Denormalized fields
+    family = serializers.CharField(read_only=True)
+
     class Meta:
         """
-        Associates the django model ACLAssignment & fields to the serializer.
+        Associates the django model ACLAssignment & fields with the serializer.
         """
 
         model = ACLAssignment
@@ -113,6 +128,7 @@ class ACLAssignmentSerializer(NetBoxModelSerializer):
             "url",
             "display",
             "access_list",
+            "family",
             "direction",
             "assigned_object_type",
             "assigned_object_id",
@@ -158,7 +174,7 @@ class ACLStandardRuleSerializer(NetBoxModelSerializer):
 
     class Meta:
         """
-        Associates the django model ACLStandardRule & fields to the serializer.
+        Associates the django model ACLStandardRule & fields with the serializer.
         """
 
         model = ACLStandardRule

--- a/netbox_acls/api/serializers.py
+++ b/netbox_acls/api/serializers.py
@@ -4,6 +4,7 @@ while Django itself handles the database abstraction.
 """
 
 from django.contrib.contenttypes.models import ContentType
+from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import extend_schema_field
 from netbox.api.fields import ContentTypeField
 from netbox.api.serializers import NetBoxModelSerializer
@@ -13,8 +14,8 @@ from utilities.api import get_serializer_for_model
 from ..constants import ACL_ASSIGNMENT_MODELS, ACL_RULE_SOURCE_DESTINATION_MODELS
 from ..models import (
     AccessList,
-    ACLExtendedRule,
     ACLAssignment,
+    ACLExtendedRule,
     ACLStandardRule,
 )
 
@@ -26,13 +27,13 @@ __all__ = [
 ]
 
 # Sets a standard error message for ACL rules with an action of remark, but no remark set.
-error_message_no_remark = "Action is set to remark, you MUST add a remark."
+error_message_no_remark = _("Action is set to remark, you MUST add a remark.")
 # Sets a standard error message for ACL rules with an action of remark, but no source is set.
-error_message_action_remark_source_set = "Action is set to remark, Source CANNOT be set."
+error_message_action_remark_source_set = _("Action is set to remark, Source CANNOT be set.")
 # Sets a standard error message for ACL rules with an action not set to remark, but no remark is set.
-error_message_remark_without_action_remark = "CANNOT set remark unless action is set to remark."
+error_message_remark_without_action_remark = _("CANNOT set remark unless action is set to remark.")
 # Sets a standard error message for ACL rules no associated with an ACL of the same type.
-error_message_acl_type = "Provided parent Access List is not of right type."
+error_message_acl_type = _("Provided parent Access List is not of right type.")
 
 
 class AccessListSerializer(NetBoxModelSerializer):
@@ -78,7 +79,7 @@ class AccessListSerializer(NetBoxModelSerializer):
         # Check if Access List has no existing rules before change the Access List's type.
         if self.instance and self.instance.type != data.get("type") and self.instance.rule_count > 0:
             error_message["type"] = [
-                "This ACL has ACL rules associated, CANNOT change ACL type.",
+                _("This ACL has ACL rules associated, CANNOT change ACL type."),
             ]
 
         if error_message:
@@ -316,7 +317,6 @@ class ACLExtendedRuleSerializer(NetBoxModelSerializer):
           - Check if action set to remark, but destination set.
           - Check if action set to remark, but destination_ports set.
           - Check if action set to remark, but protocol set.
-          - Check if action set to remark, but protocol set.
         """
         error_message = {}
 
@@ -334,22 +334,22 @@ class ACLExtendedRuleSerializer(NetBoxModelSerializer):
             # Check if action set to remark, but source_ports set.
             if data.get("source_ports"):
                 error_message["source_ports"] = [
-                    "Action is set to remark, Source Ports CANNOT be set.",
+                    _("Action is set to remark, Source Ports CANNOT be set."),
                 ]
             # Check if action set to remark, but destination set.
             if data.get("destination"):
                 error_message["destination"] = [
-                    "Action is set to remark, Destination Prefix CANNOT be set.",
+                    _("Action is set to remark, Destination Prefix CANNOT be set."),
                 ]
             # Check if action set to remark, but destination_ports set.
             if data.get("destination_ports"):
                 error_message["destination_ports"] = [
-                    "Action is set to remark, Destination Ports CANNOT be set.",
+                    _("Action is set to remark, Destination Ports CANNOT be set."),
                 ]
             # Check if action set to remark, but protocol set.
             if data.get("protocol"):
                 error_message["protocol"] = [
-                    "Action is set to remark, Protocol CANNOT be set.",
+                    _("Action is set to remark, Protocol CANNOT be set."),
                 ]
 
         if error_message:

--- a/netbox_acls/choices.py
+++ b/netbox_acls/choices.py
@@ -8,6 +8,7 @@ __all__ = (
     "ACLActionChoices",
     "ACLAssignmentDirectionChoices",
     "ACLAssignmentDirectionUIChoices",
+    "ACLFamilyChoices",
     "ACLProtocolChoices",
     "ACLRuleActionChoices",
     "ACLTypeChoices",
@@ -28,6 +29,24 @@ class ACLActionChoices(ChoiceSet):
         (ACTION_DENY, "Deny", "red"),
         (ACTION_PERMIT, "Permit", "green"),
         (ACTION_REJECT, "Reject (Reset)", "orange"),
+    ]
+
+
+class ACLFamilyChoices(ChoiceSet):
+    """
+    Defines the IP protocol families available for the Access Lists.
+    """
+
+    key = "netbox_acls.AccessList.family"
+
+    FAMILY_DUAL = "dual"
+    FAMILY_IPV4 = "ipv4"
+    FAMILY_IPV6 = "ipv6"
+
+    CHOICES = [
+        (FAMILY_IPV4, "IPv4", "blue"),
+        (FAMILY_IPV6, "IPv6", "purple"),
+        (FAMILY_DUAL, "Dual", "cyan"),
     ]
 
 

--- a/netbox_acls/filtersets.py
+++ b/netbox_acls/filtersets.py
@@ -38,6 +38,7 @@ class AccessListFilterSet(NetBoxModelFilterSet):
             "id",
             "name",
             "type",
+            "family",
             "default_action",
             "comments",
         )
@@ -166,6 +167,7 @@ class ACLAssignmentFilterSet(NetBoxModelFilterSet):
         fields = (
             "id",
             "access_list",
+            "family",
             "site",
             "site_group",
             "region",

--- a/netbox_acls/forms/filtersets.py
+++ b/netbox_acls/forms/filtersets.py
@@ -19,6 +19,7 @@ from virtualization.models import VirtualMachine, VMInterface
 from ..choices import (
     ACLActionChoices,
     ACLAssignmentDirectionChoices,
+    ACLFamilyChoices,
     ACLProtocolChoices,
     ACLRuleActionChoices,
     ACLTypeChoices,
@@ -52,6 +53,7 @@ class AccessListFilterForm(NetBoxModelFilterSetForm):
         ),
         FieldSet(
             "type",
+            "family",
             "default_action",
             name=_("ACL Details"),
         ),
@@ -62,6 +64,11 @@ class AccessListFilterForm(NetBoxModelFilterSetForm):
         choices=add_blank_choice(ACLTypeChoices),
         required=False,
         label=_("Type"),
+    )
+    family = forms.ChoiceField(
+        choices=add_blank_choice(ACLFamilyChoices),
+        required=False,
+        label=_("Family"),
     )
     default_action = forms.ChoiceField(
         choices=add_blank_choice(ACLActionChoices),
@@ -87,6 +94,7 @@ class ACLAssignmentFilterForm(NetBoxModelFilterSetForm):
         ),
         FieldSet(
             "access_list_id",
+            "family",
             "direction",
             name=_("ACL Details"),
         ),
@@ -114,6 +122,11 @@ class ACLAssignmentFilterForm(NetBoxModelFilterSetForm):
         queryset=AccessList.objects.all(),
         required=False,
         label=_("Access List"),
+    )
+    family = forms.ChoiceField(
+        choices=add_blank_choice(ACLFamilyChoices),
+        required=False,
+        label=_("Family"),
     )
     direction = forms.ChoiceField(
         choices=add_blank_choice(ACLAssignmentDirectionChoices),

--- a/netbox_acls/forms/models.py
+++ b/netbox_acls/forms/models.py
@@ -5,7 +5,7 @@ Defines each django model's GUI form to add or edit objects for each django mode
 from django import forms
 from dcim.models import Device, Interface
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ObjectDoesNotExist
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from ipam.models import Prefix
@@ -68,6 +68,7 @@ class AccessListForm(NetBoxModelForm):
         FieldSet(
             "name",
             "type",
+            "family",
             "default_action",
             "tags",
             name=_("Access List Details"),
@@ -79,6 +80,7 @@ class AccessListForm(NetBoxModelForm):
         fields = (
             "name",
             "type",
+            "family",
             "default_action",
             "comments",
             "tags",
@@ -86,30 +88,12 @@ class AccessListForm(NetBoxModelForm):
 
         help_texts = {
             "default_action": _("The default behavior of the ACL."),
+            "family": _("Determines whether this ACL contains IPv4, IPv6, or dual-stack rules. Cannot be changed if rules are associated."),
             "name": _("The name uniqueness per device is case insensitive."),
             "type": mark_safe(
                 _("<b>*Note:</b> CANNOT be changed if ACL Rules are associated to this Access List."),
             ),
         }
-
-    def clean(self):
-        """
-        Validates and cleans the input data for the current object.
-
-        Ensures that the type of the Access Control List (ACL) cannot be
-        altered if there are existing rules associated with the current ACL.
-        """
-        super().clean()
-
-        acl_type = self.cleaned_data.get("type")
-
-        # Check if Access List has no existing rules before change the
-        # Access List's type.
-        if self.instance.pk and (
-            (acl_type == ACLTypeChoices.TYPE_EXTENDED and self.instance.aclstandardrules.exists())
-            or (acl_type == ACLTypeChoices.TYPE_STANDARD and self.instance.aclextendedrules.exists())
-        ):
-            raise ValidationError({"type": _("This ACL has ACL rules associated, CANNOT change ACL type.")})
 
 
 class ACLAssignmentForm(NetBoxModelForm):

--- a/netbox_acls/graphql/enums.py
+++ b/netbox_acls/graphql/enums.py
@@ -3,6 +3,7 @@ import strawberry
 from ..choices import (
     ACLActionChoices,
     ACLAssignmentDirectionChoices,
+    ACLFamilyChoices,
     ACLProtocolChoices,
     ACLRuleActionChoices,
     ACLTypeChoices,
@@ -11,6 +12,7 @@ from ..choices import (
 __all__ = (
     "ACLActionEnum",
     "ACLAssignmentDirectionEnum",
+    "ACLFamilyEnum",
     "ACLProtocolEnum",
     "ACLRuleActionEnum",
     "ACLTypeEnum",
@@ -21,6 +23,7 @@ __all__ = (
 #
 
 ACLActionEnum = strawberry.enum(ACLActionChoices.as_enum())
+ACLFamilyEnum = strawberry.enum(ACLFamilyChoices.as_enum())
 ACLTypeEnum = strawberry.enum(ACLTypeChoices.as_enum())
 
 #

--- a/netbox_acls/graphql/filters/access_lists.py
+++ b/netbox_acls/graphql/filters/access_lists.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from ..enums import (
         ACLActionEnum,
         ACLAssignmentDirectionEnum,
+        ACLFamilyEnum,
         ACLTypeEnum,
     )
 
@@ -31,6 +32,9 @@ class AccessListFilter(NetBoxModelFilterMixin):
 
     name: FilterLookup[str] | None = strawberry_django.filter_field()
     type: Annotated["ACLTypeEnum", strawberry.lazy("netbox_acls.graphql.enums")] | None = (
+        strawberry_django.filter_field()
+    )
+    family: Annotated["ACLFamilyEnum", strawberry.lazy("netbox_acls.graphql.enums")] | None = (
         strawberry_django.filter_field()
     )
     default_action: Annotated["ACLActionEnum", strawberry.lazy("netbox_acls.graphql.enums")] | None = (
@@ -53,5 +57,8 @@ class ACLAssignmentFilter(NetBoxModelFilterMixin):
     )
     assigned_object_id: ID | None = strawberry_django.filter_field()
     direction: Annotated["ACLAssignmentDirectionEnum", strawberry.lazy("netbox_acls.graphql.enums")] | None = (
+        strawberry_django.filter_field()
+    )
+    family: Annotated["ACLFamilyEnum", strawberry.lazy("netbox_acls.graphql.enums")] | None = (
         strawberry_django.filter_field()
     )

--- a/netbox_acls/migrations/0009_accesslist_ip_family.py
+++ b/netbox_acls/migrations/0009_accesslist_ip_family.py
@@ -1,0 +1,177 @@
+from django.db import migrations, models
+
+
+def infer_family(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
+
+    AccessList = apps.get_model("netbox_acls", "AccessList")
+    ACLStandardRule = apps.get_model("netbox_acls", "ACLStandardRule")
+    ACLExtendedRule = apps.get_model("netbox_acls", "ACLExtendedRule")
+
+    def _add_family_from_obj(fams, obj):
+        """Append 'ipv4' or 'ipv6' to fams based on common NetBox IPAM shapes."""
+        if obj is None:
+            return
+
+        version = (
+            getattr(obj, "family", None)
+            or getattr(getattr(obj, "prefix", None), "version", None)
+            or getattr(getattr(obj, "address", None), "version", None)
+            or getattr(getattr(obj, "start_address", None), "version", None)
+        )
+        if version == 4:
+            fams.add("ipv4")
+            return
+        if version == 6:
+            fams.add("ipv6")
+            return
+        return
+
+    # Pull all ACLs
+    for acl in AccessList.objects.using(db_alias).all().iterator():
+        fams = set()
+
+        # Standard rules (cached FKs)
+        if acl.type == "standard":
+            std_qs = (
+                ACLStandardRule.objects.using(db_alias)
+                .filter(access_list_id=acl.pk)
+                .select_related(
+                    "_source_prefix",
+                    "_source_ipaddress",
+                    "_source_iprange",
+                    "_source_aggregate",
+                )
+                .only(  # keep it light
+                    "id",
+                    "_source_prefix__prefix",
+                    "_source_ipaddress__address",
+                    "_source_iprange__start_address",
+                    "_source_aggregate__prefix",
+                )
+            )
+            for r in std_qs.iterator():
+                # Source side (one of the cached FKs should be set)
+                for attr in ("_source_prefix", "_source_ipaddress", "_source_iprange", "_source_aggregate"):
+                    obj = getattr(r, attr, None)
+                    if obj:
+                        _add_family_from_obj(fams, obj)
+                        break  # only one will be set
+                if len(fams) == 2:
+                    break
+
+        # Extended rules (cached FKs)
+        else:
+            ext_qs = (
+                ACLExtendedRule.objects.using(db_alias)
+                .filter(access_list_id=acl.pk)
+                .select_related(
+                    "_source_prefix",
+                    "_source_ipaddress",
+                    "_source_iprange",
+                    "_source_aggregate",
+                    "_destination_prefix",
+                    "_destination_ipaddress",
+                    "_destination_iprange",
+                    "_destination_aggregate",
+                )
+                .only(
+                    "id",
+                    "_source_prefix__prefix",
+                    "_source_ipaddress__address",
+                    "_source_iprange__start_address",
+                    "_source_aggregate__prefix",
+                    "_destination_prefix__prefix",
+                    "_destination_ipaddress__address",
+                    "_destination_iprange__start_address",
+                    "_destination_aggregate__prefix",
+                )
+            )
+            for r in ext_qs.iterator():
+                # Source
+                for attr in ("_source_prefix", "_source_ipaddress", "_source_iprange", "_source_aggregate"):
+                    obj = getattr(r, attr, None)
+                    if obj:
+                        _add_family_from_obj(fams, obj)
+                        break
+                # Destination
+                for attr in (
+                    "_destination_prefix",
+                    "_destination_ipaddress",
+                    "_destination_iprange",
+                    "_destination_aggregate",
+                ):
+                    obj = getattr(r, attr, None)
+                    if obj:
+                        _add_family_from_obj(fams, obj)
+                        break
+                if len(fams) == 2:
+                    break
+
+        # Decide
+        if fams == {"ipv4"}:
+            acl.family = "ipv4"
+        elif fams == {"ipv6"}:
+            acl.family = "ipv6"
+        elif fams == {"ipv4", "ipv6"}:
+            acl.family = "dual"
+        else:
+            # No signal (no rules or 'any') — conservative default
+            acl.family = "dual"
+
+        acl.save(update_fields=["family"])
+
+
+def backfill_assignment_family(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
+    ACLAssignment = apps.get_model("netbox_acls", "ACLAssignment")
+    for a in ACLAssignment.objects.using(db_alias).select_related("access_list").all().iterator():
+        a.family = a.access_list.family
+        a.save(update_fields=["family"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_acls", "0008_acl_rule_sequence_conditional_unique"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="aclassignment",
+            options={"ordering": ["assigned_object_type", "assigned_object_id", "access_list", "family", "direction"]},
+        ),
+        migrations.AlterUniqueTogether(
+            name="aclassignment",
+            unique_together=set(),
+        ),
+        migrations.AddField(
+            model_name="accesslist",
+            name="family",
+            field=models.CharField(db_index=True, default="ipv4", max_length=8),
+        ),
+        migrations.RunPython(infer_family, migrations.RunPython.noop),
+        migrations.AddField(
+            model_name="aclassignment",
+            name="family",
+            field=models.CharField(db_index=True, default="dual", editable=False, max_length=8),
+            preserve_default=False,
+        ),
+        migrations.RunPython(backfill_assignment_family, migrations.RunPython.noop),
+        migrations.AddConstraint(
+            model_name="aclassignment",
+            constraint=models.UniqueConstraint(
+                fields=("access_list", "assigned_object_type", "assigned_object_id", "direction"),
+                name="netbox_acls_aclassignment_unique_object_direction_family_per_access_list",
+                violation_error_message="ACL Assignment for the given object and direction.",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="aclassignment",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("direction", "none"), _negated=True),
+                fields=("assigned_object_type", "assigned_object_id", "direction", "family"),
+                name="netbox_acls_aclassignment_unique_object_direction_family_interface_only",
+                violation_error_message="ACL Assignment for the given object, direction and family exists.",
+            ),
+        ),
+    ]

--- a/netbox_acls/models/access_list_rules.py
+++ b/netbox_acls/models/access_list_rules.py
@@ -11,8 +11,14 @@ from django.utils.translation import gettext_lazy as _
 from ipam.models import Aggregate, IPAddress, IPRange, Prefix
 from netbox.models import NetBoxModel
 
-from ..choices import ACLProtocolChoices, ACLRuleActionChoices, ACLTypeChoices
+from ..choices import (
+    ACLFamilyChoices,
+    ACLProtocolChoices,
+    ACLRuleActionChoices,
+    ACLTypeChoices,
+)
 from ..constants import ACL_RULE_SOURCE_DESTINATION_MODELS
+from ..validators import infer_family_from_object
 from .access_lists import AccessList
 
 __all__ = (
@@ -191,6 +197,9 @@ class ACLRule(NetBoxModel):
             )
         super().clean()
 
+        # Validate rule family
+        self._validate_rule_family()
+
     def save(self, *args, **kwargs):
         """
         Saves the current instance to the database.
@@ -217,6 +226,32 @@ class ACLRule(NetBoxModel):
                 self._source_prefix = self.source
 
     cache_related_source_object.alters_data = True
+
+    def _validate_rule_family(self):
+        acl_family = self.access_list.family
+        families = set()
+
+        # Source
+        source = getattr(self, "source", None)
+        if source:
+            fam = infer_family_from_object(source)
+            if fam:
+                families.add(fam)
+
+        # Destination (extended only)
+        destination = getattr(self, "destination", None)
+        if destination:
+            fam = infer_family_from_object(destination)
+            if fam:
+                families.add(fam)
+
+        # Enforce
+        if acl_family == ACLFamilyChoices.FAMILY_IPV4 and ACLFamilyChoices.FAMILY_IPV6 in families:
+            raise ValidationError(_("IPv4 ACL: Rule contains IPv6 criteria."))
+        if acl_family == ACLFamilyChoices.FAMILY_IPV6 and ACLFamilyChoices.FAMILY_IPV4 in families:
+            raise ValidationError(_("IPv6 ACL: Rule contains IPv4 criteria."))
+        if acl_family == ACLFamilyChoices.FAMILY_DUAL and len(families) > 1:
+            raise ValidationError(_("Dual-stack ACL: A single rule must not mix IPv4 and IPv6 criteria."))
 
     def get_action_color(self):
         """

--- a/netbox_acls/models/access_lists.py
+++ b/netbox_acls/models/access_lists.py
@@ -7,12 +7,17 @@ from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelatio
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_slug
-from django.db import models
+from django.db import models, transaction
 from django.utils.translation import gettext_lazy as _
 from netbox.models import NetBoxModel
 from virtualization.models import VirtualMachine, VMInterface
 
-from ..choices import ACLActionChoices, ACLAssignmentDirectionChoices, ACLTypeChoices
+from ..choices import (
+    ACLActionChoices,
+    ACLAssignmentDirectionChoices,
+    ACLFamilyChoices,
+    ACLTypeChoices,
+)
 from ..constants import ACL_ASSIGNMENT_MODELS
 
 __all__ = (
@@ -36,6 +41,13 @@ class AccessList(NetBoxModel):
         max_length=30,
         choices=ACLTypeChoices,
     )
+    family = models.CharField(
+        verbose_name=_("Family"),
+        max_length=8,
+        db_index=True,
+        default=ACLFamilyChoices.FAMILY_IPV4,
+        choices=ACLFamilyChoices,
+    )
     default_action = models.CharField(
         verbose_name=_("Default Action"),
         max_length=30,
@@ -48,6 +60,7 @@ class AccessList(NetBoxModel):
 
     clone_fields = (
         "default_action",
+        "family",
         "type",
     )
 
@@ -77,45 +90,185 @@ class AccessList(NetBoxModel):
         """
         super().clean()
 
-        # Validate that uniqueness of the AccessList name per assigned host type
-        # (device, virtual chassis, or virtual machine) during renaming.
-        if self.pk and self._original_name and self._original_name != self.name:
-            host_assigned_object_types = [
-                ContentType.objects.get_for_model(Device),
-                ContentType.objects.get_for_model(VirtualChassis),
-                ContentType.objects.get_for_model(VirtualMachine),
-            ]
-            acl_assignments = ACLAssignment.objects.filter(
-                access_list=self,
-                assigned_object_type__in=host_assigned_object_types,
-            )
-            for acl_assignment in acl_assignments:
-                conflicting_acl_assignments = ACLAssignment.objects.filter(
-                    access_list__name=self.name,
-                    assigned_object_type=acl_assignment.assigned_object_type,
-                    assigned_object_id=acl_assignment.assigned_object_id,
-                ).exclude(pk=acl_assignment.pk)
-                if conflicting_acl_assignments.exists():
-                    assigned_object_model = acl_assignment.assigned_object_type.model_class()
+        if self.pk:
+            original_values = self._get_persisted_values(("name", "type", "family"))
+
+            # TYPE guard: if any rules exist, forbid changing type
+            if original_values["type"] != self.type and self._has_rules():
+                raise ValidationError({"type": _("This ACL has ACL rules associated, CANNOT change ACL type.")})
+
+            # FAMILY guard
+            if original_values["family"] != self.family:
+                if self._has_rules():
+                    # If any rules exist, forbid changing family
+                    raise ValidationError({"family": _("This ACL has ACL rules associated, CANNOT change ACL family.")})
+                # Validate family changes for interface assignments
+                self._validate_interface_family_conflicts(self.family)
+                # Validate host-level duplicate-name constraints under the *new* family
+                self._validate_host_name_family_conflicts(self.family)
+
+            # NAME rename guard
+            if original_values["name"] != self.name:
+                self._validate_host_name_family_conflicts(self.family)
+
+    def save(self, *args, **kwargs):
+        """
+        Override the model's save method for custom validation.
+        """
+        # Repeat the critical guards for callers that skip full_clean(), and
+        # if family changes without rules, update assignment families atomically.
+        with transaction.atomic():
+            original_values = self._get_persisted_values(("type", "family"))
+            family_changed = False
+
+            if original_values:
+                # Re-enforce TYPE guard
+                if original_values["type"] != self.type and self._has_rules():
+                    raise ValidationError({"type": _("This ACL has ACL rules associated, CANNOT change ACL type.")})
+
+                # FAMILY change preflight
+                if original_values["family"] != self.family:
+                    if self._has_rules():
+                        raise ValidationError(
+                            {"family": _("This ACL has ACL rules associated, CANNOT change ACL family.")}
+                        )
+                    # Validate family changes for interface assignments
+                    self._validate_interface_family_conflicts(self.family)
+                    # Validate host-level duplicate-name constraints under the *new* family
+                    self._validate_host_name_family_conflicts(self.family)
+                    family_changed = True
+
+            rv = super().save(*args, **kwargs)
+
+            # If family changed (and we passed preflight), mirror it on assignments now
+            if family_changed:
+                # Sync denormalized family on *all* assignments (host + interface)
+                qs = self.aclassignments.select_for_update()
+                if qs.exists():
+                    qs.update(family=self.family)
+
+            return rv
+
+    def _has_rules(self) -> bool:
+        """
+        Returns whether this ACL has rules.
+        """
+        return self.aclstandardrules.exists() or self.aclextendedrules.exists()
+
+    def _get_persisted_values(self, fields=("name", "type", "family")) -> dict:
+        """
+        Fetch persisted values directly from the DB to compare against current in‑memory changes.
+        """
+        if not self.pk:
+            return {}
+        return type(self).objects.filter(pk=self.pk).values(*fields).first() or {}
+
+    def _validate_interface_family_conflicts(self, target_family: str) -> None:
+        """
+        Validates potential conflicts in interface family assignments within ACL configurations.
+
+        Ensures that assigning a target family to an access control list does not conflict
+        with existing interface assignments on the same object and direction.
+        """
+        interface_assignments = self.aclassignments.exclude(direction=ACLAssignmentDirectionChoices.DIRECTION_NONE)
+        for intf_assignment in interface_assignments:
+            qs = ACLAssignment.objects.filter(
+                assigned_object_type_id=intf_assignment.assigned_object_type_id,
+                assigned_object_id=intf_assignment.assigned_object_id,
+                direction=intf_assignment.direction,
+            ).exclude(access_list=self)
+
+            if target_family == ACLFamilyChoices.FAMILY_DUAL:
+                # Dual occupies both family slots → any existing assignment is a conflict
+                if qs.exists():
                     raise ValidationError(
                         {
-                            "name": _(
-                                "An Access List with the name '{access_list}' "
-                                "is already assigned to the {assigned_object} "
-                                "'{assigned_object_name}'.".format(
-                                    access_list=self.name,
-                                    assigned_object=assigned_object_model._meta.verbose_name,
-                                    assigned_object_name=acl_assignment.assigned_object.name,
-                                )
-                            )
-                        }
+                            "family": _(
+                                "Changing to Dual would conflict with an existing interface assignment on the same object and direction.",
+                            ),
+                        },
                     )
+            else:
+                # v4 conflicts with (v4 or dual); v6 conflicts with (v6 or dual)
+                conflict_families = [target_family, ACLFamilyChoices.FAMILY_DUAL]
+                if qs.filter(family__in=conflict_families).exists():
+                    raise ValidationError(
+                        {
+                            "family": _(
+                                "Changing to {family} would conflict with an existing {family} or Dual interface assignment "
+                                "on the same object and direction.",
+                            ).format(family=target_family),
+                        },
+                    )
+
+    def _validate_host_name_family_conflicts(self, target_family: str):
+        """
+        Validates that there are no conflicting host assignments for the given target family.
+
+        This method checks if there are any Access Control List (ACL) assignments with the
+        same name, assigned object type, assigned object ID, and target family that conflict
+        with the existing host assignments.
+        It raises a validation error in case of conflicts.
+        """
+
+        host_assignments = self.aclassignments.filter(direction=ACLAssignmentDirectionChoices.DIRECTION_NONE)
+        for host_assignment in host_assignments:
+            conflicting_host_assignments = ACLAssignment.objects.filter(
+                access_list__name=self.name,
+                assigned_object_type=host_assignment.assigned_object_type,
+                assigned_object_id=host_assignment.assigned_object_id,
+                family=target_family,
+            ).exclude(pk=host_assignment.pk)
+            if conflicting_host_assignments.exists():
+                assigned_object_model = host_assignment.assigned_object_type.model_class()
+                raise ValidationError(
+                    {
+                        "name": _(
+                            "An {family} Access List with the name "
+                            "'{access_list}' is already assigned to the "
+                            "{assigned_object} '{assigned_object_name}'.".format(
+                                access_list=self.name,
+                                assigned_object=assigned_object_model._meta.verbose_name,
+                                assigned_object_name=host_assignment.assigned_object.name,
+                                # TODO: Fix formating!
+                                family=target_family,
+                            ),
+                        ),
+                    },
+                )
+
+    @property
+    def is_dual(self) -> bool:
+        """
+        Returns True if the Access List is dual, False otherwise.
+        """
+        return self.family == ACLFamilyChoices.FAMILY_DUAL
+
+    @property
+    def is_ipv4(self) -> bool:
+        """
+        Returns True if the Access List is IPv4, False otherwise.
+        """
+        return self.family == ACLFamilyChoices.FAMILY_IPV4
+
+    @property
+    def is_ipv6(self) -> bool:
+        """
+        Returns True if the Access List is IPv6, False otherwise.
+        """
+        return self.family == ACLFamilyChoices.FAMILY_IPV6
 
     def get_default_action_color(self):
         """
         Retrieves the default action color from the ACLActionChoices.
         """
         return ACLActionChoices.colors.get(self.default_action)
+
+    def get_family_color(self):
+        """
+        Retrieves the family color from the ACLFamilyChoices.
+        """
+        return ACLFamilyChoices.colors.get(self.family)
 
     def get_type_color(self):
         """
@@ -160,20 +313,39 @@ class ACLAssignment(NetBoxModel):
         blank=True,
     )
 
+    # Denormalized family (kept in sync with access_list.family)
+    family = models.CharField(
+        verbose_name=_("Family"),
+        max_length=8,
+        db_index=True,
+        editable=False,
+        choices=ACLFamilyChoices,
+    )
+
     clone_fields = ("access_list", "direction")
     prerequisite_models = ("netbox_acls.AccessList",)
 
     class Meta:
-        unique_together = [
-            "assigned_object_type",
-            "assigned_object_id",
-            "access_list",
-            "direction",
+        constraints = [
+            # Prevent the *same ACL* from being assigned twice to the same object+direction
+            models.UniqueConstraint(
+                fields=["access_list", "assigned_object_type", "assigned_object_id", "direction"],
+                name="%(app_label)s_%(class)s_unique_object_direction_family_per_access_list",
+                violation_error_message=_("ACL Assignment for the given object and direction."),
+            ),
+            # Enforce per-family uniqueness ONLY for interface-level (direction != NONE)
+            models.UniqueConstraint(
+                fields=["assigned_object_type", "assigned_object_id", "direction", "family"],
+                condition=~models.Q(direction=ACLAssignmentDirectionChoices.DIRECTION_NONE),
+                name="%(app_label)s_%(class)s_unique_object_direction_family_interface_only",
+                violation_error_message=_("ACL Assignment for the given object, direction and family exists."),
+            ),
         ]
         ordering = [
             "assigned_object_type",
             "assigned_object_id",
             "access_list",
+            "family",
             "direction",
         ]
         verbose_name = _("ACL Assignment")
@@ -197,13 +369,16 @@ class ACLAssignment(NetBoxModel):
                 {
                     "assigned_object": _(
                         "The {assigned_object} field is required,if an assigned object type is selected.".format(
-                            assigned_object=assigned_object_model._meta.verbose_name
-                        )
-                    )
-                }
+                            assigned_object=assigned_object_model._meta.verbose_name,
+                        ),
+                    ),
+                },
             )
 
         super().clean()
+
+        # Mirror ACL family to denormalized column early
+        self.family = self.access_list.family
 
         # Validate that uniqueness of the AccessList name per assigned host type
         # (device, virtual chassis, or virtual machine)
@@ -212,6 +387,13 @@ class ACLAssignment(NetBoxModel):
             ContentType.objects.get_for_model(VirtualChassis),
             ContentType.objects.get_for_model(VirtualMachine),
         ]
+        # If the assigned object is a host type (device, virtual chassis,
+        # or virtual machine), directional semantics (ingress/egress) are
+        # not applicable.
+        # Therefore, the direction field is set to "none" in these cases.
+        if self.assigned_object_type in host_assigned_object_types:
+            self.direction = ACLAssignmentDirectionChoices.DIRECTION_NONE
+
         if self.assigned_object_type in host_assigned_object_types:
             self._validate_unique_acl_name_per_assigned_object()
         else:
@@ -227,6 +409,7 @@ class ACLAssignment(NetBoxModel):
             access_list__name=self.access_list.name,
             assigned_object_type=self.assigned_object_type,
             assigned_object_id=self.assigned_object_id,
+            family=self.family,
         )
         if self.pk:
             conflicting_acl_assignments = conflicting_acl_assignments.exclude(pk=self.pk)
@@ -238,11 +421,12 @@ class ACLAssignment(NetBoxModel):
                     "access_list": _(
                         "An Access List with the name '{access_list}' "
                         "already exists for the specified "
-                        "{assigned_object}.".format(
-                            access_list=self.access_list.name, assigned_object=assigned_object_model._meta.verbose_name
-                        )
-                    )
-                }
+                        "{assigned_object} and family.".format(
+                            access_list=self.access_list.name,
+                            assigned_object=assigned_object_model._meta.verbose_name,
+                        ),
+                    ),
+                },
             )
 
     def _validate_unique_acl_assignment_per_assigned_interface(self) -> None:
@@ -251,6 +435,13 @@ class ACLAssignment(NetBoxModel):
             assigned_object_id=self.assigned_object_id,
             direction=self.direction,
         )
+        # Enforce: at most one IPv4 and at most one IPv6 per object+direction.
+        # A 'dual' ACL conflicts with any existing family at that object+direction.
+        if self.family != ACLFamilyChoices.FAMILY_DUAL:
+            # v4 conflicts with existing v4 or dual; same for v6
+            conflicting_acl_assignments = conflicting_acl_assignments.filter(
+                family__in=[self.family, ACLFamilyChoices.FAMILY_DUAL]
+            )
         if self.pk:
             conflicting_acl_assignments = conflicting_acl_assignments.exclude(pk=self.pk)
         if conflicting_acl_assignments.exists():
@@ -258,16 +449,20 @@ class ACLAssignment(NetBoxModel):
             raise ValidationError(
                 {
                     "direction": _(
-                        "An ACL Assignment with the same direction already exists for the specified "
-                        "{assigned_object}.".format(assigned_object=assigned_object_model._meta.verbose_name)
-                    )
-                }
+                        "An ACL Assignment for this family (or a Dual ACL) already exists on the interface "
+                        "{assigned_object} and direction.".format(
+                            assigned_object=assigned_object_model._meta.verbose_name
+                        ),
+                    ),
+                },
             )
 
     def save(self, *args, **kwargs):
         """
         Saves the current instance to the database.
         """
+        self.family = self.access_list.family
+
         host_assigned_object_types = [
             ContentType.objects.get_for_model(Device),
             ContentType.objects.get_for_model(VirtualChassis),
@@ -288,6 +483,12 @@ class ACLAssignment(NetBoxModel):
         Retrieves the direction color from the ACLAssignmentDirectionChoices.
         """
         return ACLAssignmentDirectionChoices.colors.get(self.direction)
+
+    def get_family_color(self):
+        """
+        Retrieves the family color from the ACLFamilyChoices.
+        """
+        return ACLFamilyChoices.colors.get(self.family)
 
 
 GenericRelation(

--- a/netbox_acls/tables.py
+++ b/netbox_acls/tables.py
@@ -32,6 +32,7 @@ class AccessListTable(NetBoxTable):
         linkify=True,
     )
     type = columns.ChoiceFieldColumn()
+    family = columns.ChoiceFieldColumn()
     default_action = columns.ChoiceFieldColumn()
     rule_count = tables.Column(
         verbose_name=_("Rule Count"),
@@ -47,6 +48,7 @@ class AccessListTable(NetBoxTable):
             "id",
             "name",
             "type",
+            "family",
             "rule_count",
             "default_action",
             "comments",
@@ -56,6 +58,7 @@ class AccessListTable(NetBoxTable):
         default_columns = (
             "name",
             "type",
+            "family",
             "rule_count",
             "default_action",
             "tags",
@@ -74,6 +77,7 @@ class ACLAssignmentTable(NetBoxTable):
     access_list = tables.Column(
         linkify=True,
     )
+    family = columns.ChoiceFieldColumn()
     assigned_object_type = columns.ContentTypeColumn(
         linkify=True,
     )
@@ -103,6 +107,7 @@ class ACLAssignmentTable(NetBoxTable):
             "pk",
             "id",
             "access_list",
+            "family",
             "assigned_object_type",
             "assigned_object",
             "direction",
@@ -112,6 +117,7 @@ class ACLAssignmentTable(NetBoxTable):
             "id",
             "access_list",
             "type",
+            "family",
             "assigned_object",
             "direction",
             "tags",

--- a/netbox_acls/templates/netbox_acls/accesslist.html
+++ b/netbox_acls/templates/netbox_acls/accesslist.html
@@ -27,6 +27,10 @@
             <td>{% badge object.get_type_display bg_color=object.get_type_color %}</td>
           </tr>
           <tr>
+            <th scope="row">Family</th>
+            <td>{% badge object.get_family_display bg_color=object.get_family_color %}</td>
+          </tr>
+          <tr>
             <th scope="row">Default Action</th>
             <td>{% badge object.get_default_action_display bg_color=object.get_default_action_color %}</td>
           </tr>

--- a/netbox_acls/tests/api/test_access_list_rules.py
+++ b/netbox_acls/tests/api/test_access_list_rules.py
@@ -3,6 +3,7 @@ from utilities.testing import APIViewTestCases
 
 from netbox_acls.choices import (
     ACLActionChoices,
+    ACLFamilyChoices,
     ACLProtocolChoices,
     ACLRuleActionChoices,
     ACLTypeChoices,
@@ -31,11 +32,13 @@ class ACLStandardRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
         access_list_device = AccessList.objects.create(
             name="testacl1",
             type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
             default_action=ACLActionChoices.ACTION_DENY,
         )
         access_list_vm = AccessList.objects.create(
             name="testacl2",
             type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
             default_action=ACLActionChoices.ACTION_PERMIT,
         )
 
@@ -125,11 +128,13 @@ class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
         access_list_device = AccessList.objects.create(
             name="testacl1",
             type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
             default_action=ACLActionChoices.ACTION_DENY,
         )
         access_list_vm = AccessList.objects.create(
             name="testacl2",
             type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
             default_action=ACLActionChoices.ACTION_PERMIT,
         )
 

--- a/netbox_acls/tests/api/test_access_lists.py
+++ b/netbox_acls/tests/api/test_access_lists.py
@@ -217,3 +217,6 @@ class ACLAssignmentAPIViewTestCase(APIViewTestCases.APIViewTestCase):
                 "direction": ACLAssignmentDirectionChoices.DIRECTION_EGRESS,
             },
         ]
+        cls.bulk_update_data = {
+            "comments": "Rule bulk update",
+        }

--- a/netbox_acls/tests/api/test_access_lists.py
+++ b/netbox_acls/tests/api/test_access_lists.py
@@ -7,6 +7,7 @@ from virtualization.models import Cluster, ClusterType, VirtualMachine, VMInterf
 from netbox_acls.choices import (
     ACLActionChoices,
     ACLAssignmentDirectionChoices,
+    ACLFamilyChoices,
     ACLTypeChoices,
 )
 from netbox_acls.models import AccessList, ACLAssignment
@@ -28,16 +29,19 @@ class AccessListAPIViewTestCase(APIViewTestCases.APIViewTestCase):
             AccessList(
                 name="testacl1",
                 type=ACLTypeChoices.TYPE_STANDARD,
+                family=ACLFamilyChoices.FAMILY_IPV4,
                 default_action=ACLActionChoices.ACTION_DENY,
             ),
             AccessList(
                 name="testacl2",
                 type=ACLTypeChoices.TYPE_EXTENDED,
+                family=ACLFamilyChoices.FAMILY_IPV4,
                 default_action=ACLActionChoices.ACTION_PERMIT,
             ),
             AccessList(
                 name="testacl3",
                 type=ACLTypeChoices.TYPE_EXTENDED,
+                family=ACLFamilyChoices.FAMILY_IPV6,
                 default_action=ACLActionChoices.ACTION_DENY,
             ),
         )
@@ -47,16 +51,19 @@ class AccessListAPIViewTestCase(APIViewTestCases.APIViewTestCase):
             {
                 "name": "testacl4",
                 "type": ACLTypeChoices.TYPE_STANDARD,
+                "family": ACLFamilyChoices.FAMILY_IPV4,
                 "default_action": ACLActionChoices.ACTION_DENY,
             },
             {
                 "name": "testacl5",
                 "type": ACLTypeChoices.TYPE_EXTENDED,
+                "family": ACLFamilyChoices.FAMILY_DUAL,
                 "default_action": ACLActionChoices.ACTION_DENY,
             },
             {
                 "name": "testacl6",
                 "type": ACLTypeChoices.TYPE_STANDARD,
+                "family": ACLFamilyChoices.FAMILY_IPV6,
                 "default_action": ACLActionChoices.ACTION_PERMIT,
             },
         ]
@@ -159,11 +166,13 @@ class ACLAssignmentAPIViewTestCase(APIViewTestCases.APIViewTestCase):
         acl1 = AccessList.objects.create(
             name="testacl1",
             type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
             default_action=ACLActionChoices.ACTION_DENY,
         )
         acl2 = AccessList.objects.create(
             name="testacl2",
             type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
             default_action=ACLActionChoices.ACTION_PERMIT,
         )
 

--- a/netbox_acls/tests/models/base.py
+++ b/netbox_acls/tests/models/base.py
@@ -150,3 +150,6 @@ class BaseTestCase(TestCase):
         cls.prefix2 = Prefix.objects.create(
             prefix=IPNetwork("10.2.0.0/16"),
         )
+        cls.prefix1_v6 = Prefix.objects.create(
+            prefix=IPNetwork("2001:db8::/64"),
+        )

--- a/netbox_acls/tests/models/test_accesslists.py
+++ b/netbox_acls/tests/models/test_accesslists.py
@@ -1,8 +1,21 @@
 from itertools import cycle
 
+from dcim.models import Interface
 from django.core.exceptions import ValidationError
 
-from netbox_acls.models import AccessList
+from netbox_acls.choices import (
+    ACLActionChoices,
+    ACLAssignmentDirectionChoices,
+    ACLFamilyChoices,
+    ACLRuleActionChoices,
+    ACLTypeChoices,
+)
+from netbox_acls.models import (
+    AccessList,
+    ACLAssignment,
+    ACLExtendedRule,
+    ACLStandardRule,
+)
 
 from .base import BaseTestCase
 
@@ -13,9 +26,31 @@ class TestAccessList(BaseTestCase):
     """
 
     common_acl_params = {
-        "type": "extended",
-        "default_action": "permit",
+        "type": ACLTypeChoices.TYPE_EXTENDED,
+        "family": ACLFamilyChoices.FAMILY_IPV4,
+        "default_action": ACLActionChoices.ACTION_DENY,
     }
+
+    @classmethod
+    def setUpTestData(cls):
+        """
+        Extend BaseTestCase's setUpTestData() to create additional data for testing.
+        """
+        super().setUpTestData()
+
+        interface_type = "1000baset"
+
+        # Device Interfaces
+        cls.device_interface1 = Interface.objects.create(
+            name="Interface 1",
+            device=cls.device1,
+            type=interface_type,
+        )
+        cls.device_interface2 = Interface.objects.create(
+            name="Interface 2",
+            device=cls.device1,
+            type=interface_type,
+        )
 
     def test_accesslist_standard_creation(self):
         """
@@ -26,6 +61,7 @@ class TestAccessList(BaseTestCase):
         created_acl = AccessList(
             name=acl_name,
             type="standard",
+            family="ipv4",
             default_action="deny",
         )
 
@@ -43,6 +79,7 @@ class TestAccessList(BaseTestCase):
         created_acl = AccessList(
             name=acl_name,
             type="extended",
+            family="ipv4",
             default_action="permit",
         )
 
@@ -94,6 +131,7 @@ class TestAccessList(BaseTestCase):
             valid_acl_choice = AccessList(
                 name=f"TestACL_Valid_Choice_{default_action}_{acl_type}",
                 type=acl_type,
+                family=ACLFamilyChoices.FAMILY_IPV4,
                 default_action=default_action,
                 comments=f"VALID ACL CHOICES USED: {default_action=} {acl_type=}",
             )
@@ -108,6 +146,7 @@ class TestAccessList(BaseTestCase):
         invalid_acl_default_action = AccessList(
             name=f"TestACL_Valid_Choice_{invalid_acl_default_action_choice}_{valid_acl_types[0]}",
             type=valid_acl_types[0],
+            family=ACLFamilyChoices.FAMILY_IPV4,
             default_action=invalid_acl_default_action_choice,
             comments=f"INVALID ACL DEFAULT CHOICE USED: default_action='{invalid_acl_default_action_choice}'",
         )
@@ -119,8 +158,146 @@ class TestAccessList(BaseTestCase):
         invalid_acl_type = AccessList(
             name=f"TestACL_Valid_Choice_{valid_acl_default_action_choices[0]}_{invalid_acl_type}",
             type=invalid_acl_type,
+            family=ACLFamilyChoices.FAMILY_IPV4,
             default_action=valid_acl_default_action_choices[0],
             comments=f"INVALID ACL DEFAULT CHOICE USED: type='{invalid_acl_type}'",
         )
         with self.assertRaises(ValidationError):
             invalid_acl_type.full_clean()
+
+    def test_acl_family_change_blocked_if_standard_rules_exist(self):
+        """
+        Changing the ACL family must be blocked when any rules exist (standard).
+        """
+        acl = AccessList.objects.create(
+            name="STD",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        # Minimal valid standard rule (uses GFK "source")
+        ACLStandardRule.objects.create(
+            access_list=acl,
+            index=10,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+        )
+
+        acl.family = ACLFamilyChoices.FAMILY_IPV6
+        with self.assertRaises(ValidationError):
+            acl.full_clean()
+
+    def test_acl_family_change_blocked_if_extended_rules_exist(self):
+        """
+        Changing the ACL family must be blocked when any rules exist (extended).
+        """
+        acl = AccessList.objects.create(
+            name="EXT",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV6,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        ACLExtendedRule.objects.create(
+            access_list=acl,
+            index=10,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=None,
+            destination=self.prefix1_v6,
+        )
+
+        acl.family = ACLFamilyChoices.FAMILY_IPV4
+        with self.assertRaises(ValidationError):
+            acl.full_clean()
+
+    def test_acl_family_change_updates_assignments_when_allowed_host_only(self):
+        """
+        Test that changing the ACL family with host assignments passes validation.
+        """
+        acl = AccessList.objects.create(
+            name="AccessList-v4",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        assignment = ACLAssignment.objects.create(
+            access_list=acl,
+            assigned_object=self.device1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+        )
+        self.assertEqual(assignment.family, ACLFamilyChoices.FAMILY_IPV4)
+
+        # Change to IPv6 without rules is allowed
+        acl.family = ACLFamilyChoices.FAMILY_IPV6
+        acl.full_clean()
+        acl.save()
+
+        assignment.refresh_from_db()
+        self.assertEqual(assignment.family, ACLFamilyChoices.FAMILY_IPV6)
+
+    def test_acl_family_change_blocked_if_interface_assignment_conflicts(self):
+        """
+        Test that changing the ACL family is blocked if a conflicting interface assignment exists.
+        """
+        acl_v4 = AccessList.objects.create(
+            name="AccessList-v4",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        acl_v6 = AccessList.objects.create(
+            name="AccessList-v6",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV6,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+
+        # Place both ACLs (v4 and v6) on the same interface/direction
+        ACLAssignment.objects.create(
+            access_list=acl_v4,
+            assigned_object=self.device_interface1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+        ACLAssignment.objects.create(
+            access_list=acl_v6,
+            assigned_object=self.device_interface1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+
+        # Trying to change 'AccessList-v6' to DUAL must be blocked
+        # (conflicts with existing v4)
+        acl_v6.family = ACLFamilyChoices.FAMILY_DUAL
+        with self.assertRaises(ValidationError):
+            acl_v6.full_clean()
+
+    def test_acl_family_change_on_host_blocks_duplicate_name_within_target_family(self):
+        """
+        Tests that changing the ACL family on a host with existing ACLs of the same name and family is blocked.
+        """
+        acl_v4 = AccessList.objects.create(
+            name="ACL1",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        acl_v6 = AccessList.objects.create(
+            name="ACL1",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV6,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+
+        ACLAssignment.objects.create(
+            access_list=acl_v4,
+            assigned_object=self.device1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+        )
+        ACLAssignment.objects.create(
+            access_list=acl_v6,
+            assigned_object=self.device1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+        )
+
+        # Changing the family leads to a duplicate name error
+        acl_v6.family = ACLFamilyChoices.FAMILY_IPV4
+        with self.assertRaises(ValidationError):
+            acl_v6.full_clean()

--- a/netbox_acls/tests/models/test_aclassignments.py
+++ b/netbox_acls/tests/models/test_aclassignments.py
@@ -1,8 +1,13 @@
+from dcim.models import Device, Interface, VirtualChassis
 from django.core.exceptions import ValidationError
-from virtualization.models import VirtualMachine
-from dcim.models import Device, VirtualChassis, Interface
-from virtualization.models import VMInterface
+from virtualization.models import VirtualMachine, VMInterface
 
+from netbox_acls.choices import (
+    ACLActionChoices,
+    ACLAssignmentDirectionChoices,
+    ACLFamilyChoices,
+    ACLTypeChoices,
+)
 from netbox_acls.models import AccessList, ACLAssignment
 
 from .base import BaseTestCase
@@ -56,6 +61,20 @@ class TestACLAssignment(BaseTestCase):
             type="standard",
             default_action="permit",
             comments="STANDARD_ACL",
+        )
+        cls.acl_standard_v6 = AccessList.objects.create(
+            name="STANDARD_ACL_V6",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV6,
+            default_action=ACLActionChoices.ACTION_PERMIT,
+            comments="STANDARD_ACL_V6",
+        )
+        cls.acl_standard_dual = AccessList.objects.create(
+            name="STANDARD_ACL_DUAL",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_DUAL,
+            default_action=ACLActionChoices.ACTION_PERMIT,
+            comments="STANDARD_ACL_DUAL",
         )
 
         # Extended ACLs
@@ -242,3 +261,147 @@ class TestACLAssignment(BaseTestCase):
         )
         with self.assertRaises(ValidationError):
             invalid_acl_assignment_direction.full_clean()
+
+    def test_acl_assignment_denormalized_family_mirrors_acl_on_creation(self):
+        """
+        Test that ACLAssignment denormalized family mirrors ACL on creation.
+        """
+        acl_assignment = ACLAssignment(
+            access_list=self.acl_standard1,
+            assigned_object=self.device_interface1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+        acl_assignment.full_clean()
+        acl_assignment.save()
+        self.assertEqual(acl_assignment.family, ACLFamilyChoices.FAMILY_IPV4)
+
+    def test_acl_assignment_interface_uniqueness_by_family_and_dual_conflicts(self):
+        """
+        Test that ACLAssignment interface uniqueness by family and dual conflicts.
+        """
+        # Put IPv4 on ingress
+        ACLAssignment.objects.create(
+            access_list=self.acl_standard1,
+            assigned_object=self.device_interface1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+
+        # Second IPv4 on the same interface+direction-> rejected
+        with self.assertRaises(ValidationError):
+            ACLAssignment(
+                access_list=self.acl_standard2,
+                assigned_object=self.device_interface1,
+                direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+            ).full_clean()
+
+        # IPv6 on same interface+direction -> allowed
+        ACLAssignment.objects.create(
+            access_list=self.acl_standard_v6,
+            assigned_object=self.device_interface1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+
+        # Dual on the same interface+direction-> rejected
+        # (conflicts with v4/v6 present)
+        with self.assertRaises(ValidationError):
+            ACLAssignment(
+                access_list=self.acl_standard_dual,
+                assigned_object=self.device_interface1,
+                direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+            ).full_clean()
+
+    def test_acl_assignment_multiple_same_name_acls_but_unique_within_family(self):
+        """
+        Test that ACLAssignment multiple names acl but the same family is unique.
+        """
+
+        # Same name in different families -> allowed
+        acl_v4 = AccessList.objects.create(
+            name="ACL1",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        acl_v6 = AccessList.objects.create(
+            name="ACL1",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV6,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        acl_v4_same_name = AccessList.objects.create(
+            name="ACL1",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+
+        ACLAssignment.objects.create(
+            access_list=acl_v4,
+            assigned_object=self.device1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+        )
+        ACLAssignment.objects.create(
+            access_list=acl_v6,
+            assigned_object=self.device1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+        )
+
+        # Same name, same family on the same host-> rejected
+        with self.assertRaises(ValidationError):
+            ACLAssignment(
+                access_list=acl_v4_same_name,
+                assigned_object=self.device1,
+                direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+            ).full_clean()
+
+    def test_denormalized_family_syncs_after_acl_family_change(self):
+        """
+        Test denormalized family sync after ACL family change.
+        """
+        acl = AccessList.objects.create(
+            name="AccessList-Family-Sync",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        assignment = ACLAssignment.objects.create(
+            access_list=acl,
+            assigned_object=self.device1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+        )
+        self.assertEqual(assignment.family, ACLFamilyChoices.FAMILY_IPV4)
+
+        # Flip to IPv6 — allowed for host-only; should mirror on assignment after save()
+        acl.family = ACLFamilyChoices.FAMILY_IPV6
+        acl.full_clean()
+        acl.save()
+        assignment.refresh_from_db()
+        self.assertEqual(assignment.family, ACLFamilyChoices.FAMILY_IPV6)
+
+    def test_acl_assignment_ipv4_and_ipv6_allowed_on_same_interface(self):
+        """
+        Test that ACLAssignment IPv4 and IPv6 are allowed on the same interface.
+        """
+        # Create IPv4 ACL assignment
+        ipv4_assignment = ACLAssignment.objects.create(
+            access_list=self.acl_standard1,  # IPv4
+            assigned_object=self.device_interface1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+
+        # Create IPv6 ACL assignment on the same interface+direction - should succeed
+        ipv6_assignment = ACLAssignment.objects.create(
+            access_list=self.acl_standard_v6,  # IPv6
+            assigned_object=self.device_interface1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+
+        self.assertEqual(ipv4_assignment.family, ACLFamilyChoices.FAMILY_IPV4)
+        self.assertEqual(ipv6_assignment.family, ACLFamilyChoices.FAMILY_IPV6)
+
+        # Verify both exist
+        assignments = ACLAssignment.objects.filter(
+            assigned_object_id=self.device_interface1.pk,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+        self.assertEqual(assignments.count(), 2)

--- a/netbox_acls/tests/models/test_extendedrules.py
+++ b/netbox_acls/tests/models/test_extendedrules.py
@@ -1,6 +1,11 @@
 from django.core.exceptions import ValidationError
 
-from netbox_acls.choices import ACLProtocolChoices, ACLTypeChoices
+from netbox_acls.choices import (
+    ACLActionChoices,
+    ACLFamilyChoices,
+    ACLProtocolChoices,
+    ACLTypeChoices,
+)
 from netbox_acls.models import AccessList, ACLExtendedRule
 
 from .base import BaseTestCase
@@ -19,6 +24,7 @@ class TestACLExtendedRule(BaseTestCase):
         super().setUpTestData()
 
         cls.acl_type = ACLTypeChoices.TYPE_EXTENDED
+        cls.family = ACLFamilyChoices.FAMILY_IPV4
         cls.default_action = "deny"
         cls.protocol = ACLProtocolChoices.PROTOCOL_TCP
 
@@ -26,14 +32,30 @@ class TestACLExtendedRule(BaseTestCase):
         cls.extended_acl1 = AccessList.objects.create(
             name="EXTENDED_ACL",
             type=cls.acl_type,
+            family=cls.family,
             default_action=cls.default_action,
             comments="EXTENDED_ACL",
         )
         cls.extended_acl2 = AccessList.objects.create(
             name="EXTENDED_ACL",
             type=cls.acl_type,
+            family=cls.family,
             default_action=cls.default_action,
             comments="EXTENDED_ACL",
+        )
+        cls.extended_acl_v6 = AccessList.objects.create(
+            name="EXTENDED_ACL_V6",
+            type=cls.acl_type,
+            family=ACLFamilyChoices.FAMILY_IPV6,
+            default_action=cls.default_action,
+            comments="EXTENDED_ACL_V6",
+        )
+        cls.extended_acl_dual = AccessList.objects.create(
+            name="EXTENDED_ACL_DUAL",
+            type=cls.acl_type,
+            family=ACLFamilyChoices.FAMILY_DUAL,
+            default_action=cls.default_action,
+            comments="EXTENDED_ACL_DUAL",
         )
 
     def test_acl_extended_rule_creation_success(self):
@@ -868,3 +890,63 @@ class TestACLExtendedRule(BaseTestCase):
 
         with self.assertRaises(ValidationError):
             invalid_acl_rule_protocol.full_clean()
+
+    def test_acl_extended_rule_family_v4_acl_rejects_v6_objects(self):
+        """
+        Test that IPv4 ACL must not accept rules carrying IPv6 objects.
+        """
+        acl_v4 = AccessList.objects.create(
+            name="RF4",
+            type=self.acl_type,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=self.default_action,
+        )
+        invalid_rule = ACLExtendedRule(
+            access_list=acl_v4,
+            index=10,
+            action=ACLActionChoices.ACTION_PERMIT,
+            source=self.prefix1_v6,
+            destination=self.prefix1_v6,
+        )
+        with self.assertRaises(ValidationError):
+            invalid_rule.full_clean()
+
+    def test_acl_extended_rule_family_v6_acl_rejects_v4_objects(self):
+        """
+        Test that IPv6 ACL must not accept rules carrying IPv4 objects.
+        """
+        acl = AccessList.objects.create(
+            name="RF6",
+            type=self.acl_type,
+            family=ACLFamilyChoices.FAMILY_IPV6,
+            default_action=self.default_action,
+        )
+        invalid_rule = ACLExtendedRule(
+            access_list=acl,
+            index=10,
+            action=ACLActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+            destination=self.prefix1_v6,
+        )
+        with self.assertRaises(ValidationError):
+            invalid_rule.full_clean()
+
+    def test_acl_extended_rule_family_dual_forbids_mixing_families_within_one_rule(self):
+        """
+        Test that dual ACLs forbid mixing of IPv4 and IPv6 objects within one rule.
+        """
+        acl = AccessList.objects.create(
+            name="RFD",
+            type=self.acl_type,
+            family=ACLFamilyChoices.FAMILY_DUAL,
+            default_action=self.default_action,
+        )
+        mixed = ACLExtendedRule(
+            access_list=acl,
+            index=10,
+            action=ACLActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+            destination=self.prefix1_v6,
+        )
+        with self.assertRaises(ValidationError):
+            mixed.full_clean()

--- a/netbox_acls/tests/models/test_standardrules.py
+++ b/netbox_acls/tests/models/test_standardrules.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 
-from netbox_acls.choices import ACLTypeChoices
+from netbox_acls.choices import ACLActionChoices, ACLFamilyChoices, ACLTypeChoices
 from netbox_acls.models import AccessList, ACLStandardRule
 
 from .base import BaseTestCase
@@ -19,20 +19,37 @@ class TestACLStandardRule(BaseTestCase):
         super().setUpTestData()
 
         cls.acl_type = ACLTypeChoices.TYPE_STANDARD
+        cls.family = ACLFamilyChoices.FAMILY_IPV4
         cls.default_action = "deny"
 
         # AccessLists
         cls.standard_acl1 = AccessList.objects.create(
             name="STANDARD_ACL",
             type=cls.acl_type,
+            family=cls.family,
             default_action=cls.default_action,
             comments="STANDARD_ACL",
         )
         cls.standard_acl2 = AccessList.objects.create(
             name="STANDARD_ACL",
             type=cls.acl_type,
+            family=cls.family,
             default_action=cls.default_action,
             comments="STANDARD_ACL",
+        )
+        cls.standard_acl_v6 = AccessList.objects.create(
+            name="STANDARD_ACL_V6",
+            type=cls.acl_type,
+            family=ACLFamilyChoices.FAMILY_IPV6,
+            default_action=cls.default_action,
+            comments="STANDARD_ACL_V6",
+        )
+        cls.standard_acl_dual = AccessList.objects.create(
+            name="STANDARD_ACL_DUAL",
+            type=cls.acl_type,
+            family=ACLFamilyChoices.FAMILY_DUAL,
+            default_action=cls.default_action,
+            comments="STANDARD_ACL_DUAL",
         )
 
     def test_acl_standard_rule_creation_success(self):
@@ -341,3 +358,41 @@ class TestACLStandardRule(BaseTestCase):
 
         with self.assertRaises(ValidationError):
             invalid_acl_rule_action.full_clean()
+
+    def test_acl_standard_rule_family_v4_acl_rejects_v6_objects(self):
+        """
+        Test that IPv4 ACL must not accept rules carrying IPv6 objects.
+        """
+        acl_v4 = AccessList.objects.create(
+            name="RF4",
+            type=self.acl_type,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=self.default_action,
+        )
+        invalid_rule = ACLStandardRule(
+            access_list=acl_v4,
+            index=10,
+            action=ACLActionChoices.ACTION_PERMIT,
+            source=self.prefix1_v6,
+        )
+        with self.assertRaises(ValidationError):
+            invalid_rule.full_clean()
+
+    def test_acl_standard_rule_family_v6_acl_rejects_v4_objects(self):
+        """
+        Test that IPv6 ACL must not accept rules carrying IPv4 objects.
+        """
+        acl = AccessList.objects.create(
+            name="RF6",
+            type=self.acl_type,
+            family=ACLFamilyChoices.FAMILY_IPV6,
+            default_action=self.default_action,
+        )
+        invalid_rule = ACLStandardRule(
+            access_list=acl,
+            index=10,
+            action=ACLActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+        )
+        with self.assertRaises(ValidationError):
+            invalid_rule.full_clean()

--- a/netbox_acls/validators.py
+++ b/netbox_acls/validators.py
@@ -1,0 +1,23 @@
+"""
+Defines validators.
+"""
+
+from .choices import ACLFamilyChoices
+
+
+def infer_family_from_object(obj):
+    """
+    Infers the family type (IPv4 or IPv6) from a given object's attributes.
+    """
+    # Prefer a 'version' if present
+    version = (
+        getattr(obj, "family", None)
+        or getattr(getattr(obj, "prefix", None), "version", None)
+        or getattr(getattr(obj, "address", None), "version", None)
+        or getattr(getattr(obj, "start_address", None), "version", None)
+    )
+    if version == 4:
+        return ACLFamilyChoices.FAMILY_IPV4
+    if version == 6:
+        return ACLFamilyChoices.FAMILY_IPV6
+    return None


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `dev` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->
# Pull Request

## Related Issue

#258  
#282

## New Behavior

This PR adds explicit IP family support to ACLs by introducing a `family` field with the values `IPv4`, `IPv6`, and `Dual`. It also adds validation for ACL rules and assignments so that family-specific conflicts are detected early and invalid combinations are rejected.

For interface assignments, this allows one IPv4 ACL and one IPv6 ACL in the same direction, while still preventing conflicting same-family or dual assignments. For host assignments, multiple ACLs remain possible, but duplicate ACL names within the same family are rejected. The family field is also exposed in the UI, filters, forms, serializers, GraphQL, and tables.

## Contrast to Current Behavior

Today ACLs do not explicitly track IP family, so IPv4, IPv6, and dual-stack ACLs are not clearly distinguished. This makes validation less precise and makes it harder to model assignments correctly, especially when separate IPv4 and IPv6 ACLs should coexist on the same interface.

With this change, ACLs become family-aware and assignment behavior can be validated more accurately for both hosts and interfaces.

## Discussion: Benefits and Drawbacks

I think this improves the plugin in two main ways: it makes ACL data more explicit, and it prevents a number of avoidable configuration mistakes. It should be especially helpful in environments where IPv4 and IPv6 policies are managed separately, while still supporting dual-stack use cases.

The main drawback is a bit of additional complexity in the models, validation, and migration logic. Existing data also needs to be inferred during migration, which means edge cases have to be handled carefully. From a user perspective, the change is largely backwards-compatible, but stricter validation may surface inconsistent existing data that previously went unnoticed.

## Changes to the Documentation

The documentation should be updated to describe the new `family` field, the assignment behavior for hosts versus interfaces, and the related validation rules for ACL rules and ACL assignments.

## Proposed Release Note Entry

Add IP family support for ACLs with `IPv4`, `IPv6`, and `Dual` families, including validation for rules and assignments, family-aware filtering, and improved assignment handling for hosts and interfaces.

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.