### PR TITLE
Closes #304: Automatically suggest the next ACL rule sequence when creating rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ PLUGINS = [
 
 PLUGINS_CONFIG = {
     "netbox_acls": {
-        "top_level_menu": True # If set to True the plugin will add a top level menu item for the plugin. If set to False the plugin will add a menu item under the Plugins menu item.  Default is set to True.
+        # Display the plugin in the top-level menu (True) or under the Plugins menu (False)
+        "top_level_menu": True,
+        # Sequence number increment for new ACL rules (e.g., 10, 20, 30...)
+        "rule_sequence_step": 10,
     },
 }
 ```

--- a/configuration/plugins.py
+++ b/configuration/plugins.py
@@ -9,5 +9,8 @@ PLUGINS = [
 ]
 
 PLUGINS_CONFIG = {  # type: ignore
-    "netbox_acls": {},
+    "netbox_acls": {
+        "top_level_menu": True,
+        "rule_sequence_step": 10,
+    },
 }

--- a/netbox_acls/__init__.py
+++ b/netbox_acls/__init__.py
@@ -1,24 +1,29 @@
 """
-Define the NetBox Plugin
+NetBox ACLs Plugin - Manage Access Control Lists in NetBox.
 """
 
-import importlib.metadata
+from importlib.metadata import version
 
 from netbox.plugins import PluginConfig
+
+__all__ = ("NetBoxACLsConfig",)
 
 
 class NetBoxACLsConfig(PluginConfig):
     """
-    Plugin specifc configuration
+    NetBox plugin configuration for Access Control Lists management.
     """
 
     name = "netbox_acls"
     verbose_name = "Access Lists"
-    version = importlib.metadata.version("netbox-acls")
-    description = "Manage simple ACLs in NetBox"
+    version = version("netbox-acls")
+    description = "Manage Access Control Lists (ACL) in NetBox"
     base_url = "access-lists"
     min_version = "4.5.0"
     max_version = "4.5.99"
+    default_settings = {
+        "rule_sequence_step": 10,
+    }
 
 
 config = NetBoxACLsConfig

--- a/netbox_acls/models/__init__.py
+++ b/netbox_acls/models/__init__.py
@@ -5,3 +5,4 @@ Import each of the directory's scripts.
 
 from .access_list_rules import *
 from .access_lists import *
+from .managers import *

--- a/netbox_acls/models/access_list_rules.py
+++ b/netbox_acls/models/access_list_rules.py
@@ -23,6 +23,7 @@ from ..constants import ACL_RULE_SOURCE_DESTINATION_MODELS
 from ..utils import infer_family_from_object, normalize_port_ranges
 from ..validators import validate_port_ranges
 from .access_lists import AccessList
+from .managers import ACLRuleManager
 
 __all__ = (
     "ACLExtendedRule",
@@ -146,6 +147,8 @@ class ACLRule(PrimaryModel):
         null=True,
     )
 
+    objects = ACLRuleManager()
+
     clone_fields = (
         "access_list",
         "action",
@@ -202,6 +205,18 @@ class ACLRule(PrimaryModel):
         # Validate rule family
         self._validate_rule_family()
 
+    def clone(self):
+        """
+        Creates a clone of the current ACL rule instance.
+        """
+        attrs = super().clone()
+
+        # Use the next sequence for clone / create-and-add-another
+        if self.access_list_id:
+            attrs["sequence"] = self.__class__.objects.get_next_sequence(self.access_list_id)
+
+        return attrs
+
     def save(self, *args, **kwargs):
         """
         Saves the current instance to the database.
@@ -230,6 +245,9 @@ class ACLRule(PrimaryModel):
     cache_related_source_object.alters_data = True
 
     def _validate_rule_family(self):
+        """
+        Validates that the ACL rule's family matches the source and destination families.
+        """
         acl_family = self.access_list.family
         families = set()
 
@@ -262,6 +280,9 @@ class ACLRule(PrimaryModel):
         return ACLRuleActionChoices.colors.get(self.action)
 
     def to_objectchange(self, action):
+        """
+        Creates an ObjectChange instance for the ACL rule.
+        """
         objectchange = super().to_objectchange(action)
         objectchange.related_object = self.access_list
         return objectchange

--- a/netbox_acls/models/managers.py
+++ b/netbox_acls/models/managers.py
@@ -4,9 +4,13 @@ Define custom model managers for this plugin.
 
 from django.db import models
 
+from netbox.plugins.utils import get_plugin_config
 from utilities.querysets import RestrictedQuerySet
 
 __all__ = ("ACLRuleManager",)
+
+# Plugin name constant to avoid circular imports
+PLUGIN_NAME = "netbox_acls"
 
 
 class ACLRuleManager(models.Manager.from_queryset(RestrictedQuerySet)):
@@ -14,17 +18,21 @@ class ACLRuleManager(models.Manager.from_queryset(RestrictedQuerySet)):
     Custom manager for ACL rules providing utility methods.
     """
 
-    def get_next_sequence(self, access_list_id: int, step: int = 10) -> int:
+    def get_next_sequence(self, access_list_id: int, step: int | None = None) -> int:
         """
         Return the next available sequence number for a new rule in the given access list.
 
         Args:
             access_list_id: The ID of the access list to query.
-            step: Increment between sequence numbers (default: 10).
+            step: Increment between sequence numbers. If None, uses plugin config
+                  `rule_sequence_step` (default: 10).
 
         Returns:
             The next sequence number (first rule gets `step`, later rules get `max + step`).
         """
+        if step is None or step <= 0:
+            step = get_plugin_config(PLUGIN_NAME, "rule_sequence_step", 10)
+
         max_sequence = (
             self.filter(access_list_id=access_list_id).aggregate(max_seq=models.Max("sequence")).get("max_seq")
         )

--- a/netbox_acls/models/managers.py
+++ b/netbox_acls/models/managers.py
@@ -1,0 +1,31 @@
+"""
+Define custom model managers for this plugin.
+"""
+
+from django.db import models
+
+from utilities.querysets import RestrictedQuerySet
+
+__all__ = ("ACLRuleManager",)
+
+
+class ACLRuleManager(models.Manager.from_queryset(RestrictedQuerySet)):
+    """
+    Custom manager for ACL rules providing utility methods.
+    """
+
+    def get_next_sequence(self, access_list_id: int, step: int = 10) -> int:
+        """
+        Return the next available sequence number for a new rule in the given access list.
+
+        Args:
+            access_list_id: The ID of the access list to query.
+            step: Increment between sequence numbers (default: 10).
+
+        Returns:
+            The next sequence number (first rule gets `step`, later rules get `max + step`).
+        """
+        max_sequence = (
+            self.filter(access_list_id=access_list_id).aggregate(max_seq=models.Max("sequence")).get("max_seq")
+        )
+        return step if max_sequence is None else max_sequence + step

--- a/netbox_acls/tests/models/test_managers.py
+++ b/netbox_acls/tests/models/test_managers.py
@@ -1,0 +1,141 @@
+"""
+Tests for ACLRuleManager.
+"""
+
+from django.test import TestCase, override_settings
+
+from ...choices import ACLFamilyChoices, ACLTypeChoices
+from ...models import AccessList, ACLStandardRule
+
+
+class TestACLRuleManager(TestCase):
+    """
+    Test ACLRuleManager methods.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """
+        Create base data for testing the ACLRuleManager.
+        """
+        cls.access_list = AccessList.objects.create(
+            name="TEST_ACL",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action="deny",
+        )
+
+    def test_get_next_sequence_empty_access_list(self):
+        """
+        Test that get_next_sequence returns the step value for an empty access list.
+        """
+        # The default step is 10
+        next_seq = ACLStandardRule.objects.get_next_sequence(self.access_list.pk)
+        self.assertEqual(next_seq, 10)
+
+    def test_get_next_sequence_with_existing_rules(self):
+        """
+        Test that get_next_sequence returns max_sequence + step when rules exist.
+        """
+        # Create a rule with sequence 10
+        ACLStandardRule.objects.create(
+            access_list=self.access_list,
+            sequence=10,
+            action="permit",
+        )
+
+        next_seq = ACLStandardRule.objects.get_next_sequence(self.access_list.pk)
+        self.assertEqual(next_seq, 20)
+
+    def test_get_next_sequence_with_custom_step(self):
+        """
+        Test that get_next_sequence respects a custom step parameter.
+        """
+        next_seq = ACLStandardRule.objects.get_next_sequence(self.access_list.pk, step=5)
+        self.assertEqual(next_seq, 5)
+
+        # Create a rule and verify the custom step is applied to existing max
+        ACLStandardRule.objects.create(
+            access_list=self.access_list,
+            sequence=5,
+            action="permit",
+        )
+
+        next_seq = ACLStandardRule.objects.get_next_sequence(self.access_list.pk, step=5)
+        self.assertEqual(next_seq, 10)
+
+    def test_get_next_sequence_with_non_sequential_rules(self):
+        """
+        Test that get_next_sequence finds the max sequence regardless of order.
+        """
+        # Create rules with non-sequential sequences
+        ACLStandardRule.objects.create(
+            access_list=self.access_list,
+            sequence=100,
+            action="permit",
+        )
+        ACLStandardRule.objects.create(
+            access_list=self.access_list,
+            sequence=50,
+            action="deny",
+        )
+
+        next_seq = ACLStandardRule.objects.get_next_sequence(self.access_list.pk)
+        self.assertEqual(next_seq, 110)  # max(100, 50) + 10
+
+    def test_get_next_sequence_zero_step_uses_config(self):
+        """
+        Test that a step <= 0 falls back to plugin config.
+        """
+        next_seq = ACLStandardRule.objects.get_next_sequence(self.access_list.pk, step=0)
+        self.assertEqual(next_seq, 10)  # Should use default config value
+
+        next_seq = ACLStandardRule.objects.get_next_sequence(self.access_list.pk, step=-5)
+        self.assertEqual(next_seq, 10)  # Should use default config value
+
+    def test_get_next_sequence_none_step_uses_config(self):
+        """
+        Test that step=None falls back to plugin config.
+        """
+        next_seq = ACLStandardRule.objects.get_next_sequence(self.access_list.pk, step=None)
+        self.assertEqual(next_seq, 10)
+
+    def test_get_next_sequence_isolates_access_lists(self):
+        """
+        Test that get_next_sequence only considers rules from the specified access list.
+        """
+        other_acl = AccessList.objects.create(
+            name="OTHER_ACL",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action="deny",
+        )
+
+        # Create a rule in the other ACL with a high sequence
+        ACLStandardRule.objects.create(
+            access_list=other_acl,
+            sequence=1000,
+            action="permit",
+        )
+
+        # Original ACL should still return step value (empty)
+        next_seq = ACLStandardRule.objects.get_next_sequence(self.access_list.pk)
+        self.assertEqual(next_seq, 10)
+
+    @override_settings(PLUGINS_CONFIG={"netbox_acls": {"rule_sequence_step": 25}})
+    def test_get_next_sequence_respects_plugin_config(self):
+        """
+        Test that get_next_sequence uses the configured rule_sequence_step.
+        """
+        next_seq = ACLStandardRule.objects.get_next_sequence(self.access_list.pk)
+        self.assertEqual(next_seq, 25)
+
+        # Create a rule and verify the config step is applied
+        ACLStandardRule.objects.create(
+            access_list=self.access_list,
+            sequence=25,
+            action="permit",
+        )
+
+        next_seq = ACLStandardRule.objects.get_next_sequence(self.access_list.pk)
+        self.assertEqual(next_seq, 50)

--- a/netbox_acls/views.py
+++ b/netbox_acls/views.py
@@ -38,6 +38,31 @@ __all__ = (
     "AccessListView",
 )
 
+
+class ACLRuleSequenceMixin:
+    """
+    Mixin that auto-assigns the next available sequence number to new ACL rules.
+
+    Used with ObjectEditView to pre-populate the sequence field when creating
+    rules via the "Add" form (not clone/add-another, which preserves sequence).
+    """
+
+    def alter_object(self, obj, request, url_args, url_kwargs):
+        obj = super().alter_object(obj, request, url_args, url_kwargs)
+
+        # Skip if editing an existing object or sequence already provided (clone/add-another)
+        if obj.pk or "sequence" in request.GET:
+            return obj
+
+        # Parse access_list ID; bail out gracefully if missing/invalid
+        access_list_id = request.GET.get("access_list")
+        if not access_list_id or not access_list_id.isdigit():
+            return obj
+
+        obj.sequence = obj.__class__.objects.get_next_sequence(int(access_list_id))
+        return obj
+
+
 #
 # Base children views
 #
@@ -435,7 +460,7 @@ class ACLStandardRuleListView(generic.ObjectListView):
 
 @register_model_view(models.ACLStandardRule, "add", detail=False)
 @register_model_view(models.ACLStandardRule, "edit")
-class ACLStandardRuleEditView(generic.ObjectEditView):
+class ACLStandardRuleEditView(ACLRuleSequenceMixin, generic.ObjectEditView):
     """
     Defines the edit view for the ACLStandardRule django model.
     """
@@ -516,7 +541,7 @@ class ACLExtendedRuleListView(generic.ObjectListView):
 
 @register_model_view(models.ACLExtendedRule, "add", detail=False)
 @register_model_view(models.ACLExtendedRule, "edit")
-class ACLExtendedRuleEditView(generic.ObjectEditView):
+class ACLExtendedRuleEditView(ACLRuleSequenceMixin, generic.ObjectEditView):
     """
     Defines the edit view for the ACLExtendedRule django model.
     """


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #304


## New Behavior

When creating a new ACL rule, the sequence field is now prefilled with the next suggested value for the same access list. The suggestion is calculated from the highest existing sequence plus a configurable step, which defaults to `10`.

This applies when opening the add form from an access list and when using “create and add another”. The same sequence logic is also reused when cloning a rule.


## Contrast to Current Behavior

Previously, the sequence had to be entered manually for each new rule. This made repeated rule creation more tedious and increased the chance of inconsistent numbering.

With this change, a sensible next sequence is suggested automatically while still allowing users to adjust it when needed.


## Discussion: Benefits and Drawbacks

This improves day-to-day usability when documenting ACLs, especially in environments where rules are commonly numbered in steps of 10. It reduces repetitive input and helps keep rule numbering consistent.

The change is backwards-compatible, since users can still override the suggested value manually. The main behavioral difference is that the create form no longer starts with an empty sequence field in these workflows.

To keep the behavior flexible, the increment is configurable through the new `rule_sequence_step` plugin setting, with a default of `10`. The sequence calculation is also covered by tests for empty access lists, custom steps, non-sequential rules, access list isolation, and plugin configuration integration.


## Changes to the Documentation

The README was updated to document the new `rule_sequence_step` plugin setting and its default behavior.


## Proposed Release Note Entry

Added automatic ACL rule sequence suggestions for new rules based on the highest existing sequence, with a configurable step size (default: `10`).


## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.