### PR TITLE
Closes #305: Add Owner Support to ACL Objects

### DIFF
--- a/netbox_acls/api/serializers.py
+++ b/netbox_acls/api/serializers.py
@@ -9,7 +9,8 @@ from rest_framework import serializers
 
 from netbox.api.fields import ContentTypeField, IntegerRangeSerializer
 from netbox.api.gfk_fields import GFKSerializerField
-from netbox.api.serializers import NetBoxModelSerializer
+from netbox.api.serializers import NetBoxModelSerializer, PrimaryModelSerializer
+from users.api.serializers_.mixins import OwnerMixin
 
 from ..constants import ACL_ASSIGNMENT_MODELS, ACL_RULE_SOURCE_DESTINATION_MODELS
 from ..models import (
@@ -36,7 +37,7 @@ error_message_remark_without_action_remark = _("CANNOT set remark unless action 
 error_message_acl_type = _("Provided parent Access List is not of right type.")
 
 
-class AccessListSerializer(NetBoxModelSerializer):
+class AccessListSerializer(PrimaryModelSerializer):
     """
     Defines the serializer for the django AccessList model and associates it with a view.
     """
@@ -60,6 +61,8 @@ class AccessListSerializer(NetBoxModelSerializer):
             "type",
             "family",
             "default_action",
+            "description",
+            "owner",
             "comments",
             "tags",
             "custom_fields",
@@ -100,7 +103,7 @@ class AccessListSerializer(NetBoxModelSerializer):
         return super().validate(data)
 
 
-class ACLAssignmentSerializer(NetBoxModelSerializer):
+class ACLAssignmentSerializer(OwnerMixin, NetBoxModelSerializer):
     """
     Defines the serializer for the django ACLAssignment model and associates it with a view.
     """
@@ -133,6 +136,7 @@ class ACLAssignmentSerializer(NetBoxModelSerializer):
             "assigned_object_type",
             "assigned_object_id",
             "assigned_object",
+            "owner",
             "comments",
             "tags",
             "custom_fields",
@@ -142,7 +146,7 @@ class ACLAssignmentSerializer(NetBoxModelSerializer):
         brief_fields = ("id", "url", "display", "access_list")
 
 
-class ACLStandardRuleSerializer(NetBoxModelSerializer):
+class ACLStandardRuleSerializer(PrimaryModelSerializer):
     """
     Defines the serializer for the django ACLStandardRule model and associates it with a view.
     """
@@ -182,6 +186,8 @@ class ACLStandardRuleSerializer(NetBoxModelSerializer):
             "source_id",
             "source",
             "description",
+            "owner",
+            "comments",
             "tags",
             "created",
             "custom_fields",
@@ -221,7 +227,7 @@ class ACLStandardRuleSerializer(NetBoxModelSerializer):
         return super().validate(data)
 
 
-class ACLExtendedRuleSerializer(NetBoxModelSerializer):
+class ACLExtendedRuleSerializer(PrimaryModelSerializer):
     """
     Defines the serializer for the django ACLExtendedRule model and associates it with a view.
     """
@@ -285,6 +291,8 @@ class ACLExtendedRuleSerializer(NetBoxModelSerializer):
             "destination_port_ranges",
             "destination_port_terms",
             "description",
+            "owner",
+            "comments",
             "tags",
             "created",
             "custom_fields",

--- a/netbox_acls/api/views.py
+++ b/netbox_acls/api/views.py
@@ -29,13 +29,9 @@ class AccessListViewSet(NetBoxModelViewSet):
     Defines the view set for the django AccessList model and associates it with a view.
     """
 
-    queryset = (
-        models.AccessList.objects.prefetch_related("tags")
-        .annotate(
-            rule_count=Count("aclextendedrules") + Count("aclstandardrules"),
-        )
-        .prefetch_related("tags")
-    )
+    queryset = models.AccessList.objects.annotate(
+        rule_count=Count("aclextendedrules") + Count("aclstandardrules")
+    ).prefetch_related("owner", "tags")
     serializer_class = AccessListSerializer
     filterset_class = filtersets.AccessListFilterSet
 
@@ -47,6 +43,7 @@ class ACLAssignmentViewSet(NetBoxModelViewSet):
 
     queryset = models.ACLAssignment.objects.prefetch_related(
         "access_list",
+        "owner",
         "tags",
     )
     serializer_class = ACLAssignmentSerializer
@@ -61,6 +58,7 @@ class ACLStandardRuleViewSet(NetBoxModelViewSet):
     queryset = models.ACLStandardRule.objects.prefetch_related(
         "access_list",
         "source",
+        "owner",
         "tags",
     )
     serializer_class = ACLStandardRuleSerializer
@@ -76,6 +74,7 @@ class ACLExtendedRuleViewSet(NetBoxModelViewSet):
         "access_list",
         "source",
         "destination",
+        "owner",
         "tags",
     )
     serializer_class = ACLExtendedRuleSerializer

--- a/netbox_acls/filtersets.py
+++ b/netbox_acls/filtersets.py
@@ -9,7 +9,8 @@ from django.utils.translation import gettext_lazy as _
 
 from dcim.models import Device, Interface, Region, Site, SiteGroup, VirtualChassis
 from ipam.models import Aggregate, IPAddress, IPRange, Prefix
-from netbox.filtersets import NetBoxModelFilterSet
+from netbox.filtersets import NetBoxModelFilterSet, PrimaryModelFilterSet
+from users.filterset_mixins import OwnerFilterMixin
 from utilities.filters import ContentTypeFilter
 from utilities.filtersets import register_filterset
 from virtualization.models import VirtualMachine, VMInterface
@@ -26,14 +27,14 @@ __all__ = (
 
 
 @register_filterset
-class AccessListFilterSet(NetBoxModelFilterSet):
+class AccessListFilterSet(PrimaryModelFilterSet):
     """
     Define the filter set for the django model AccessList.
     """
 
     class Meta:
         """
-        Associates the django model AccessList & fields to the filter set.
+        Associates the django model AccessList & fields with the filter set.
         """
 
         model = AccessList
@@ -43,6 +44,7 @@ class AccessListFilterSet(NetBoxModelFilterSet):
             "type",
             "family",
             "default_action",
+            "description",
             "comments",
         )
 
@@ -54,13 +56,14 @@ class AccessListFilterSet(NetBoxModelFilterSet):
             Q(name__icontains=value)
             | Q(type__icontains=value)
             | Q(default_action__icontains=value)
+            | Q(description__icontains=value)
             | Q(comments__icontains=value)
         )
         return queryset.filter(query)
 
 
 @register_filterset
-class ACLAssignmentFilterSet(NetBoxModelFilterSet):
+class ACLAssignmentFilterSet(OwnerFilterMixin, NetBoxModelFilterSet):
     """
     Define the filter set for the django model ACLAssignment.
     """
@@ -164,7 +167,7 @@ class ACLAssignmentFilterSet(NetBoxModelFilterSet):
 
     class Meta:
         """
-        Associates the django model ACLInterfaceAssignment & fields to the filter set.
+        Associates the django model ACLInterfaceAssignment & fields with the filter set.
         """
 
         model = ACLAssignment
@@ -205,7 +208,7 @@ class ACLAssignmentFilterSet(NetBoxModelFilterSet):
 
 
 @register_filterset
-class ACLStandardRuleFilterSet(NetBoxModelFilterSet):
+class ACLStandardRuleFilterSet(PrimaryModelFilterSet):
     """
     Define the filter set for the django model ACLStandardRule.
     """
@@ -277,7 +280,7 @@ class ACLStandardRuleFilterSet(NetBoxModelFilterSet):
 
     class Meta:
         """
-        Associates the django model ACLStandardRule & fields to the filter set.
+        Associates the django model ACLStandardRule & fields with the filter set.
         """
 
         model = ACLStandardRule
@@ -289,18 +292,26 @@ class ACLStandardRuleFilterSet(NetBoxModelFilterSet):
             "remark",
             "source_type",
             "source_id",
+            "description",
+            "comments",
         )
 
     def search(self, queryset, name, value):
         """
         Override the default search behavior for the django model.
         """
-        query = Q(access_list__name__icontains=value) | Q(sequence__icontains=value) | Q(action__icontains=value)
+        query = (
+            Q(access_list__name__icontains=value)
+            | Q(sequence__icontains=value)
+            | Q(action__icontains=value)
+            | Q(remark__icontains=value)
+            | Q(description__icontains=value)
+        )
         return queryset.filter(query)
 
 
 @register_filterset
-class ACLExtendedRuleFilterSet(NetBoxModelFilterSet):
+class ACLExtendedRuleFilterSet(PrimaryModelFilterSet):
     """
     Define the filter set for the django model ACLExtendedRule.
     """
@@ -435,7 +446,7 @@ class ACLExtendedRuleFilterSet(NetBoxModelFilterSet):
 
     class Meta:
         """
-        Associates the django model ACLExtendedRule & fields to the filter set.
+        Associates the django model ACLExtendedRule & fields with the filter set.
         """
 
         model = ACLExtendedRule
@@ -445,13 +456,15 @@ class ACLExtendedRuleFilterSet(NetBoxModelFilterSet):
             "sequence",
             "action",
             "remark",
+            "protocol",
             "source_type",
             "source_id",
             "source_port",
             "destination_type",
             "destination_id",
             "destination_port",
-            "protocol",
+            "description",
+            "comments",
         )
 
     def search(self, queryset, name, value):
@@ -462,6 +475,8 @@ class ACLExtendedRuleFilterSet(NetBoxModelFilterSet):
             Q(access_list__name__icontains=value)
             | Q(sequence__icontains=value)
             | Q(action__icontains=value)
+            | Q(remark__icontains=value)
             | Q(protocol__icontains=value)
+            | Q(description__icontains=value)
         )
         return queryset.filter(query)

--- a/netbox_acls/forms/filtersets.py
+++ b/netbox_acls/forms/filtersets.py
@@ -7,7 +7,8 @@ from django.utils.translation import gettext_lazy as _
 
 from dcim.models import Device, Interface, Region, Site, SiteGroup, VirtualChassis
 from ipam.models import Aggregate, IPAddress, IPRange, Prefix
-from netbox.forms import NetBoxModelFilterSetForm
+from netbox.forms import NetBoxModelFilterSetForm, PrimaryModelFilterSetForm
+from netbox.forms.mixins import OwnerFilterMixin
 from utilities.forms.fields import (
     DynamicModelChoiceField,
     DynamicModelMultipleChoiceField,
@@ -40,7 +41,7 @@ __all__ = (
 )
 
 
-class AccessListFilterForm(NetBoxModelFilterSetForm):
+class AccessListFilterForm(PrimaryModelFilterSetForm):
     """
     GUI filter form to search the django AccessList model.
     """
@@ -56,7 +57,13 @@ class AccessListFilterForm(NetBoxModelFilterSetForm):
             "type",
             "family",
             "default_action",
+            "description",
             name=_("ACL Details"),
+        ),
+        FieldSet(
+            "owner_group_id",
+            "owner_id",
+            name=_("Ownership"),
         ),
     )
 
@@ -81,7 +88,7 @@ class AccessListFilterForm(NetBoxModelFilterSetForm):
     tag = TagFilterField(model)
 
 
-class ACLAssignmentFilterForm(NetBoxModelFilterSetForm):
+class ACLAssignmentFilterForm(OwnerFilterMixin, NetBoxModelFilterSetForm):
     """
     GUI filter form to search the django ACLAssignment model.
     """
@@ -115,6 +122,11 @@ class ACLAssignmentFilterForm(NetBoxModelFilterSetForm):
             "virtual_machine_id",
             "vminterface_id",
             name=_("Virtual Machine Details"),
+        ),
+        FieldSet(
+            "owner_group_id",
+            "owner_id",
+            name=_("Ownership"),
         ),
     )
 
@@ -200,7 +212,7 @@ class ACLAssignmentFilterForm(NetBoxModelFilterSetForm):
     tag = TagFilterField(model)
 
 
-class ACLStandardRuleFilterForm(NetBoxModelFilterSetForm):
+class ACLStandardRuleFilterForm(PrimaryModelFilterSetForm):
     """
     GUI filter form to search the django ACLStandardRule model.
     """
@@ -225,6 +237,11 @@ class ACLStandardRuleFilterForm(NetBoxModelFilterSetForm):
             "source_iprange_id",
             "source_prefix_id",
             name=_("Source Details"),
+        ),
+        FieldSet(
+            "owner_group_id",
+            "owner_id",
+            name=_("Ownership"),
         ),
     )
 
@@ -276,7 +293,7 @@ class ACLStandardRuleFilterForm(NetBoxModelFilterSetForm):
     tag = TagFilterField(model)
 
 
-class ACLExtendedRuleFilterForm(NetBoxModelFilterSetForm):
+class ACLExtendedRuleFilterForm(PrimaryModelFilterSetForm):
     """
     GUI filter form to search the django ACLExtendedRule model.
     """
@@ -311,6 +328,11 @@ class ACLExtendedRuleFilterForm(NetBoxModelFilterSetForm):
             "destination_prefix_id",
             "destination_port",
             name=_("Destination Details"),
+        ),
+        FieldSet(
+            "owner_group_id",
+            "owner_id",
+            name=_("Ownership"),
         ),
     )
 

--- a/netbox_acls/forms/models.py
+++ b/netbox_acls/forms/models.py
@@ -10,7 +10,8 @@ from django.utils.translation import gettext_lazy as _
 
 from dcim.models import Device, Interface
 from ipam.models import Prefix
-from netbox.forms import NetBoxModelForm
+from netbox.forms import NetBoxModelForm, PrimaryModelForm
+from netbox.forms.mixins import OwnerMixin
 from utilities.forms import (
     add_blank_choice,
     get_field_value,
@@ -64,13 +65,11 @@ help_text_acl_remark = _("Remark the rule will take.")
 help_text_acl_rule_port_ranges = _("Comma/hyphen (inclusive). Example: 22,80-81,1024-65535")
 
 
-class AccessListForm(NetBoxModelForm):
+class AccessListForm(PrimaryModelForm):
     """
     GUI form to add or edit an AccessList.
     Requires a device, a name, a type, and a default_action.
     """
-
-    comments = CommentField()
 
     fieldsets = (
         FieldSet(
@@ -78,6 +77,7 @@ class AccessListForm(NetBoxModelForm):
             "type",
             "family",
             "default_action",
+            "description",
             "tags",
             name=_("Access List Details"),
         ),
@@ -90,6 +90,8 @@ class AccessListForm(NetBoxModelForm):
             "type",
             "family",
             "default_action",
+            "description",
+            "owner",
             "comments",
             "tags",
         )
@@ -107,7 +109,7 @@ class AccessListForm(NetBoxModelForm):
         }
 
 
-class ACLAssignmentForm(NetBoxModelForm):
+class ACLAssignmentForm(OwnerMixin, NetBoxModelForm):
     """
     GUI form to add or edit ACL assignments
     Requires an access_list, a name, a type, and a default_action.
@@ -160,6 +162,17 @@ class ACLAssignmentForm(NetBoxModelForm):
         ),
     )
 
+    class Meta:
+        model = ACLAssignment
+        fields = (
+            "access_list",
+            "assigned_object_type",
+            "direction",
+            "owner",
+            "comments",
+            "tags",
+        )
+
     def __init__(self, *args, **kwargs) -> None:
         """
         Initialize the ACL Assignment form.
@@ -211,18 +224,8 @@ class ACLAssignmentForm(NetBoxModelForm):
         # Ensure the selected object gets assigned
         self.instance.assigned_object = self.cleaned_data.get("assigned_object")
 
-    class Meta:
-        model = ACLAssignment
-        fields = (
-            "access_list",
-            "assigned_object_type",
-            "direction",
-            "comments",
-            "tags",
-        )
 
-
-class ACLStandardRuleForm(NetBoxModelForm):
+class ACLStandardRuleForm(PrimaryModelForm):
     """
     GUI form to add or edit Standard Access List.
     Requires an access_list, a sequence, and ACL rule type.
@@ -288,8 +291,10 @@ class ACLStandardRuleForm(NetBoxModelForm):
             "action",
             "remark",
             "source_type",
-            "tags",
             "description",
+            "owner",
+            "comments",
+            "tags",
         )
 
         help_texts = {
@@ -343,10 +348,10 @@ class ACLStandardRuleForm(NetBoxModelForm):
         self.instance.source = self.cleaned_data.get("source")
 
 
-class ACLExtendedRuleForm(NetBoxModelForm):
+class ACLExtendedRuleForm(PrimaryModelForm):
     """
     GUI form to add or edit Extended Access List.
-    Requires an access_list, an sequence, and ACL rule type.
+    Requires an access_list, a sequence, and ACL rule type.
     See the clean function for logic on other field requirements.
     """
 
@@ -451,8 +456,10 @@ class ACLExtendedRuleForm(NetBoxModelForm):
             "destination_type",
             "destination_port_ranges",
             "protocol",
-            "tags",
             "description",
+            "owner",
+            "comments",
+            "tags",
         )
 
         help_texts = {

--- a/netbox_acls/graphql/filters/access_list_rules.py
+++ b/netbox_acls/graphql/filters/access_list_rules.py
@@ -7,7 +7,7 @@ from strawberry.scalars import ID
 from strawberry_django import BaseFilterLookup
 
 from core.graphql.filters import ContentTypeFilter
-from netbox.graphql.filters import NetBoxModelFilter
+from netbox.graphql.filters import PrimaryModelFilter
 
 try:
     from strawberry_django import StrFilterLookup
@@ -33,7 +33,7 @@ __all__ = (
 
 
 @dataclass
-class ACLRuleFilterMixin(NetBoxModelFilter):
+class ACLRuleFilterMixin(PrimaryModelFilter):
     """
     Base GraphQL filter mixin for ACL Rule models.
     """
@@ -45,7 +45,6 @@ class ACLRuleFilterMixin(NetBoxModelFilter):
     sequence: Annotated["IntegerLookup", strawberry.lazy("netbox.graphql.filter_lookups")] | None = (
         strawberry_django.filter_field()
     )
-    description: StrFilterLookup[str] | None = strawberry_django.filter_field()
     action: BaseFilterLookup[Annotated["ACLRuleActionEnum", strawberry.lazy("netbox_acls.graphql.enums")]] | None = (
         strawberry_django.filter_field()
     )

--- a/netbox_acls/graphql/filters/access_lists.py
+++ b/netbox_acls/graphql/filters/access_lists.py
@@ -6,7 +6,7 @@ from strawberry.scalars import ID
 from strawberry_django import BaseFilterLookup
 
 from core.graphql.filters import ContentTypeFilter
-from netbox.graphql.filters import NetBoxModelFilter
+from netbox.graphql.filters import NetBoxModelFilter, PrimaryModelFilter
 
 try:
     from strawberry_django import StrFilterLookup
@@ -31,7 +31,7 @@ __all__ = (
 
 
 @strawberry_django.filter(models.AccessList, lookups=True)
-class AccessListFilter(NetBoxModelFilter):
+class AccessListFilter(PrimaryModelFilter):
     """
     GraphQL filter definition for the AccessList model.
     """
@@ -68,3 +68,4 @@ class ACLAssignmentFilter(NetBoxModelFilter):
     family: BaseFilterLookup[Annotated["ACLFamilyEnum", strawberry.lazy("netbox_acls.graphql.enums")]] | None = (
         strawberry_django.filter_field()
     )
+    comments: StrFilterLookup[str] | None = strawberry_django.filter_field()

--- a/netbox_acls/graphql/types.py
+++ b/netbox_acls/graphql/types.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING, Annotated
 import strawberry
 import strawberry_django
 
-from netbox.graphql.types import ContentTypeType, NetBoxObjectType
+from netbox.graphql.types import ContentTypeType, NetBoxObjectType, PrimaryObjectType
+from users.graphql.mixins import OwnerMixin
 
 from .. import models
 from . import filters
@@ -23,7 +24,7 @@ if TYPE_CHECKING:
     fields="__all__",
     filters=filters.AccessListFilter,
 )
-class AccessListType(NetBoxObjectType):
+class AccessListType(PrimaryObjectType):
     """
     Defines the object type for the django model AccessList.
     """
@@ -55,7 +56,7 @@ class AccessListType(NetBoxObjectType):
     exclude=["assigned_object_type", "assigned_object_id"],
     filters=filters.ACLAssignmentFilter,
 )
-class ACLAssignmentType(NetBoxObjectType):
+class ACLAssignmentType(OwnerMixin, NetBoxObjectType):
     """
     Defines the object type for the django model ACLInterfaceAssignment.
     """
@@ -82,7 +83,7 @@ class ACLAssignmentType(NetBoxObjectType):
     ],
     filters=filters.ACLStandardRuleFilter,
 )
-class ACLStandardRuleType(NetBoxObjectType):
+class ACLStandardRuleType(PrimaryObjectType):
     """
     Defines the object type for the django model ACLStandardRule.
     """
@@ -119,7 +120,7 @@ class ACLStandardRuleType(NetBoxObjectType):
     ],
     filters=filters.ACLExtendedRuleFilter,
 )
-class ACLExtendedRuleType(NetBoxObjectType):
+class ACLExtendedRuleType(PrimaryObjectType):
     """
     Defines the object type for the django model ACLExtendedRule.
     """

--- a/netbox_acls/migrations/0013_acl_owner.py
+++ b/netbox_acls/migrations/0013_acl_owner.py
@@ -1,0 +1,55 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_acls", "0012_aclextendedrule_port_ranges"),
+        ("users", "0015_owner"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="accesslist",
+            name="description",
+            field=models.CharField(blank=True, max_length=200),
+        ),
+        migrations.AddField(
+            model_name="accesslist",
+            name="owner",
+            field=models.ForeignKey(
+                blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to="users.owner"
+            ),
+        ),
+        migrations.AddField(
+            model_name="aclassignment",
+            name="owner",
+            field=models.ForeignKey(
+                blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to="users.owner"
+            ),
+        ),
+        migrations.AddField(
+            model_name="aclextendedrule",
+            name="comments",
+            field=models.TextField(blank=True),
+        ),
+        migrations.AddField(
+            model_name="aclextendedrule",
+            name="owner",
+            field=models.ForeignKey(
+                blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to="users.owner"
+            ),
+        ),
+        migrations.AddField(
+            model_name="aclstandardrule",
+            name="comments",
+            field=models.TextField(blank=True),
+        ),
+        migrations.AddField(
+            model_name="aclstandardrule",
+            name="owner",
+            field=models.ForeignKey(
+                blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to="users.owner"
+            ),
+        ),
+    ]

--- a/netbox_acls/models/access_list_rules.py
+++ b/netbox_acls/models/access_list_rules.py
@@ -10,7 +10,7 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from ipam.models import Aggregate, IPAddress, IPRange, Prefix
-from netbox.models import NetBoxModel
+from netbox.models import PrimaryModel
 from utilities.data import ranges_to_string_list
 
 from ..choices import (
@@ -59,7 +59,7 @@ ERROR_MESSAGE_PROTOCOL_NOT_TCP_OR_UDP_WITH_DESTINATION_PORTS_SET = _(
 )
 
 
-class ACLRule(NetBoxModel):
+class ACLRule(PrimaryModel):
     """
     Abstract model for ACL Rules.
     Inherited by both ACLStandardRule and ACLExtendedRule.

--- a/netbox_acls/models/access_lists.py
+++ b/netbox_acls/models/access_lists.py
@@ -10,7 +10,8 @@ from django.db import models, transaction
 from django.utils.translation import gettext_lazy as _
 
 from dcim.models import Device, Interface, VirtualChassis
-from netbox.models import NetBoxModel
+from netbox.models import NetBoxModel, PrimaryModel
+from netbox.models.mixins import OwnerMixin
 from virtualization.models import VirtualMachine, VMInterface
 
 from ..choices import (
@@ -27,7 +28,7 @@ __all__ = (
 )
 
 
-class AccessList(NetBoxModel):
+class AccessList(PrimaryModel):
     """
     Model definition for Access Lists.
     """
@@ -54,9 +55,6 @@ class AccessList(NetBoxModel):
         max_length=30,
         default=ACLActionChoices.ACTION_DENY,
         choices=ACLActionChoices,
-    )
-    comments = models.TextField(
-        blank=True,
     )
 
     clone_fields = (
@@ -279,7 +277,7 @@ class AccessList(NetBoxModel):
         return ACLTypeChoices.colors.get(self.type)
 
 
-class ACLAssignment(NetBoxModel):
+class ACLAssignment(OwnerMixin, NetBoxModel):
     """
     Model definition for Access Lists associations with objects:
       - device

--- a/netbox_acls/tables.py
+++ b/netbox_acls/tables.py
@@ -5,7 +5,7 @@ Define the object lists / table view for each of the plugin models.
 import django_tables2 as tables
 from django.utils.translation import gettext_lazy as _
 
-from netbox.tables import NetBoxTable, columns
+from netbox.tables import NetBoxTable, PrimaryModelTable, columns
 
 from .models import AccessList, ACLAssignment, ACLExtendedRule, ACLStandardRule
 
@@ -17,7 +17,7 @@ __all__ = (
 )
 
 
-class AccessListTable(NetBoxTable):
+class AccessListTable(PrimaryModelTable):
     """
     Defines the table view for the AccessList model.
     """
@@ -42,7 +42,7 @@ class AccessListTable(NetBoxTable):
         url_name="plugins:netbox_acls:accesslist_list",
     )
 
-    class Meta(NetBoxTable.Meta):
+    class Meta(PrimaryModelTable.Meta):
         model = AccessList
         fields = (
             "pk",
@@ -52,9 +52,10 @@ class AccessListTable(NetBoxTable):
             "family",
             "rule_count",
             "default_action",
+            "description",
             "comments",
-            "action",
             "tags",
+            "action",
         )
         default_columns = (
             "name",
@@ -62,6 +63,7 @@ class AccessListTable(NetBoxTable):
             "family",
             "rule_count",
             "default_action",
+            "description",
             "tags",
         )
 
@@ -88,9 +90,6 @@ class ACLAssignmentTable(NetBoxTable):
         linkify=True,
     )
     direction = columns.ChoiceFieldColumn()
-    tags = columns.TagColumn(
-        url_name="plugins:netbox_acls:aclassignment_list",
-    )
     type = tables.Column(
         accessor=tables.A("access_list__type"),
         orderable=False,
@@ -100,6 +99,21 @@ class ACLAssignmentTable(NetBoxTable):
         accessor=tables.A("access_list__default_action"),
         orderable=False,
         verbose_name=_("Default Action"),
+    )
+    owner_group = tables.Column(
+        accessor="owner__group",
+        linkify=True,
+        verbose_name=_("Owner Group"),
+    )
+    owner = tables.Column(
+        linkify=True,
+        verbose_name=_("Owner"),
+    )
+    comments = columns.MarkdownColumn(
+        verbose_name=_("Comments"),
+    )
+    tags = columns.TagColumn(
+        url_name="plugins:netbox_acls:aclassignment_list",
     )
 
     class Meta(NetBoxTable.Meta):
@@ -112,6 +126,7 @@ class ACLAssignmentTable(NetBoxTable):
             "assigned_object_type",
             "assigned_object",
             "direction",
+            "owner",
             "tags",
         )
         default_columns = (
@@ -125,7 +140,7 @@ class ACLAssignmentTable(NetBoxTable):
         )
 
 
-class ACLStandardRuleTable(NetBoxTable):
+class ACLStandardRuleTable(PrimaryModelTable):
     """
     Defines the table view for the ACLStandardRule model.
     """
@@ -152,7 +167,7 @@ class ACLStandardRuleTable(NetBoxTable):
         linkify=True,
     )
 
-    class Meta(NetBoxTable.Meta):
+    class Meta(PrimaryModelTable.Meta):
         model = ACLStandardRule
         fields = (
             "pk",
@@ -161,9 +176,10 @@ class ACLStandardRuleTable(NetBoxTable):
             "sequence",
             "action",
             "remark",
-            "tags",
-            "description",
             "source",
+            "description",
+            "tags",
+            "comments",
         )
         default_columns = (
             "access_list",
@@ -175,7 +191,7 @@ class ACLStandardRuleTable(NetBoxTable):
         )
 
 
-class ACLExtendedRuleTable(NetBoxTable):
+class ACLExtendedRuleTable(PrimaryModelTable):
     """
     Defines the table view for the ACLExtendedRule model.
     """
@@ -221,7 +237,7 @@ class ACLExtendedRuleTable(NetBoxTable):
         orderable=False,
     )
 
-    class Meta(NetBoxTable.Meta):
+    class Meta(PrimaryModelTable.Meta):
         model = ACLExtendedRule
         fields = (
             "pk",
@@ -230,13 +246,14 @@ class ACLExtendedRuleTable(NetBoxTable):
             "sequence",
             "action",
             "remark",
-            "tags",
-            "description",
+            "protocol",
             "source",
             "source_port_ranges_list",
             "destination",
             "destination_port_ranges_list",
-            "protocol",
+            "description",
+            "tags",
+            "comments",
         )
         default_columns = (
             "access_list",

--- a/netbox_acls/templates/netbox_acls/accesslist.html
+++ b/netbox_acls/templates/netbox_acls/accesslist.html
@@ -46,6 +46,10 @@
               </td>
             {% endif %}
           </tr>
+          <tr>
+            <th scope="row">Description</th>
+            <td>{{ object.description|placeholder }}</td>
+          </tr>
         </table>
       </div>
       {% include 'inc/panels/custom_fields.html' %}

--- a/netbox_acls/templates/netbox_acls/aclextendedrule.html
+++ b/netbox_acls/templates/netbox_acls/aclextendedrule.html
@@ -25,10 +25,7 @@
           </tr>
         </table>
       </div>
-      {% include 'inc/panels/custom_fields.html' %}
-      {% include 'inc/panels/tags.html' %}
-    </div>
-    <div class="col col-md-6">
+
       <div class="card">
         <h2 class="card-header">Details</h2>
         <table class="table table-hover attr-table">
@@ -62,6 +59,11 @@
           </tr>
         </table>
       </div>
+    </div>
+    <div class="col col-md-6">
+      {% include 'inc/panels/custom_fields.html' %}
+      {% include 'inc/panels/tags.html' %}
+      {% include 'inc/panels/comments.html' %}
     </div>
   </div>
 {% endblock content %}

--- a/netbox_acls/templates/netbox_acls/aclstandardrule.html
+++ b/netbox_acls/templates/netbox_acls/aclstandardrule.html
@@ -25,10 +25,6 @@
           </tr>
         </table>
       </div>
-      {% include 'inc/panels/custom_fields.html' %}
-      {% include 'inc/panels/tags.html' %}
-    </div>
-    <div class="col col-md-6">
       <div class="card">
         <h2 class="card-header">Details</h2>
         <table class="table table-hover attr-table">
@@ -46,6 +42,11 @@
           </tr>
         </table>
       </div>
+    </div>
+    <div class="col col-md-6">
+      {% include 'inc/panels/custom_fields.html' %}
+      {% include 'inc/panels/comments.html' %}
+      {% include 'inc/panels/tags.html' %}
     </div>
   </div>
 {% endblock content %}

--- a/netbox_acls/views.py
+++ b/netbox_acls/views.py
@@ -124,7 +124,7 @@ class AccessListListView(generic.ObjectListView):
 
     queryset = models.AccessList.objects.annotate(
         rule_count=Count("aclextendedrules") + Count("aclstandardrules"),
-    ).prefetch_related("tags")
+    ).prefetch_related("owner", "tags")
     table = tables.AccessListTable
     filterset = filtersets.AccessListFilterSet
     filterset_form = forms.AccessListFilterForm
@@ -138,7 +138,7 @@ class AccessListEditView(generic.ObjectEditView):
     Defines the edit view for the AccessLists django model.
     """
 
-    queryset = models.AccessList.objects.prefetch_related("tags")
+    queryset = models.AccessList.objects.prefetch_related("owner", "tags")
     form = forms.AccessListForm
 
 
@@ -148,12 +148,12 @@ class AccessListDeleteView(generic.ObjectDeleteView):
     Defines delete view for the AccessLists django model.
     """
 
-    queryset = models.AccessList.objects.prefetch_related("tags")
+    queryset = models.AccessList.objects.prefetch_related("owner", "tags")
 
 
 @register_model_view(models.AccessList, "bulk_delete", path="delete", detail=False)
 class AccessListBulkDeleteView(generic.BulkDeleteView):
-    queryset = models.AccessList.objects.prefetch_related("tags")
+    queryset = models.AccessList.objects.prefetch_related("owner", "tags")
     filterset = filtersets.AccessListFilterSet
     table = tables.AccessListTable
 
@@ -204,6 +204,7 @@ class ACLAssignmentView(generic.ObjectView):
 
     queryset = models.ACLAssignment.objects.prefetch_related(
         "access_list",
+        "owner",
         "tags",
     )
 
@@ -216,6 +217,7 @@ class ACLAssignmentListView(generic.ObjectListView):
 
     queryset = models.ACLAssignment.objects.prefetch_related(
         "access_list",
+        "owner",
         "tags",
     )
     table = tables.ACLAssignmentTable
@@ -233,6 +235,7 @@ class ACLAssignmentEditView(generic.ObjectEditView):
 
     queryset = models.ACLAssignment.objects.prefetch_related(
         "access_list",
+        "owner",
         "tags",
     )
     form = forms.ACLAssignmentForm
@@ -256,6 +259,7 @@ class ACLAssignmentDeleteView(generic.ObjectDeleteView):
 
     queryset = models.ACLAssignment.objects.prefetch_related(
         "access_list",
+        "owner",
         "tags",
     )
 
@@ -264,6 +268,7 @@ class ACLAssignmentDeleteView(generic.ObjectDeleteView):
 class ACLAssignmentBulkDeleteView(generic.BulkDeleteView):
     queryset = models.ACLAssignment.objects.prefetch_related(
         "access_list",
+        "owner",
         "tags",
     )
     filterset = filtersets.ACLAssignmentFilterSet
@@ -325,7 +330,7 @@ class InterfaceACLAssignmentView(ACLAssignmentChildrenView):
 @register_model_view(VirtualChassis, "aclassignments", path="access-lists")
 class VirtualChassisACLAssignmentView(ACLAssignmentChildrenView):
     """
-    Children view of ACL Assignment of VirtualChassiss.
+    Children view of ACL Assignment of VirtualChassis.
     """
 
     queryset = VirtualChassis.objects.all()
@@ -415,6 +420,7 @@ class ACLStandardRuleView(generic.ObjectView):
     queryset = models.ACLStandardRule.objects.prefetch_related(
         "access_list",
         "source",
+        "owner",
         "tags",
     )
 
@@ -428,6 +434,7 @@ class ACLStandardRuleListView(generic.ObjectListView):
     queryset = models.ACLStandardRule.objects.prefetch_related(
         "access_list",
         "source",
+        "owner",
         "tags",
     )
     table = tables.ACLStandardRuleTable
@@ -446,6 +453,7 @@ class ACLStandardRuleEditView(generic.ObjectEditView):
     queryset = models.ACLStandardRule.objects.prefetch_related(
         "access_list",
         "source",
+        "owner",
         "tags",
     )
     form = forms.ACLStandardRuleForm
@@ -469,6 +477,7 @@ class ACLStandardRuleDeleteView(generic.ObjectDeleteView):
     queryset = models.ACLStandardRule.objects.prefetch_related(
         "access_list",
         "source",
+        "owner",
         "tags",
     )
 
@@ -478,6 +487,7 @@ class ACLStandardRuleBulkDeleteView(generic.BulkDeleteView):
     queryset = models.ACLStandardRule.objects.prefetch_related(
         "access_list",
         "source",
+        "owner",
         "tags",
     )
     filterset = filtersets.ACLStandardRuleFilterSet
@@ -499,6 +509,7 @@ class ACLExtendedRuleView(generic.ObjectView):
         "access_list",
         "source",
         "destination",
+        "owner",
         "tags",
     )
 
@@ -513,6 +524,7 @@ class ACLExtendedRuleListView(generic.ObjectListView):
         "access_list",
         "source",
         "destination",
+        "owner",
         "tags",
     )
     table = tables.ACLExtendedRuleTable
@@ -532,6 +544,7 @@ class ACLExtendedRuleEditView(generic.ObjectEditView):
         "access_list",
         "source",
         "destination",
+        "owner",
         "tags",
     )
     form = forms.ACLExtendedRuleForm
@@ -556,6 +569,7 @@ class ACLExtendedRuleDeleteView(generic.ObjectDeleteView):
         "access_list",
         "source",
         "destination",
+        "owner",
         "tags",
     )
 
@@ -566,6 +580,7 @@ class ACLExtendedRuleBulkDeleteView(generic.BulkDeleteView):
         "access_list",
         "source",
         "destination",
+        "owner",
         "tags",
     )
     filterset = filtersets.ACLExtendedRuleFilterSet


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #305

## New Behavior

This PR adds native owner support to ACL objects. `AccessList` and `ACLRule` now use `PrimaryModel`, `ACLAssignment` gains owner support as an intermediate object, and the owner field is exposed consistently in the UI, filters, tables, REST API, and GraphQL. As part of that alignment, `AccessList` gains a `description` field and ACL rules gain `comments`.

## Contrast to Current Behavior

Today ACL objects do not support NetBox’s native ownership model, so ownership cannot be tracked or queried directly. `AccessList` and `ACLRule` were also not aligned with NetBox’s primary object pattern, which meant some standard metadata fields and related UI/API support were missing.

## Discussion: Benefits and Drawbacks

I think this makes the plugin feel more natural within current NetBox and gives users a clearer way to record responsibility for ACL objects without relying on tags or custom fields. It also reduces some plugin-specific boilerplate by using the standard `PrimaryModel` / `PrimaryModel*` helpers where they fit, while keeping `ACLAssignment` as a non-primary/intermediate model. The main trade-off is that `AccessList` and `ACLRule` now expose the usual NetBox metadata fields more broadly, so API and GraphQL consumers will see additional fields. Overall, the change is additive and includes the required migrations.

## Changes to the Documentation

No dedicated documentation changes are included in this PR. The user-facing impact is mainly the new native ownership support and the related metadata fields, so I think a release note entry should be sufficient.

## Proposed Release Note Entry

Added native owner support for ACL objects and aligned `AccessList` and ACL rules with NetBox primary object behavior across the UI, filters, REST API, and GraphQL.

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.