### PR TITLE
Fixes #309: Enforce ACL rule index uniqueness

### DIFF
--- a/netbox_acls/migrations/0008_acl_rule_sequence_conditional_unique.py
+++ b/netbox_acls/migrations/0008_acl_rule_sequence_conditional_unique.py
@@ -26,18 +26,16 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="aclextendedrule",
             constraint=models.UniqueConstraint(
-                condition=models.Q(("action__in", ("permit", "deny"))),
                 fields=("access_list", "index"),
-                name="netbox_acls_aclextendedrule_unique_aclrule_index_for_real_rules",
+                name="netbox_acls_aclextendedrule_unique_aclrule_index",
                 violation_error_message="Unique ACL rule index already exists.",
             ),
         ),
         migrations.AddConstraint(
             model_name="aclstandardrule",
             constraint=models.UniqueConstraint(
-                condition=models.Q(("action__in", ("permit", "deny"))),
                 fields=("access_list", "index"),
-                name="netbox_acls_aclstandardrule_unique_aclrule_index_for_real_rules",
+                name="netbox_acls_aclstandardrule_unique_aclrule_index",
                 violation_error_message="Unique ACL rule index already exists.",
             ),
         ),

--- a/netbox_acls/models/access_list_rules.py
+++ b/netbox_acls/models/access_list_rules.py
@@ -166,8 +166,7 @@ class ACLRule(NetBoxModel):
         constraints = [
             models.UniqueConstraint(
                 fields=("access_list", "index"),
-                condition=models.Q(action__in=("permit", "deny")),
-                name="%(app_label)s_%(class)s_unique_aclrule_index_for_real_rules",
+                name="%(app_label)s_%(class)s_unique_aclrule_index",
                 violation_error_message=_("Unique ACL rule index already exists."),
             ),
         ]

--- a/netbox_acls/tests/models/test_extendedrules.py
+++ b/netbox_acls/tests/models/test_extendedrules.py
@@ -557,9 +557,9 @@ class TestACLExtendedRule(BaseTestCase):
         self.assertEqual(isinstance(created_rule.access_list, AccessList), True)
         self.assertEqual(created_rule.access_list.type, self.acl_type)
 
-    def test_acl_extended_rule_action_permit_with_shared_index_action_remark_success(self):
+    def test_acl_extended_rule_action_permit_with_shared_index_action_remark_fail(self):
         """
-        Test that ACLExtendedRule with action 'permit' and action 'remark' shared index passes validation.
+        Test that ACLExtendedRule rejects a standalone remark sharing the same index as a permit rule.
         """
         created_permit_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
@@ -588,15 +588,8 @@ class TestACLExtendedRule(BaseTestCase):
             protocol=None,
             description="Created remark rule with same index as permit rule",
         )
-        created_remark_rule.full_clean()
-
-        self.assertTrue(isinstance(created_remark_rule, ACLExtendedRule), True)
-        self.assertEqual(created_remark_rule.index, 130)
-        self.assertEqual(created_remark_rule.action, "remark")
-        self.assertEqual(created_remark_rule.remark, "Standalone remark")
-        self.assertEqual(created_remark_rule.description, "Created remark rule with same index as permit rule")
-        self.assertEqual(isinstance(created_remark_rule.access_list, AccessList), True)
-        self.assertEqual(created_remark_rule.access_list.type, self.acl_type)
+        with self.assertRaises(ValidationError):
+            created_remark_rule.full_clean()
 
     def test_access_list_standard_to_acl_extended_rule_assignment_fail(self):
         """

--- a/netbox_acls/tests/models/test_standardrules.py
+++ b/netbox_acls/tests/models/test_standardrules.py
@@ -212,9 +212,9 @@ class TestACLStandardRule(BaseTestCase):
         self.assertEqual(isinstance(created_rule.access_list, AccessList), True)
         self.assertEqual(created_rule.access_list.type, self.acl_type)
 
-    def test_acl_standard_rule_action_permit_with_shared_index_action_remark_success(self):
+    def test_acl_standard_rule_action_permit_with_shared_index_action_remark_fail(self):
         """
-        Test that ACLStandardRule with action 'permit' and action 'remark' shared index passes validation.
+        Test that ACLStandardRule rejects a standalone remark sharing the same index as a permit rule.
         """
         created_permit_rule = ACLStandardRule(
             access_list=self.standard_acl1,
@@ -235,15 +235,8 @@ class TestACLStandardRule(BaseTestCase):
             source=None,
             description="Created remark rule with same index as permit rule",
         )
-        created_remark_rule.full_clean()
-
-        self.assertTrue(isinstance(created_remark_rule, ACLStandardRule), True)
-        self.assertEqual(created_remark_rule.index, 80)
-        self.assertEqual(created_remark_rule.action, "remark")
-        self.assertEqual(created_remark_rule.remark, "Standalone remark")
-        self.assertEqual(created_remark_rule.description, "Created remark rule with same index as permit rule")
-        self.assertEqual(isinstance(created_remark_rule.access_list, AccessList), True)
-        self.assertEqual(created_remark_rule.access_list.type, self.acl_type)
+        with self.assertRaises(ValidationError):
+            created_remark_rule.full_clean()
 
     def test_access_list_extended_to_acl_standard_rule_assignment_fail(self):
         """


### PR DESCRIPTION
# Pull Request

## Related Issue

#309

## New Behavior

This PR enforces ACL rule index uniqueness for all rules by removing the `condition` from the `UniqueConstraint` on `(access_list, index)`. It also updates the constraint names and tests to match the stricter validation.

## Contrast to Current Behavior

Today, a standalone `remark` can reuse the same index as a `permit` or `deny` rule. With this change, every rule in an ACL must have a unique index, regardless of action.

## Discussion: Benefits and Drawbacks

This keeps rule identity and ordering clear and avoids multiple database rows representing the same sequence number. It also keeps the data model simpler and more vendor-neutral, while still allowing remarks to be stored
with the related rule instead of as a separate same-index entry.

The drawback is that standalone `remark` rules can no longer share an index with a `permit` or `deny` rule. This is a partial revert of the optional same-sequence behavior introduced in #283. As this has not been released
yet, this is a good point to tighten the behavior before v2.0.

## Changes to the Documentation

No documentation changes are required for this PR. The behavior change should be noted in the release notes.

## Proposed Release Note Entry

Enforce unique ACL rule indexes for all rule types. Remark rules can no longer share the same index as a permit or deny rule.

## Double Check

* [x] I have explained my PR according to the information in the comments  or in a linked issue.
* [x] My PR targets the `dev` branch.