### PR TITLE
Closes #327: Add BulkEdit support for all ACL models

### DIFF
--- a/netbox_acls/forms/__init__.py
+++ b/netbox_acls/forms/__init__.py
@@ -1,17 +1,7 @@
-# flake8: noqa
 """
 Import each of the directory's scripts.
 """
 
-# from .bulk_create import *
-# from .bulk_edit import *
-
-# from .bulk_import import *
-# from .connections import *
+from .bulk_edit import *
 from .filtersets import *
-
-# from .formsets import *
 from .models import *
-
-# from .object_create import *
-# from .object_import import *

--- a/netbox_acls/forms/bulk_edit.py
+++ b/netbox_acls/forms/bulk_edit.py
@@ -2,92 +2,393 @@
 Draft for a possible BulkEditForm, but may not be worth wile.
 """
 
-# from django import forms
-# from django.utils.safestring import mark_safe
-#
-# from dcim.models import Device, Region, Site, SiteGroup
-# from netbox.forms import NetBoxModelBulkEditForm
-# from utilities.forms.fields import ChoiceField, DynamicModelChoiceField, StaticSelect
-# from utilities.forms.utils import add_blank_choice
-#
-# from ..choices import ACLActionChoices, ACLTypeChoices
-# from ..models import AccessList
-#
-# __all__ = ("AccessListBulkEditForm",)
-#
-#
-# class AccessListBulkEditForm(NetBoxModelBulkEditForm):
-#     model = AccessList
-#     region = DynamicModelChoiceField(
-#         queryset=Region.objects.all(),
-#         required=False,
-#     )
-#     site_group = DynamicModelChoiceField(
-#         queryset=SiteGroup.objects.all(),
-#         required=False,
-#         label="Site Group",
-#     )
-#     site = DynamicModelChoiceField(
-#         queryset=Site.objects.all(),
-#         required=False,
-#     )
-#     device = DynamicModelChoiceField(
-#         queryset=Device.objects.all(),
-#         query_params={
-#             "region": "$region",
-#             "group_id": "$site_group",
-#             "site_id": "$site",
-#         },
-#         required=False,
-#     )
-#     type = ChoiceField(
-#         choices=add_blank_choice(ACLTypeChoices),
-#         required=False,
-#         widget=StaticSelect(),
-#     )
-#     default_action = ChoiceField(
-#         choices=add_blank_choice(ACLActionChoices),
-#         required=False,
-#         widget=StaticSelect(),
-#         label="Default Action",
-#     )
-#     fieldsets = [
-#         ("Host Details", ("region", "site_group", "site", "device")),
-#         ("Access List Details", ("type", "default_action", "add_tags", "remove_tags")),
-#     ]
-#
-#     class Meta:
-#         model = AccessList
-#         fields = ("region", "site_group", "site", "device", "type", "default_action", "add_tags", "remove_tags")
-#         help_texts = {
-#             "default_action": "The default behavior of the ACL.",
-#             "name": "The name uniqueness per device is case insensitive.",
-#             "type": mark_safe("<b>*Note:</b> CANNOT be changed if ACL Rules are assoicated to this Access List."),
-#         }
-#
-#     def clean(self):  # Not working given you are bulk editing multiple forms
-#         cleaned_data = super().clean()
-#         if self.errors.get("name"):
-#             return cleaned_data
-#         name = cleaned_data.get("name")
-#         device = cleaned_data.get("device")
-#         acl_type = cleaned_data.get("type")
-#
-#         if ("name" in self.changed_data or "device" in self.changed_data) and AccessList.objects.filter(
-#             name__iexact=name, device=device
-#         ).exists():
-#             raise forms.ValidationError(
-#                 "An ACL with this name (case insensitive) is already associated to this device."
-#             )
-#
-#         if acl_type == "extended" and self.cleaned_data["aclstandardrules"].exists():
-#             raise forms.ValidationError(
-#                 "This ACL has Standard ACL rules already associated, CANNOT change ACL type!!"
-#             )
-#
-#         if acl_type == "standard" and self.cleaned_data["aclextendedrules"].exists():
-#             raise forms.ValidationError(
-#                 "This ACL has Extended ACL rules already associated, CANNOT change ACL type!!"
-#             )
-#
-#         return cleaned_data
+from django import forms
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
+from django.utils.translation import gettext_lazy as _
+
+from dcim.models import Device, Interface
+from ipam.models import Prefix
+from netbox.forms import NetBoxModelBulkEditForm, PrimaryModelBulkEditForm
+from netbox.forms.mixins import OwnerMixin
+from utilities.forms.fields import CommentField, ContentTypeChoiceField, DynamicModelChoiceField, NumericRangeArrayField
+from utilities.forms.rendering import FieldSet
+from utilities.forms.utils import add_blank_choice, get_field_value
+from utilities.forms.widgets import HTMXSelect
+from utilities.templatetags.builtins.filters import bettertitle
+from virtualization.models import VMInterface
+
+from ..choices import (
+    ACLActionChoices,
+    ACLAssignmentDirectionUIChoices,
+    ACLFamilyChoices,
+    ACLProtocolChoices,
+    ACLRuleActionChoices,
+    ACLTypeChoices,
+)
+from ..constants import ACL_ASSIGNMENT_MODELS, ACL_RULE_SOURCE_DESTINATION_MODELS
+from ..models import AccessList, ACLAssignment, ACLExtendedRule, ACLStandardRule
+
+__all__ = (
+    "ACLAssignmentBulkEditForm",
+    "ACLExtendedRuleBulkEditForm",
+    "ACLStandardRuleBulkEditForm",
+    "AccessListBulkEditForm",
+)
+
+
+class AccessListBulkEditForm(PrimaryModelBulkEditForm):
+    """
+    Form for bulk editing multiple AccessList instances.
+    """
+
+    type = forms.ChoiceField(
+        choices=add_blank_choice(ACLTypeChoices),
+        required=False,
+        label=_("Type"),
+    )
+    family = forms.ChoiceField(
+        choices=add_blank_choice(ACLFamilyChoices),
+        required=False,
+        label=_("Family"),
+    )
+    default_action = forms.ChoiceField(
+        choices=add_blank_choice(ACLActionChoices),
+        required=False,
+        label=_("Default Action"),
+    )
+
+    model = AccessList
+    fieldsets = (
+        FieldSet(
+            "name",
+            "type",
+            "family",
+            "default_action",
+            "description",
+            name=_("Access List Details"),
+        ),
+    )
+    nullable_fields = (
+        "description",
+        "comments",
+    )
+
+
+class ACLAssignmentBulkEditForm(OwnerMixin, NetBoxModelBulkEditForm):
+    """
+    Form for bulk editing multiple ACLStandardRule instances.
+    """
+
+    access_list = DynamicModelChoiceField(
+        queryset=AccessList.objects.all(),
+        required=False,
+        label=_("Access List"),
+    )
+
+    assigned_object_type = ContentTypeChoiceField(
+        queryset=ContentType.objects.filter(ACL_ASSIGNMENT_MODELS),
+        required=False,
+        widget=HTMXSelect(method="post", attrs={"hx-select": "#form_fields"}),
+        label=_("Assignment Type"),
+    )
+    assigned_object = DynamicModelChoiceField(
+        queryset=Device.objects.none(),  # Initial queryset
+        selector=True,
+        required=False,
+        label=_("Assignment Object"),
+        disabled=True,
+    )
+    direction = forms.ChoiceField(
+        choices=add_blank_choice(ACLAssignmentDirectionUIChoices),
+        required=False,
+        label=_("Direction"),
+    )
+    comments = CommentField()
+
+    model = ACLAssignment
+    fieldsets = (
+        FieldSet(
+            "access_list",
+            name=_("Access List Details"),
+        ),
+        FieldSet(
+            "assigned_object_type",
+            "assigned_object",
+            "direction",
+            name=_("Assignment"),
+        ),
+    )
+    nullable_fields = ("comments",)
+
+    def __init__(self, *args, **kwargs) -> None:
+        """
+        Initialize the ACLStandardRuleForm.
+        """
+        super().__init__(*args, **kwargs)
+
+        if assigned_object_type_id := get_field_value(self, "assigned_object_type"):
+            try:
+                # Retrieve the ContentType model class based on the assigned object type
+                assigned_object_type = ContentType.objects.get(pk=assigned_object_type_id)
+                assigned_object_model = assigned_object_type.model_class()
+
+                # Configure the queryset and label for the assigned_object field
+                self.fields["assigned_object"].queryset = assigned_object_model.objects.all()
+                self.fields["assigned_object"].widget.attrs["selector"] = assigned_object_model._meta.label_lower
+                self.fields["assigned_object"].disabled = False
+                self.fields["assigned_object"].label = _(bettertitle(assigned_object_model._meta.verbose_name))
+                if assigned_object_model in (Interface, VMInterface):
+                    self.fields["direction"].disabled = False
+                    self.fields["direction"].choices = add_blank_choice(ACLAssignmentDirectionUIChoices)
+                else:
+                    self.fields["direction"].disabled = True
+                    self.fields["direction"].widget.attrs["value"] = "None"
+            except ObjectDoesNotExist:
+                pass
+
+
+class ACLStandardRuleBulkEditForm(PrimaryModelBulkEditForm):
+    """
+    Form for bulk editing multiple ACLStandardRule instances.
+    """
+
+    access_list = DynamicModelChoiceField(
+        queryset=AccessList.objects.all(),
+        query_params={
+            "type": ACLTypeChoices.TYPE_STANDARD,
+        },
+        required=False,
+        label=_("Access List"),
+    )
+
+    # Rule
+    action = forms.ChoiceField(
+        choices=add_blank_choice(ACLRuleActionChoices),
+        required=False,
+        label=_("Action"),
+    )
+
+    # Remark
+    remark = forms.CharField(
+        max_length=500,
+        required=False,
+        label=_("Remark"),
+    )
+
+    # Source
+    source_type = ContentTypeChoiceField(
+        queryset=ContentType.objects.filter(ACL_RULE_SOURCE_DESTINATION_MODELS),
+        required=False,
+        widget=HTMXSelect(method="post", attrs={"hx-select": "#form_fields"}),
+        label=_("Source Type"),
+    )
+    source = DynamicModelChoiceField(
+        queryset=Prefix.objects.none(),  # Initial queryset
+        selector=True,
+        required=False,
+        label=_("Source"),
+        disabled=True,
+    )
+
+    model = ACLStandardRule
+    fieldsets = (
+        FieldSet(
+            "access_list",
+            "description",
+            name=_("Access List Details"),
+        ),
+        FieldSet(
+            "action",
+            name=_("Rule Definition"),
+        ),
+        FieldSet(
+            "remark",
+            name=_("Remark"),
+        ),
+        FieldSet(
+            "source_type",
+            "source",
+            name=_("Source Definition"),
+        ),
+    )
+    nullable_fields = (
+        "remark",
+        "source_type",
+        "source",
+        "description",
+        "comments",
+    )
+
+    def __init__(self, *args, **kwargs) -> None:
+        """
+        Initialize the ACLStandardRuleForm.
+        """
+        super().__init__(*args, **kwargs)
+
+        if source_type_id := get_field_value(self, "source_type"):
+            try:
+                # Retrieve the ContentType model class based on the source type
+                source_type = ContentType.objects.get(pk=source_type_id)
+                source_model = source_type.model_class()
+
+                # Configure the queryset and label for the source field
+                self.fields["source"].queryset = source_model.objects.all()
+                self.fields["source"].widget.attrs["selector"] = source_model._meta.label_lower
+                self.fields["source"].disabled = False
+                self.fields["source"].label = _("Source " + bettertitle(source_model._meta.verbose_name))
+            except ObjectDoesNotExist:
+                pass
+
+
+class ACLExtendedRuleBulkEditForm(PrimaryModelBulkEditForm):
+    """
+    Form for bulk editing multiple ACLExtendedRule instances.
+    """
+
+    access_list = DynamicModelChoiceField(
+        queryset=AccessList.objects.all(),
+        query_params={
+            "type": ACLTypeChoices.TYPE_STANDARD,
+        },
+        required=False,
+        label=_("Access List"),
+    )
+
+    # Rule
+    action = forms.ChoiceField(
+        choices=add_blank_choice(ACLRuleActionChoices),
+        required=False,
+        label=_("Action"),
+    )
+
+    # Remark
+    remark = forms.CharField(
+        max_length=500,
+        required=False,
+        label=_("Remark"),
+    )
+
+    # Protocol
+    protocol = forms.ChoiceField(
+        choices=add_blank_choice(ACLProtocolChoices),
+        required=False,
+        label=_("Protocol"),
+    )
+
+    # Source
+    source_type = ContentTypeChoiceField(
+        queryset=ContentType.objects.filter(ACL_RULE_SOURCE_DESTINATION_MODELS),
+        required=False,
+        widget=HTMXSelect(method="post", attrs={"hx-select": "#form_fields"}),
+        label=_("Source Type"),
+    )
+    source = DynamicModelChoiceField(
+        queryset=Prefix.objects.none(),  # Initial queryset
+        selector=True,
+        required=False,
+        label=_("Source"),
+        disabled=True,
+    )
+    source_port_ranges = NumericRangeArrayField(
+        required=False,
+        label=_("Source Port Ranges"),
+    )
+
+    # Destination
+    destination_type = ContentTypeChoiceField(
+        queryset=ContentType.objects.filter(ACL_RULE_SOURCE_DESTINATION_MODELS),
+        required=False,
+        widget=HTMXSelect(method="post", attrs={"hx-select": "#form_fields"}),
+        label=_("Destination Type"),
+    )
+    destination = DynamicModelChoiceField(
+        queryset=Prefix.objects.none(),  # Initial queryset
+        selector=True,
+        required=False,
+        label=_("Destination"),
+        disabled=True,
+    )
+    destination_port_ranges = NumericRangeArrayField(
+        required=False,
+        label=_("Destination Port Ranges"),
+    )
+
+    model = ACLExtendedRule
+    fieldsets = (
+        FieldSet(
+            "access_list",
+            "description",
+            name=_("Access List Details"),
+        ),
+        FieldSet(
+            "sequence",
+            "action",
+            name=_("Rule Definition"),
+        ),
+        FieldSet(
+            "remark",
+            name=_("Remark"),
+        ),
+        FieldSet(
+            "protocol",
+            name=_("Protocol"),
+        ),
+        FieldSet(
+            "source_type",
+            "source",
+            "source_port_ranges",
+            name=_("Source Definition"),
+        ),
+        FieldSet(
+            "destination_type",
+            "destination",
+            "destination_port_ranges",
+            name=_("Destination Definition"),
+        ),
+    )
+    nullable_fields = (
+        "remark",
+        "source_type",
+        "source",
+        "destination_type",
+        "destination",
+        "description",
+        "comments",
+    )
+
+    def __init__(self, *args, **kwargs) -> None:
+        """
+        Initialize the ACLExtendedRuleForm.
+        """
+        super().__init__(*args, **kwargs)
+
+        # Source
+        if source_type_id := get_field_value(self, "source_type"):
+            try:
+                # Retrieve the ContentType model class based on the source type
+                source_type = ContentType.objects.get(pk=source_type_id)
+                source_model = source_type.model_class()
+
+                # Configure the queryset and label for the source field
+                self.fields["source"].queryset = source_model.objects.all()
+                self.fields["source"].widget.attrs["selector"] = source_model._meta.label_lower
+                self.fields["source"].disabled = False
+                self.fields["source"].label = _("Source " + bettertitle(source_model._meta.verbose_name))
+            except ObjectDoesNotExist:
+                pass
+
+        # Destination
+        if destination_type_id := get_field_value(self, "destination_type"):
+            try:
+                # Retrieve the ContentType model class based on the destination type
+                destination_type = ContentType.objects.get(pk=destination_type_id)
+                destination_model = destination_type.model_class()
+
+                # Configure the queryset and label for the destination field
+                self.fields["destination"].queryset = destination_model.objects.all()
+                self.fields["destination"].widget.attrs["selector"] = destination_model._meta.label_lower
+                self.fields["destination"].disabled = False
+                self.fields["destination"].label = _("Destination " + bettertitle(destination_model._meta.verbose_name))
+            except ObjectDoesNotExist:
+                pass

--- a/netbox_acls/forms/models.py
+++ b/netbox_acls/forms/models.py
@@ -117,7 +117,7 @@ class ACLAssignmentForm(OwnerMixin, NetBoxModelForm):
 
     access_list = DynamicModelChoiceField(
         queryset=AccessList.objects.all(),
-        label="Access List",
+        label=_("Access List"),
         help_text=mark_safe(
             "<b>*Note:</b> Access List must be present on the device already.",
         ),
@@ -237,10 +237,10 @@ class ACLStandardRuleForm(PrimaryModelForm):
         query_params={
             "type": ACLTypeChoices.TYPE_STANDARD,
         },
+        label=_("Access List"),
         help_text=mark_safe(
             _("<b>*Note:</b> This field will only display Standard ACLs."),
         ),
-        label="Access List",
     )
 
     # Source
@@ -360,10 +360,10 @@ class ACLExtendedRuleForm(PrimaryModelForm):
         query_params={
             "type": ACLTypeChoices.TYPE_EXTENDED,
         },
+        label=_("Access List"),
         help_text=mark_safe(
             _("<b>*Note:</b> This field will only display Extended ACLs."),
         ),
-        label="Access List",
     )
 
     # Source

--- a/netbox_acls/views.py
+++ b/netbox_acls/views.py
@@ -8,7 +8,7 @@ from django.db.models import Count
 from django.utils.translation import gettext_lazy as _
 
 from dcim.models import Device, Interface, VirtualChassis
-from netbox.object_actions import AddObject, BulkDelete, BulkExport
+from netbox.object_actions import AddObject, BulkDelete, BulkEdit, BulkExport
 from netbox.views import generic
 from utilities.views import ViewTab, register_model_view
 from virtualization.models import VirtualMachine, VMInterface
@@ -153,7 +153,7 @@ class AccessListListView(generic.ObjectListView):
     table = tables.AccessListTable
     filterset = filtersets.AccessListFilterSet
     filterset_form = forms.AccessListFilterForm
-    actions = (AddObject, BulkExport, BulkDelete)
+    actions = (AddObject, BulkEdit, BulkExport, BulkDelete)
 
 
 @register_model_view(models.AccessList, "add", detail=False)
@@ -176,8 +176,24 @@ class AccessListDeleteView(generic.ObjectDeleteView):
     queryset = models.AccessList.objects.prefetch_related("owner", "tags")
 
 
+@register_model_view(models.AccessList, "bulk_edit", path="edit", detail=False)
+class AccessListBulkEditView(generic.BulkEditView):
+    """
+    Bulk edit view for editing multiple objects of AccessLists.
+    """
+
+    queryset = models.AccessList.objects.all()
+    filterset = filtersets.AccessListFilterSet
+    table = tables.AccessListTable
+    form = forms.AccessListBulkEditForm
+
+
 @register_model_view(models.AccessList, "bulk_delete", path="delete", detail=False)
 class AccessListBulkDeleteView(generic.BulkDeleteView):
+    """
+    Bulk delete view for deleting multiple objects of AccessLists.
+    """
+
     queryset = models.AccessList.objects.prefetch_related("owner", "tags")
     filterset = filtersets.AccessListFilterSet
     table = tables.AccessListTable
@@ -248,7 +264,7 @@ class ACLAssignmentListView(generic.ObjectListView):
     table = tables.ACLAssignmentTable
     filterset = filtersets.ACLAssignmentFilterSet
     filterset_form = forms.ACLAssignmentFilterForm
-    actions = (AddObject, BulkExport, BulkDelete)
+    actions = (AddObject, BulkEdit, BulkExport, BulkDelete)
 
 
 @register_model_view(models.ACLAssignment, "add", detail=False)
@@ -279,8 +295,24 @@ class ACLAssignmentDeleteView(generic.ObjectDeleteView):
     )
 
 
+@register_model_view(models.ACLAssignment, "bulk_edit", path="edit", detail=False)
+class ACLAssignmentBulkEditView(generic.BulkEditView):
+    """
+    Bulk edit view for editing multiple objects of ACLAssignments.
+    """
+
+    queryset = models.ACLAssignment.objects.all()
+    filterset = filtersets.ACLAssignmentFilterSet
+    table = tables.ACLAssignmentTable
+    form = forms.ACLAssignmentBulkEditForm
+
+
 @register_model_view(models.ACLAssignment, "bulk_delete", path="delete", detail=False)
 class ACLAssignmentBulkDeleteView(generic.BulkDeleteView):
+    """
+    Bulk delete view for deleting multiple objects of ACLAssignments.
+    """
+
     queryset = models.ACLAssignment.objects.prefetch_related(
         "access_list",
         "owner",
@@ -455,7 +487,7 @@ class ACLStandardRuleListView(generic.ObjectListView):
     table = tables.ACLStandardRuleTable
     filterset = filtersets.ACLStandardRuleFilterSet
     filterset_form = forms.ACLStandardRuleFilterForm
-    actions = (AddObject, BulkExport, BulkDelete)
+    actions = (AddObject, BulkEdit, BulkExport, BulkDelete)
 
 
 @register_model_view(models.ACLStandardRule, "add", detail=False)
@@ -488,8 +520,24 @@ class ACLStandardRuleDeleteView(generic.ObjectDeleteView):
     )
 
 
+@register_model_view(models.ACLStandardRule, "bulk_edit", path="edit", detail=False)
+class ACLStandardRuleBulkEditView(generic.BulkEditView):
+    """
+    Bulk edit view for editing multiple objects of ACLStandardRules.
+    """
+
+    queryset = models.ACLStandardRule.objects.all()
+    filterset = filtersets.ACLStandardRuleFilterSet
+    table = tables.ACLStandardRuleTable
+    form = forms.ACLStandardRuleBulkEditForm
+
+
 @register_model_view(models.ACLStandardRule, "bulk_delete", path="delete", detail=False)
 class ACLStandardRuleBulkDeleteView(generic.BulkDeleteView):
+    """
+    Bulk delete view for deleting multiple objects of ACLStandardRules.
+    """
+
     queryset = models.ACLStandardRule.objects.prefetch_related(
         "access_list",
         "source",
@@ -536,7 +584,7 @@ class ACLExtendedRuleListView(generic.ObjectListView):
     table = tables.ACLExtendedRuleTable
     filterset = filtersets.ACLExtendedRuleFilterSet
     filterset_form = forms.ACLExtendedRuleFilterForm
-    actions = (AddObject, BulkExport, BulkDelete)
+    actions = (AddObject, BulkEdit, BulkExport, BulkDelete)
 
 
 @register_model_view(models.ACLExtendedRule, "add", detail=False)
@@ -571,8 +619,24 @@ class ACLExtendedRuleDeleteView(generic.ObjectDeleteView):
     )
 
 
+@register_model_view(models.ACLExtendedRule, "bulk_edit", path="edit", detail=False)
+class ACLExtendedRuleBulkEditView(generic.BulkEditView):
+    """
+    Bulk edit view for editing multiple objects of ACLExtendedRules.
+    """
+
+    queryset = models.ACLExtendedRule.objects.all()
+    filterset = filtersets.ACLExtendedRuleFilterSet
+    table = tables.ACLExtendedRuleTable
+    form = forms.ACLExtendedRuleBulkEditForm
+
+
 @register_model_view(models.ACLExtendedRule, "bulk_delete", path="delete", detail=False)
 class ACLExtendedRuleBulkDeleteView(generic.BulkDeleteView):
+    """
+    Bulk delete view for deleting multiple objects of ACLExtendedRules.
+    """
+
     queryset = models.ACLExtendedRule.objects.prefetch_related(
         "access_list",
         "source",


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #327

## New Behavior

This PR adds BulkEdit support for all current ACL plugin models: `AccessList`, `ACLAssignment`, `ACLStandardRule`, and `ACLExtendedRule`.

It introduces bulk edit forms, registers the related bulk edit views, and adds the BulkEdit action to the corresponding list views. It also includes dynamic field handling where ContentType-based relationships need special treatment.

## Contrast to Current Behavior

At the moment, the plugin does not provide BulkEdit functionality for any model, so changes must be made one object at a time.

With this PR, users can update multiple objects in a single workflow, which is more in line with the standard NetBox experience.

## Discussion: Benefits and Drawbacks

The main benefit is usability: managing ACL-related objects in bulk is much faster and reduces repetitive manual work. It also makes the plugin feel more consistent with how NetBox handles bulk operations elsewhere.

The main drawback is a bit more maintenance complexity, especially around dynamic handling for ContentType-based relationships. That said, the change is intended to be additive and backwards-compatible, since it does not replace or remove the existing single-object edit workflows.

## Changes to the Documentation

No documentation changes are included in this PR.

If preferred, a short note can be added later to mention that BulkEdit is now available for all ACL models.

## Proposed Release Note Entry

Added BulkEdit support for all ACL plugin models, including list view actions, bulk edit views, and forms for `AccessList`, `ACLAssignment`, `ACLStandardRule`, and `ACLExtendedRule`.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `dev` branch.