### PR TITLE
Closes #321: Improve API schema generation for extended rule port terms

### DIFF
--- a/netbox_acls/api/serializers.py
+++ b/netbox_acls/api/serializers.py
@@ -5,6 +5,7 @@ while Django itself handles the database abstraction.
 
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import gettext_lazy as _
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from netbox.api.fields import ContentTypeField, IntegerRangeSerializer
@@ -306,12 +307,14 @@ class ACLExtendedRuleSerializer(PrimaryModelSerializer):
             "sequence",
         )
 
+    @extend_schema_field({"type": "array", "items": {"type": "string"}})
     def get_destination_port_terms(self, obj):
         """
         Fetches the destination port terms for the given object.
         """
         return obj.destination_port_ranges_list
 
+    @extend_schema_field({"type": "array", "items": {"type": "string"}})
     def get_source_port_terms(self, obj):
         """
         Fetches the source port terms for the given object.


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #321


## New Behavior

This PR adds explicit schema information for `get_source_port_terms()` and `get_destination_port_terms()` in `ACLExtendedRuleSerializer`.

With this change, the generated API schema reflects these fields more accurately and the Swagger warnings are resolved.

## Contrast to Current Behavior

Currently, the schema generator cannot resolve the return type of these serializer methods and falls back to `string`, which produces warnings during schema generation.

After this change, the field type is declared explicitly, so the schema output is clearer and no longer relies on the fallback behavior.

## Discussion: Benefits and Drawbacks

This is a small housekeeping improvement that helps keep the API schema clean and easier to understand for contributors and API consumers.

The change is backwards-compatible and does not affect runtime behavior. The main drawback is only a small amount of additional serializer annotation, which should be easy to maintain.

## Changes to the Documentation

No user-facing documentation changes are required for this update.

## Proposed Release Note Entry

Improved API schema generation for ACL extended rule port term fields by adding explicit schema hints and resolving Swagger warnings.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `dev` branch.