### PR TITLE
Closes #290: Rename ACL rule field `index` to `sequence`

### DIFF
--- a/netbox_acls/api/serializers.py
+++ b/netbox_acls/api/serializers.py
@@ -183,7 +183,7 @@ class ACLStandardRuleSerializer(NetBoxModelSerializer):
             "url",
             "display",
             "access_list",
-            "index",
+            "sequence",
             "action",
             "remark",
             "source_type",
@@ -200,7 +200,7 @@ class ACLStandardRuleSerializer(NetBoxModelSerializer):
             "url",
             "display",
             "access_list",
-            "index",
+            "sequence",
         )
 
     @extend_schema_field(serializers.JSONField(allow_null=True))
@@ -286,7 +286,7 @@ class ACLExtendedRuleSerializer(NetBoxModelSerializer):
             "url",
             "display",
             "access_list",
-            "index",
+            "sequence",
             "action",
             "remark",
             "protocol",
@@ -311,7 +311,7 @@ class ACLExtendedRuleSerializer(NetBoxModelSerializer):
             "url",
             "display",
             "access_list",
-            "index",
+            "sequence",
         )
 
     @extend_schema_field(serializers.JSONField(allow_null=True))

--- a/netbox_acls/filtersets.py
+++ b/netbox_acls/filtersets.py
@@ -279,7 +279,7 @@ class ACLStandardRuleFilterSet(NetBoxModelFilterSet):
         fields = (
             "id",
             "access_list",
-            "index",
+            "sequence",
             "action",
             "remark",
             "source_type",
@@ -290,7 +290,7 @@ class ACLStandardRuleFilterSet(NetBoxModelFilterSet):
         """
         Override the default search behavior for the django model.
         """
-        query = Q(access_list__name__icontains=value) | Q(index__icontains=value) | Q(action__icontains=value)
+        query = Q(access_list__name__icontains=value) | Q(sequence__icontains=value) | Q(action__icontains=value)
         return queryset.filter(query)
 
 
@@ -436,7 +436,7 @@ class ACLExtendedRuleFilterSet(NetBoxModelFilterSet):
         fields = (
             "id",
             "access_list",
-            "index",
+            "sequence",
             "action",
             "remark",
             "source_type",
@@ -454,7 +454,7 @@ class ACLExtendedRuleFilterSet(NetBoxModelFilterSet):
         """
         query = (
             Q(access_list__name__icontains=value)
-            | Q(index__icontains=value)
+            | Q(sequence__icontains=value)
             | Q(action__icontains=value)
             | Q(protocol__icontains=value)
         )

--- a/netbox_acls/forms/filtersets.py
+++ b/netbox_acls/forms/filtersets.py
@@ -213,7 +213,7 @@ class ACLStandardRuleFilterForm(NetBoxModelFilterSetForm):
         ),
         FieldSet(
             "access_list_id",
-            "index",
+            "sequence",
             "action",
             "remark",
             name=_("ACL Details"),
@@ -235,9 +235,9 @@ class ACLStandardRuleFilterForm(NetBoxModelFilterSetForm):
         required=False,
         label=_("Access List"),
     )
-    index = forms.IntegerField(
+    sequence = forms.IntegerField(
         required=False,
-        label=_("Index"),
+        label=_("Sequence"),
     )
     action = forms.ChoiceField(
         choices=add_blank_choice(ACLRuleActionChoices),
@@ -289,7 +289,7 @@ class ACLExtendedRuleFilterForm(NetBoxModelFilterSetForm):
         ),
         FieldSet(
             "access_list_id",
-            "index",
+            "sequence",
             "action",
             "remark",
             "protocol",
@@ -321,9 +321,9 @@ class ACLExtendedRuleFilterForm(NetBoxModelFilterSetForm):
         required=False,
         label=_("Access List"),
     )
-    index = forms.IntegerField(
+    sequence = forms.IntegerField(
         required=False,
-        label=_("Index"),
+        label=_("Sequence"),
     )
     action = forms.ChoiceField(
         choices=add_blank_choice(ACLRuleActionChoices),

--- a/netbox_acls/forms/models.py
+++ b/netbox_acls/forms/models.py
@@ -55,8 +55,8 @@ help_text_acl_rule_port_logic = mark_safe(
 )
 # Sets a standard help_text value to be used by the various classes for acl action
 help_text_acl_action = _("Action the rule will take (remark, deny, or allow).")
-# Sets a standard help_text value to be used by the various classes for acl index
-help_text_acl_rule_index = _("Determines the order of the rule in the ACL processing. AKA Sequence Number.")
+# Sets a standard help_text value to be used by the various classes for acl sequence
+help_text_acl_rule_sequence = _("Determines the order of the rule in the ACL processing.")
 # Standard help_text value to be used by the various classes for acl remark
 help_text_acl_remark = _("Remark the rule will take.")
 # Sets a standard help_text value to be used by the fields for acl port ranges
@@ -95,7 +95,9 @@ class AccessListForm(NetBoxModelForm):
 
         help_texts = {
             "default_action": _("The default behavior of the ACL."),
-            "family": _("Determines whether this ACL contains IPv4, IPv6, or dual-stack rules. Cannot be changed if rules are associated."),
+            "family": _(
+                "Determines whether this ACL contains IPv4, IPv6, or dual-stack rules. Cannot be changed if rules are associated."
+            ),
             "name": _("The name uniqueness per device is case insensitive."),
             "type": mark_safe(
                 _("<b>*Note:</b> CANNOT be changed if ACL Rules are associated to this Access List."),
@@ -221,7 +223,7 @@ class ACLAssignmentForm(NetBoxModelForm):
 class ACLStandardRuleForm(NetBoxModelForm):
     """
     GUI form to add or edit Standard Access List.
-    Requires an access_list, an index, and ACL rule type.
+    Requires an access_list, a sequence, and ACL rule type.
     See the clean function for logic on other field requirements.
     """
 
@@ -261,7 +263,7 @@ class ACLStandardRuleForm(NetBoxModelForm):
             name=_("Access List Details"),
         ),
         FieldSet(
-            "index",
+            "sequence",
             "action",
             name=_("Rule Definition"),
         ),
@@ -280,7 +282,7 @@ class ACLStandardRuleForm(NetBoxModelForm):
         model = ACLStandardRule
         fields = (
             "access_list",
-            "index",
+            "sequence",
             "action",
             "remark",
             "source_type",
@@ -289,7 +291,7 @@ class ACLStandardRuleForm(NetBoxModelForm):
         )
 
         help_texts = {
-            "index": help_text_acl_rule_index,
+            "sequence": help_text_acl_rule_sequence,
             "action": help_text_acl_action,
             "remark": help_text_acl_remark,
         }
@@ -342,7 +344,7 @@ class ACLStandardRuleForm(NetBoxModelForm):
 class ACLExtendedRuleForm(NetBoxModelForm):
     """
     GUI form to add or edit Extended Access List.
-    Requires an access_list, an index, and ACL rule type.
+    Requires an access_list, an sequence, and ACL rule type.
     See the clean function for logic on other field requirements.
     """
 
@@ -409,7 +411,7 @@ class ACLExtendedRuleForm(NetBoxModelForm):
             name=_("Access List Details"),
         ),
         FieldSet(
-            "index",
+            "sequence",
             "action",
             name=_("Rule Definition"),
         ),
@@ -439,7 +441,7 @@ class ACLExtendedRuleForm(NetBoxModelForm):
         model = ACLExtendedRule
         fields = (
             "access_list",
-            "index",
+            "sequence",
             "action",
             "remark",
             "source_type",
@@ -453,7 +455,7 @@ class ACLExtendedRuleForm(NetBoxModelForm):
 
         help_texts = {
             "action": help_text_acl_action,
-            "index": help_text_acl_rule_index,
+            "sequence": help_text_acl_rule_sequence,
             "protocol": help_text_acl_rule_logic,
             "remark": help_text_acl_remark,
         }

--- a/netbox_acls/graphql/filters/access_list_rules.py
+++ b/netbox_acls/graphql/filters/access_list_rules.py
@@ -36,7 +36,7 @@ class ACLRuleFilterMixin(NetBoxModelFilterMixin):
         strawberry_django.filter_field()
     )
     access_list_id: ID | None = strawberry_django.filter_field()
-    index: Annotated["IntegerLookup", strawberry.lazy("netbox.graphql.filter_lookups")] | None = (
+    sequence: Annotated["IntegerLookup", strawberry.lazy("netbox.graphql.filter_lookups")] | None = (
         strawberry_django.filter_field()
     )
     description: FilterLookup[str] | None = strawberry_django.filter_field()

--- a/netbox_acls/migrations/0007_acl_rule_sequence_unique.py
+++ b/netbox_acls/migrations/0007_acl_rule_sequence_unique.py
@@ -9,11 +9,11 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterModelOptions(
             name="aclextendedrule",
-            options={"ordering": ("access_list", "index", "-action")},
+            options={"ordering": ("access_list", "sequence", "-action")},
         ),
         migrations.AlterModelOptions(
             name="aclstandardrule",
-            options={"ordering": ("access_list", "index", "-action")},
+            options={"ordering": ("access_list", "sequence", "-action")},
         ),
         migrations.AlterUniqueTogether(
             name="aclextendedrule",
@@ -23,20 +23,30 @@ class Migration(migrations.Migration):
             name="aclstandardrule",
             unique_together=set(),
         ),
+        migrations.RenameField(
+            model_name="aclextendedrule",
+            old_name="index",
+            new_name="sequence",
+        ),
+        migrations.RenameField(
+            model_name="aclstandardrule",
+            old_name="index",
+            new_name="sequence",
+        ),
         migrations.AddConstraint(
             model_name="aclextendedrule",
             constraint=models.UniqueConstraint(
-                fields=("access_list", "index"),
-                name="netbox_acls_aclextendedrule_unique_aclrule_index",
-                violation_error_message="Unique ACL rule index already exists.",
+                fields=("access_list", "sequence"),
+                name="netbox_acls_aclextendedrule_unique_aclrule_sequence",
+                violation_error_message="Unique ACL rule sequence already exists.",
             ),
         ),
         migrations.AddConstraint(
             model_name="aclstandardrule",
             constraint=models.UniqueConstraint(
-                fields=("access_list", "index"),
-                name="netbox_acls_aclstandardrule_unique_aclrule_index",
-                violation_error_message="Unique ACL rule index already exists.",
+                fields=("access_list", "sequence"),
+                name="netbox_acls_aclstandardrule_unique_aclrule_sequence",
+                violation_error_message="Unique ACL rule sequence already exists.",
             ),
         ),
     ]

--- a/netbox_acls/models/access_list_rules.py
+++ b/netbox_acls/models/access_list_rules.py
@@ -72,7 +72,7 @@ class ACLRule(NetBoxModel):
     )
 
     # Rule
-    index = models.PositiveIntegerField()
+    sequence = models.PositiveIntegerField()
     description = models.CharField(
         verbose_name=_("Description"),
         max_length=500,
@@ -158,29 +158,29 @@ class ACLRule(NetBoxModel):
         Define the common model properties:
           - as an abstract model
           - constraints (unique together)
-          - index
+          - sequence
           - ordering
         """
 
         abstract = True
         constraints = [
             models.UniqueConstraint(
-                fields=("access_list", "index"),
-                name="%(app_label)s_%(class)s_unique_aclrule_index",
-                violation_error_message=_("Unique ACL rule index already exists."),
+                fields=("access_list", "sequence"),
+                name="%(app_label)s_%(class)s_unique_aclrule_sequence",
+                violation_error_message=_("Unique ACL rule sequence already exists."),
             ),
         ]
         indexes = (models.Index(fields=("source_type", "source_id")),)
-        ordering = ("access_list", "index", "-action")
+        ordering = ("access_list", "sequence", "-action")
 
     def __str__(self):
         """
         Returns a string representation of the object.
 
         This method generates a human-readable representation for the object
-        by including its access list and rule index.
+        by including its access list and rule sequence.
         """
-        return f"{self.access_list}: Rule {self.index}"
+        return f"{self.access_list}: Rule {self.sequence}"
 
     def clean(self):
         """

--- a/netbox_acls/search.py
+++ b/netbox_acls/search.py
@@ -44,7 +44,7 @@ class ACLStandardRuleIndex(SearchIndex):
     )
     display_attrs: tuple = (
         "access_list",
-        "index",
+        "sequence",
         "description",
         "action",
         "remark",
@@ -67,7 +67,7 @@ class ACLExtendedRuleIndex(SearchIndex):
     )
     display_attrs: tuple = (
         "access_list",
-        "index",
+        "sequence",
         "action",
         "remark",
         "protocol",

--- a/netbox_acls/tables.py
+++ b/netbox_acls/tables.py
@@ -132,7 +132,8 @@ class ACLStandardRuleTable(NetBoxTable):
     access_list = tables.Column(
         linkify=True,
     )
-    index = tables.Column(
+    sequence = tables.Column(
+        verbose_name=_("Seq"),
         linkify=True,
     )
     action = columns.ChoiceFieldColumn()
@@ -156,7 +157,7 @@ class ACLStandardRuleTable(NetBoxTable):
             "pk",
             "id",
             "access_list",
-            "index",
+            "sequence",
             "action",
             "remark",
             "tags",
@@ -165,7 +166,7 @@ class ACLStandardRuleTable(NetBoxTable):
         )
         default_columns = (
             "access_list",
-            "index",
+            "sequence",
             "action",
             "remark",
             "source",
@@ -181,7 +182,8 @@ class ACLExtendedRuleTable(NetBoxTable):
     access_list = tables.Column(
         linkify=True,
     )
-    index = tables.Column(
+    sequence = tables.Column(
+        verbose_name=_("Seq"),
         linkify=True,
     )
     action = columns.ChoiceFieldColumn()
@@ -224,7 +226,7 @@ class ACLExtendedRuleTable(NetBoxTable):
             "pk",
             "id",
             "access_list",
-            "index",
+            "sequence",
             "action",
             "remark",
             "tags",
@@ -237,7 +239,7 @@ class ACLExtendedRuleTable(NetBoxTable):
         )
         default_columns = (
             "access_list",
-            "index",
+            "sequence",
             "action",
             "remark",
             "protocol",

--- a/netbox_acls/templates/netbox_acls/aclextendedrule.html
+++ b/netbox_acls/templates/netbox_acls/aclextendedrule.html
@@ -20,8 +20,8 @@
             <td>{{ object.description|placeholder }}</td>
           </tr>
           <tr>
-            <th scope="row">Index</th>
-            <td>{{ object.index }}</td>
+            <th scope="row">Sequence</th>
+            <td>{{ object.sequence }}</td>
           </tr>
         </table>
       </div>

--- a/netbox_acls/templates/netbox_acls/aclstandardrule.html
+++ b/netbox_acls/templates/netbox_acls/aclstandardrule.html
@@ -16,8 +16,8 @@
             <td>{{ object.access_list|linkify }}</td>
           </tr>
           <tr>
-            <th scope="row">Index</th>
-            <td>{{ object.index }}</td>
+            <th scope="row">Sequence</th>
+            <td>{{ object.sequence }}</td>
           </tr>
           <tr>
             <th scope="row">Description</th>

--- a/netbox_acls/tests/api/test_access_list_rules.py
+++ b/netbox_acls/tests/api/test_access_list_rules.py
@@ -18,7 +18,7 @@ class ACLStandardRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
 
     model = ACLStandardRule
     view_namespace = "plugins-api:netbox_acls"
-    brief_fields = ["access_list", "display", "id", "index", "url"]
+    brief_fields = ["access_list", "display", "id", "sequence", "url"]
     user_permissions = (
         "ipam.view_prefix",
         "netbox_acls.view_accesslist",
@@ -53,21 +53,21 @@ class ACLStandardRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
         acl_standard_rules = (
             ACLStandardRule(
                 access_list=access_list_device,
-                index=10,
+                sequence=10,
                 description="Rule 10",
                 action=ACLRuleActionChoices.ACTION_PERMIT,
                 source=prefix1,
             ),
             ACLStandardRule(
                 access_list=access_list_device,
-                index=20,
+                sequence=20,
                 description="Rule 20",
                 action=ACLRuleActionChoices.ACTION_REMARK,
                 remark="Remark 1",
             ),
             ACLStandardRule(
                 access_list=access_list_vm,
-                index=10,
+                sequence=10,
                 description="Rule 10",
                 action=ACLRuleActionChoices.ACTION_DENY,
                 remark="Deny prefix",
@@ -79,7 +79,7 @@ class ACLStandardRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
         cls.create_data = [
             {
                 "access_list": access_list_device.id,
-                "index": 30,
+                "sequence": 30,
                 "description": "Rule 30",
                 "action": ACLRuleActionChoices.ACTION_DENY,
                 "source_type": "ipam.prefix",
@@ -87,7 +87,7 @@ class ACLStandardRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
             },
             {
                 "access_list": access_list_vm.id,
-                "index": 20,
+                "sequence": 20,
                 "description": "Rule 30",
                 "action": ACLRuleActionChoices.ACTION_PERMIT,
                 "remark": "Permit prefix",
@@ -96,7 +96,7 @@ class ACLStandardRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
             },
             {
                 "access_list": access_list_vm.id,
-                "index": 30,
+                "sequence": 30,
                 "description": "Rule 30",
                 "action": ACLRuleActionChoices.ACTION_REMARK,
                 "remark": "Remark 2",
@@ -114,7 +114,7 @@ class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
 
     model = ACLExtendedRule
     view_namespace = "plugins-api:netbox_acls"
-    brief_fields = ["access_list", "display", "id", "index", "url"]
+    brief_fields = ["access_list", "display", "id", "sequence", "url"]
     user_permissions = (
         "ipam.view_prefix",
         "netbox_acls.view_accesslist",
@@ -149,7 +149,7 @@ class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
         acl_extended_rules = (
             ACLExtendedRule(
                 access_list=access_list_device,
-                index=10,
+                sequence=10,
                 description="Rule 10",
                 action=ACLRuleActionChoices.ACTION_PERMIT,
                 remark="Permit prefix",
@@ -161,14 +161,14 @@ class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
             ),
             ACLExtendedRule(
                 access_list=access_list_device,
-                index=20,
+                sequence=20,
                 description="Rule 20",
                 action=ACLRuleActionChoices.ACTION_REMARK,
                 remark="Remark 1",
             ),
             ACLExtendedRule(
                 access_list=access_list_vm,
-                index=10,
+                sequence=10,
                 description="Rule 10",
                 action=ACLRuleActionChoices.ACTION_DENY,
                 source=prefix2,
@@ -180,7 +180,7 @@ class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
         cls.create_data = [
             {
                 "access_list": access_list_device.id,
-                "index": 30,
+                "sequence": 30,
                 "description": "Rule 30",
                 "action": ACLRuleActionChoices.ACTION_DENY,
                 "protocol": ACLProtocolChoices.PROTOCOL_UDP,
@@ -194,7 +194,7 @@ class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
             },
             {
                 "access_list": access_list_vm.id,
-                "index": 20,
+                "sequence": 20,
                 "description": "Rule 30",
                 "action": ACLRuleActionChoices.ACTION_PERMIT,
                 "protocol": ACLProtocolChoices.PROTOCOL_ICMP,
@@ -205,7 +205,7 @@ class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
             },
             {
                 "access_list": access_list_vm.id,
-                "index": 30,
+                "sequence": 30,
                 "description": "Rule 30",
                 "action": ACLRuleActionChoices.ACTION_REMARK,
                 "remark": "Remark 2",

--- a/netbox_acls/tests/models/test_accesslists.py
+++ b/netbox_acls/tests/models/test_accesslists.py
@@ -178,7 +178,7 @@ class TestAccessList(BaseTestCase):
         # Minimal valid standard rule (uses GFK "source")
         ACLStandardRule.objects.create(
             access_list=acl,
-            index=10,
+            sequence=10,
             action=ACLRuleActionChoices.ACTION_PERMIT,
             source=self.prefix1,
         )
@@ -199,7 +199,7 @@ class TestAccessList(BaseTestCase):
         )
         ACLExtendedRule.objects.create(
             access_list=acl,
-            index=10,
+            sequence=10,
             action=ACLRuleActionChoices.ACTION_PERMIT,
             source=None,
             destination=self.prefix1_v6,

--- a/netbox_acls/tests/models/test_extendedrules.py
+++ b/netbox_acls/tests/models/test_extendedrules.py
@@ -66,7 +66,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             action="permit",
             remark="",
             source=None,
@@ -82,7 +82,7 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 10)
+        self.assertEqual(created_rule.sequence, 10)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, None)
@@ -103,7 +103,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=20,
+            sequence=20,
             action="permit",
             remark="",
             source=self.aggregate1,
@@ -116,7 +116,7 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 20)
+        self.assertEqual(created_rule.sequence, 20)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, self.aggregate1)
@@ -134,7 +134,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=30,
+            sequence=30,
             action="permit",
             remark="",
             source=self.ip_address1,
@@ -147,7 +147,7 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 30)
+        self.assertEqual(created_rule.sequence, 30)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, self.ip_address1)
@@ -165,7 +165,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=40,
+            sequence=40,
             action="permit",
             remark="",
             source=self.ip_range1,
@@ -178,7 +178,7 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 40)
+        self.assertEqual(created_rule.sequence, 40)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, self.ip_range1)
@@ -196,7 +196,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=50,
+            sequence=50,
             action="permit",
             remark="",
             source=self.prefix1,
@@ -209,7 +209,7 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 50)
+        self.assertEqual(created_rule.sequence, 50)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, self.prefix1)
@@ -227,7 +227,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=70,
+            sequence=70,
             action="permit",
             remark="",
             source=self.prefix1,
@@ -240,7 +240,7 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 70)
+        self.assertEqual(created_rule.sequence, 70)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, self.prefix1)
@@ -258,7 +258,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=80,
+            sequence=80,
             action="permit",
             remark="",
             source=None,
@@ -271,7 +271,7 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 80)
+        self.assertEqual(created_rule.sequence, 80)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, None)
@@ -289,7 +289,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=90,
+            sequence=90,
             action="permit",
             remark="",
             source=None,
@@ -302,7 +302,7 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 90)
+        self.assertEqual(created_rule.sequence, 90)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, None)
@@ -320,7 +320,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=100,
+            sequence=100,
             action="permit",
             remark="",
             source=None,
@@ -333,7 +333,7 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 100)
+        self.assertEqual(created_rule.sequence, 100)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, None)
@@ -351,7 +351,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=110,
+            sequence=110,
             action="permit",
             remark="",
             source=None,
@@ -364,7 +364,7 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 110)
+        self.assertEqual(created_rule.sequence, 110)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, None)
@@ -382,7 +382,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=130,
+            sequence=130,
             action="permit",
             remark="",
             source=None,
@@ -395,7 +395,7 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 130)
+        self.assertEqual(created_rule.sequence, 130)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, None)
@@ -413,7 +413,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=140,
+            sequence=140,
             action="permit",
             remark="",
             source=self.prefix1,
@@ -426,7 +426,7 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 140)
+        self.assertEqual(created_rule.sequence, 140)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, self.prefix1)
@@ -444,7 +444,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=140,
+            sequence=140,
             action="permit",
             remark="",
             source=self.prefix1,
@@ -457,7 +457,7 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 140)
+        self.assertEqual(created_rule.sequence, 140)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, self.prefix1)
@@ -475,7 +475,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=150,
+            sequence=150,
             action="permit",
             remark="",
             source=self.prefix1,
@@ -488,7 +488,7 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 150)
+        self.assertEqual(created_rule.sequence, 150)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, self.prefix1)
@@ -506,7 +506,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=160,
+            sequence=160,
             action="remark",
             remark="Test remark",
             source=None,
@@ -519,7 +519,7 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 160)
+        self.assertEqual(created_rule.sequence, 160)
         self.assertEqual(created_rule.action, "remark")
         self.assertEqual(created_rule.remark, "Test remark")
         self.assertEqual(created_rule.source, None)
@@ -537,7 +537,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=120,
+            sequence=120,
             action="permit",
             remark="Inline remark",
             source=None,
@@ -550,20 +550,20 @@ class TestACLExtendedRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLExtendedRule), True)
-        self.assertEqual(created_rule.index, 120)
+        self.assertEqual(created_rule.sequence, 120)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "Inline remark")
         self.assertEqual(created_rule.description, "Created permit rule with remark")
         self.assertEqual(isinstance(created_rule.access_list, AccessList), True)
         self.assertEqual(created_rule.access_list.type, self.acl_type)
 
-    def test_acl_extended_rule_action_permit_with_shared_index_action_remark_fail(self):
+    def test_acl_extended_rule_action_permit_with_shared_sequence_action_remark_fail(self):
         """
-        Test that ACLExtendedRule rejects a standalone remark sharing the same index as a permit rule.
+        Test that ACLExtendedRule rejects a standalone remark sharing the same sequence as a permit rule.
         """
         created_permit_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=130,
+            sequence=130,
             action="permit",
             remark="",
             source=None,
@@ -571,14 +571,14 @@ class TestACLExtendedRule(BaseTestCase):
             destination=None,
             destination_port_ranges=None,
             protocol=self.protocol,
-            description="Created permit rule with same index as remark",
+            description="Created permit rule with same sequence as remark",
         )
         created_permit_rule.full_clean()
         created_permit_rule.save()
 
         created_remark_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=130,
+            sequence=130,
             action="remark",
             remark="Standalone remark",
             source=None,
@@ -586,7 +586,7 @@ class TestACLExtendedRule(BaseTestCase):
             destination=None,
             destination_port_ranges=None,
             protocol=None,
-            description="Created remark rule with same index as permit rule",
+            description="Created remark rule with same sequence as permit rule",
         )
         with self.assertRaises(ValidationError):
             created_remark_rule.full_clean()
@@ -603,7 +603,7 @@ class TestACLExtendedRule(BaseTestCase):
         )
         extended_rule = ACLExtendedRule(
             access_list=standard_acl1,
-            index=170,
+            sequence=170,
             action="remark",
             remark="Test remark",
             source=None,
@@ -616,13 +616,13 @@ class TestACLExtendedRule(BaseTestCase):
         with self.assertRaises(ValidationError):
             extended_rule.full_clean()
 
-    def test_duplicate_index_per_acl_fail(self):
+    def test_duplicate_sequence_per_acl_fail(self):
         """
-        Test that the rule index must be unique per AccessList.
+        Test that the rule sequence must be unique per AccessList.
         """
         params = {
             "access_list": self.extended_acl1,
-            "index": 10,
+            "sequence": 10,
             "action": "permit",
         }
         rule_1 = ACLExtendedRule(**params)
@@ -638,7 +638,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         invalid_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             action="remark",
             remark="",
             source=None,
@@ -657,7 +657,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         invalid_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             action="remark",
             remark="",
             source=self.prefix1,
@@ -676,7 +676,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         invalid_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             action="remark",
             remark="",
             source=self.prefix1,
@@ -695,7 +695,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         invalid_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             action="remark",
             remark="",
             source=None,
@@ -714,7 +714,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         invalid_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             action="remark",
             remark="",
             source=None,
@@ -733,7 +733,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         invalid_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             action="remark",
             remark="",
             source=None,
@@ -752,7 +752,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         invalid_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             action="permit",
             remark="",
             source=None,
@@ -771,7 +771,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         invalid_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             action="permit",
             remark="",
             source=None,
@@ -790,7 +790,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         invalid_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             action="permit",
             remark="",
             source=None,
@@ -809,7 +809,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         invalid_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             action="permit",
             remark="",
             source=None,
@@ -828,7 +828,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         invalid_acl_rule_source_object = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             action="permit",
             remark="",
             source=self.device1,
@@ -847,7 +847,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         invalid_acl_rule_destination_object = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             action="permit",
             remark="",
             source=None,
@@ -869,7 +869,7 @@ class TestACLExtendedRule(BaseTestCase):
         for action_choice in valid_acl_rule_action_choices:
             valid_acl_rule_action = ACLExtendedRule(
                 access_list=self.extended_acl1,
-                index=10,
+                sequence=10,
                 action=action_choice,
                 remark="Remark" if action_choice == "remark" else None,
                 description=f"VALID ACL RULE ACTION CHOICES USED: action={action_choice}",
@@ -884,7 +884,7 @@ class TestACLExtendedRule(BaseTestCase):
 
         invalid_acl_rule_action = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             action=invalid_acl_rule_action_choice,
             description=f"INVALID ACL RULE ACTION CHOICES USED: action={invalid_acl_rule_action_choice}",
         )
@@ -901,7 +901,7 @@ class TestACLExtendedRule(BaseTestCase):
         for protocol_choice in valid_acl_rule_protocol_choices:
             valid_acl_rule_protocol = ACLExtendedRule(
                 access_list=self.extended_acl1,
-                index=10,
+                sequence=10,
                 action=self.default_action,
                 protocol=protocol_choice,
                 description=f"VALID ACL RULE PROTOCOL CHOICES USED: protocol={protocol_choice}",
@@ -916,7 +916,7 @@ class TestACLExtendedRule(BaseTestCase):
 
         invalid_acl_rule_protocol = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             protocol=invalid_acl_rule_protocol_choice,
             description=f"INVALID ACL RULE PROTOCOL CHOICES USED: protocol={invalid_acl_rule_protocol_choice}",
         )
@@ -936,7 +936,7 @@ class TestACLExtendedRule(BaseTestCase):
         )
         invalid_rule = ACLExtendedRule(
             access_list=acl_v4,
-            index=10,
+            sequence=10,
             action=ACLActionChoices.ACTION_PERMIT,
             source=self.prefix1_v6,
             destination=self.prefix1_v6,
@@ -956,7 +956,7 @@ class TestACLExtendedRule(BaseTestCase):
         )
         invalid_rule = ACLExtendedRule(
             access_list=acl,
-            index=10,
+            sequence=10,
             action=ACLActionChoices.ACTION_PERMIT,
             source=self.prefix1,
             destination=self.prefix1_v6,
@@ -976,7 +976,7 @@ class TestACLExtendedRule(BaseTestCase):
         )
         mixed = ACLExtendedRule(
             access_list=acl,
-            index=10,
+            sequence=10,
             action=ACLActionChoices.ACTION_PERMIT,
             source=self.prefix1,
             destination=self.prefix1_v6,
@@ -990,7 +990,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=10,
+            sequence=10,
             action=ACLActionChoices.ACTION_PERMIT,
             source=self.prefix1,
             source_port_ranges=string_to_ranges("1024-65535"),
@@ -1010,7 +1010,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         created_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=155,
+            sequence=155,
             action="permit",
             remark="",
             source=self.prefix1,
@@ -1045,7 +1045,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         invalid_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=156,
+            sequence=156,
             action="permit",
             remark="",
             source=self.prefix1,
@@ -1068,7 +1068,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         invalid_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=157,
+            sequence=157,
             action="permit",
             remark="",
             source=self.prefix1,
@@ -1088,7 +1088,7 @@ class TestACLExtendedRule(BaseTestCase):
         """
         invalid_rule = ACLExtendedRule(
             access_list=self.extended_acl1,
-            index=158,
+            sequence=158,
             action="permit",
             remark="",
             source=self.prefix1,

--- a/netbox_acls/tests/models/test_standardrules.py
+++ b/netbox_acls/tests/models/test_standardrules.py
@@ -58,7 +58,7 @@ class TestACLStandardRule(BaseTestCase):
         """
         created_rule = ACLStandardRule(
             access_list=self.standard_acl1,
-            index=10,
+            sequence=10,
             action="permit",
             remark="",
             source=None,
@@ -67,7 +67,7 @@ class TestACLStandardRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLStandardRule), True)
-        self.assertEqual(created_rule.index, 10)
+        self.assertEqual(created_rule.sequence, 10)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, None)
@@ -81,7 +81,7 @@ class TestACLStandardRule(BaseTestCase):
         """
         created_rule = ACLStandardRule(
             access_list=self.standard_acl1,
-            index=20,
+            sequence=20,
             action="permit",
             remark="",
             source=self.prefix1,
@@ -90,7 +90,7 @@ class TestACLStandardRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLStandardRule), True)
-        self.assertEqual(created_rule.index, 20)
+        self.assertEqual(created_rule.sequence, 20)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, self.prefix1)
@@ -104,7 +104,7 @@ class TestACLStandardRule(BaseTestCase):
         """
         created_rule = ACLStandardRule(
             access_list=self.standard_acl1,
-            index=30,
+            sequence=30,
             action="remark",
             remark="Test remark",
             source=None,
@@ -113,7 +113,7 @@ class TestACLStandardRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLStandardRule), True)
-        self.assertEqual(created_rule.index, 30)
+        self.assertEqual(created_rule.sequence, 30)
         self.assertEqual(created_rule.action, "remark")
         self.assertEqual(created_rule.remark, "Test remark")
         self.assertEqual(created_rule.source, None)
@@ -127,7 +127,7 @@ class TestACLStandardRule(BaseTestCase):
         """
         created_rule = ACLStandardRule(
             access_list=self.standard_acl1,
-            index=40,
+            sequence=40,
             action="permit",
             remark="",
             source=self.aggregate1,
@@ -136,7 +136,7 @@ class TestACLStandardRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLStandardRule), True)
-        self.assertEqual(created_rule.index, 40)
+        self.assertEqual(created_rule.sequence, 40)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, self.aggregate1)
@@ -150,7 +150,7 @@ class TestACLStandardRule(BaseTestCase):
         """
         created_rule = ACLStandardRule(
             access_list=self.standard_acl1,
-            index=50,
+            sequence=50,
             action="permit",
             remark="",
             source=self.ip_address1,
@@ -159,7 +159,7 @@ class TestACLStandardRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLStandardRule), True)
-        self.assertEqual(created_rule.index, 50)
+        self.assertEqual(created_rule.sequence, 50)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, self.ip_address1)
@@ -173,7 +173,7 @@ class TestACLStandardRule(BaseTestCase):
         """
         created_rule = ACLStandardRule(
             access_list=self.standard_acl1,
-            index=60,
+            sequence=60,
             action="permit",
             remark="",
             source=self.ip_range1,
@@ -182,7 +182,7 @@ class TestACLStandardRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLStandardRule), True)
-        self.assertEqual(created_rule.index, 60)
+        self.assertEqual(created_rule.sequence, 60)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "")
         self.assertEqual(created_rule.source, self.ip_range1)
@@ -196,7 +196,7 @@ class TestACLStandardRule(BaseTestCase):
         """
         created_rule = ACLStandardRule(
             access_list=self.standard_acl1,
-            index=70,
+            sequence=70,
             action="permit",
             remark="Inline remark",
             source=None,
@@ -205,7 +205,7 @@ class TestACLStandardRule(BaseTestCase):
         created_rule.full_clean()
 
         self.assertTrue(isinstance(created_rule, ACLStandardRule), True)
-        self.assertEqual(created_rule.index, 70)
+        self.assertEqual(created_rule.sequence, 70)
         self.assertEqual(created_rule.action, "permit")
         self.assertEqual(created_rule.remark, "Inline remark")
         self.assertEqual(created_rule.description, "Created permit rule with remark")
@@ -214,26 +214,26 @@ class TestACLStandardRule(BaseTestCase):
 
     def test_acl_standard_rule_action_permit_with_shared_index_action_remark_fail(self):
         """
-        Test that ACLStandardRule rejects a standalone remark sharing the same index as a permit rule.
+        Test that ACLStandardRule rejects a standalone remark sharing the same sequence as a permit rule.
         """
         created_permit_rule = ACLStandardRule(
             access_list=self.standard_acl1,
-            index=80,
+            sequence=80,
             action="permit",
             remark="",
             source=None,
-            description="Created permit rule with same index as remark",
+            description="Created permit rule with same sequence as remark",
         )
         created_permit_rule.full_clean()
         created_permit_rule.save()
 
         created_remark_rule = ACLStandardRule(
             access_list=self.standard_acl1,
-            index=80,
+            sequence=80,
             action="remark",
             remark="Standalone remark",
             source=None,
-            description="Created remark rule with same index as permit rule",
+            description="Created remark rule with same sequence as permit rule",
         )
         with self.assertRaises(ValidationError):
             created_remark_rule.full_clean()
@@ -250,7 +250,7 @@ class TestACLStandardRule(BaseTestCase):
         )
         standard_rule = ACLStandardRule(
             access_list=extended_acl1,
-            index=30,
+            sequence=30,
             action="remark",
             remark="Test remark",
             source=None,
@@ -261,11 +261,11 @@ class TestACLStandardRule(BaseTestCase):
 
     def test_duplicate_index_per_acl_fail(self):
         """
-        Test that the rule index must be unique per AccessList.
+        Test that the rule sequence must be unique per AccessList.
         """
         params = {
             "access_list": self.standard_acl1,
-            "index": 10,
+            "sequence": 10,
             "action": "permit",
         }
         rule_1 = ACLStandardRule(**params)
@@ -281,7 +281,7 @@ class TestACLStandardRule(BaseTestCase):
         """
         invalid_rule = ACLStandardRule(
             access_list=self.standard_acl1,
-            index=10,
+            sequence=10,
             action="remark",
             remark="",
             source=None,
@@ -296,7 +296,7 @@ class TestACLStandardRule(BaseTestCase):
         """
         invalid_rule = ACLStandardRule(
             access_list=self.standard_acl1,
-            index=10,
+            sequence=10,
             action="remark",
             remark="",
             source=self.prefix1,
@@ -311,7 +311,7 @@ class TestACLStandardRule(BaseTestCase):
         """
         invalid_acl_rule_source_object = ACLStandardRule(
             access_list=self.standard_acl1,
-            index=10,
+            sequence=10,
             action="permit",
             remark="",
             source=self.device1,
@@ -329,7 +329,7 @@ class TestACLStandardRule(BaseTestCase):
         for action_choice in valid_acl_rule_action_choices:
             valid_acl_rule_action = ACLStandardRule(
                 access_list=self.standard_acl1,
-                index=10,
+                sequence=10,
                 action=action_choice,
                 remark="Remark" if action_choice == "remark" else None,
                 description=f"VALID ACL RULE ACTION CHOICES USED: action={action_choice}",
@@ -344,7 +344,7 @@ class TestACLStandardRule(BaseTestCase):
 
         invalid_acl_rule_action = ACLStandardRule(
             access_list=self.standard_acl1,
-            index=10,
+            sequence=10,
             action=invalid_acl_rule_action_choice,
             description=f"INVALID ACL RULE ACTION CHOICES USED: action={invalid_acl_rule_action_choice}",
         )
@@ -364,7 +364,7 @@ class TestACLStandardRule(BaseTestCase):
         )
         invalid_rule = ACLStandardRule(
             access_list=acl_v4,
-            index=10,
+            sequence=10,
             action=ACLActionChoices.ACTION_PERMIT,
             source=self.prefix1_v6,
         )
@@ -383,7 +383,7 @@ class TestACLStandardRule(BaseTestCase):
         )
         invalid_rule = ACLStandardRule(
             access_list=acl,
-            index=10,
+            sequence=10,
             action=ACLActionChoices.ACTION_PERMIT,
             source=self.prefix1,
         )


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #290

## New Behavior

This PR renames `index` to `sequence` in `ACLStandardRule` and `ACLExtendedRule` and updates related references across the plugin, including serializers, forms, filters, templates, and tests.

## Contrast to Current Behavior

The field is currently named `index`, which feels more generic than the role it serves. Renaming it to `sequence` makes it clearer that the field defines rule processing order within an ACL.

## Discussion: Benefits and Drawbacks

The main benefit is improved clarity and terminology that better matches how ACL rules are understood and processed. This should make the models and surrounding UI/API usage easier to follow.

The drawback is that this is a breaking change for existing integrations, API consumers, or custom code that still reference `index`, so it is not backwards-compatible and should be called out clearly in the v2.0 upgrade notes.

## Changes to the Documentation

This change should be documented in the v2.0 upgrade notes so users know to update references from `index` to `sequence`. No wiki changes are currently needed.

## Proposed Release Note Entry

Renamed the ACL rule field `index` to `sequence` to better reflect rule ordering and updated related references across the plugin.

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.