### PR TITLE
Fixes #293: Define supported Object Actions for ACL views

### DIFF
--- a/netbox_acls/views.py
+++ b/netbox_acls/views.py
@@ -7,6 +7,7 @@ from dcim.models import Device, Interface, VirtualChassis
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count
 from django.utils.translation import gettext_lazy as _
+from netbox.object_actions import AddObject, BulkDelete, BulkExport
 from netbox.views import generic
 from utilities.views import ViewTab, register_model_view
 from virtualization.models import VirtualMachine, VMInterface
@@ -53,6 +54,7 @@ class ACLAssignmentChildrenView(generic.ObjectChildrenView):
         weight=1100,
     )
     table = tables.ACLAssignmentTable
+    actions = (BulkExport, BulkDelete)
 
     def get_children(self, request, parent):
         """
@@ -125,6 +127,7 @@ class AccessListListView(generic.ObjectListView):
     table = tables.AccessListTable
     filterset = filtersets.AccessListFilterSet
     filterset_form = forms.AccessListFilterForm
+    actions = (AddObject, BulkExport, BulkDelete)
 
 
 @register_model_view(models.AccessList, "add", detail=False)
@@ -217,6 +220,7 @@ class ACLAssignmentListView(generic.ObjectListView):
     table = tables.ACLAssignmentTable
     filterset = filtersets.ACLAssignmentFilterSet
     filterset_form = forms.ACLAssignmentFilterForm
+    actions = (AddObject, BulkExport, BulkDelete)
 
 
 @register_model_view(models.ACLAssignment, "add", detail=False)
@@ -428,6 +432,7 @@ class ACLStandardRuleListView(generic.ObjectListView):
     table = tables.ACLStandardRuleTable
     filterset = filtersets.ACLStandardRuleFilterSet
     filterset_form = forms.ACLStandardRuleFilterForm
+    actions = (AddObject, BulkExport, BulkDelete)
 
 
 @register_model_view(models.ACLStandardRule, "add", detail=False)
@@ -512,6 +517,7 @@ class ACLExtendedRuleListView(generic.ObjectListView):
     table = tables.ACLExtendedRuleTable
     filterset = filtersets.ACLExtendedRuleFilterSet
     filterset_form = forms.ACLExtendedRuleFilterForm
+    actions = (AddObject, BulkExport, BulkDelete)
 
 
 @register_model_view(models.ACLExtendedRule, "add", detail=False)


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #293

## New Behavior

This PR explicitly defines the supported object actions for all ACL list views and for `ACLAssignmentChildrenView`.

The list views now show only `Add`, `Export`, and `Delete`, while `ACLAssignmentChildrenView` shows `Export` and `Delete`.

## Contrast to Current Behavior

Before this change, the default NetBox object actions were shown, which caused unsupported actions such as `Import` to appear in the UI and lead to broken links or 404 pages.

With this change, only actions that are actually supported by the plugin are displayed.

## Discussion: Benefits and Drawbacks

This makes the UI clearer and avoids confusion by hiding actions that are not implemented. It also aligns the available buttons with the plugin’s current functionality.

The change is backward-compatible, as it only removes unsupported UI actions and does not affect existing data or supported workflows.

## Changes to the Documentation

No documentation changes are needed for this PR, since it only adjusts the visible UI actions to match the currently supported functionality.

## Proposed Release Note Entry

Hide unsupported object action buttons, including Import, from ACL views.

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.