### PR TITLE
Closes #289: Prepare Release 2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 ---
 name: 🐛 Bug Report
-description: Report a reproducible bug in the current release of this NetBox Plugin
+description: Report a reproducible bug in the current release of NetBox ACLs
 title: "[Bug]: "
 labels: ["bug"]
 body:
@@ -21,32 +21,47 @@ body:
 
   - type: input
     attributes:
-      label: NetBox access-list plugin version
-      description: What version of the NetBox access-list plugin are you currently running?
-      placeholder: v1.5.0
+      label: NetBox ACLs Plugin version
+      description: What version of NetBox ACLs are you currently running?
+      placeholder: v2.0.0
     validations:
       required: true
   - type: input
     attributes:
       label: NetBox version
       description: What version of NetBox are you currently running?
-      placeholder: v3.7.4
+      placeholder: v4.5.0
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Python version
+      description: What version of Python are you currently running?
+      options:
+        - "3.12"
+        - "3.13"
+        - "3.14"
     validations:
       required: true
   - type: textarea
     attributes:
       label: Steps to Reproduce
       description: >
-        Describe in detail the exact steps that someone else can take to
-        reproduce this bug using the current stable release of the NetBox access-list plugin.
-      #placeholder: |
+        Please provide a minimal working example to demonstrate the bug. Begin
+        with the initialization of any necessary database objects and clearly
+        enumerate each operation carried out. Ensure that your example is as
+        concise as possible while adequately illustrating the issue.
+
+        _Please refrain from including any confidential or sensitive
+        information in your example._
     validations:
       required: true
   - type: textarea
     attributes:
       label: Expected Behavior
       description: What did you expect to happen?
-      placeholder: A new widget should have been created with the specified attributes
+      placeholder: >
+        The script should execute without raising any errors or exceptions
     validations:
       required: true
   - type: textarea
@@ -56,3 +71,4 @@ body:
       placeholder: A TypeError exception was raised
     validations:
       required: true
+...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,7 +6,7 @@ contact_links:
   #  url: https://netbox-acls.readthedocs.io
   #  about: "Please refer to the documentation before raising a bug or feature request."
   - name: 📖 Contributing Policy
-    url: https://github.com/ryanmerolle/netbox-acls/blob/dev/CONTRIBUTING.md
+    url: https://github.com/netbox-community/netbox-acls/blob/dev/CONTRIBUTING.md
     about: "Please read through our contributing policy before opening an issue or pull request"
   - name: 💬 Community Slack
     url: https://netdev.chat/

--- a/.github/ISSUE_TEMPLATE/documentation_change.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_change.yml
@@ -1,6 +1,6 @@
 ---
 name: 📖 Documentation Change
-description: Suggest an addition or modification to the NetBox Access Lists plugin documentation
+description: Suggest an addition or modification to the NetBox ACLs plugin documentation
 title: "[Docs]: "
 labels: ["documentation"]
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,40 +1,49 @@
 ---
 name: ✨ Feature Request
-description: Propose a new  feature or enhancement
+description: Propose a new NetBox ACLs Plugin feature or enhancement
 title: "[Feature]: "
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: >
-        **NOTE:** This form is only for submitting well-formed proposals to extend or modify
-        NetBox in some way. If you're trying to solve a problem but can't figure out how, or if
-        you still need time to work on the details of a proposed new feature, please start a
-        [discussion](https://github.com/ryanmerolle/netbox-acls/discussions) instead.
+        **NOTE:** This form is only for submitting well-formed proposals to
+        extend or modify NetBox ACLs Plugin in some way. If you're trying to
+        solve a problem but can't figure out how, or if you still need time to
+        work on the details of a proposed new feature, please start a
+        [discussion](https://github.com/netbox-community/netbox-acls/discussions)
+        instead.
+  - type: input
+    attributes:
+      label: NetBox ACLs Plugin version
+      description: What version of NetBox ACLs are you currently running?
+      placeholder: v2.0.0
+    validations:
+      required: true
   - type: input
     attributes:
       label: NetBox version
       description: What version of NetBox are you currently running?
-      placeholder: v3.6.3
+      placeholder: v4.5.0
     validations:
       required: true
   - type: dropdown
     attributes:
       label: Feature type
       options:
-        - New Model to plugin
-        - Change to existing model
-        - Add a function
-        - Remove a function
+        - Data model extension
+        - New functionality
+        - Change to existing functionality
     validations:
       required: true
   - type: textarea
     attributes:
       label: Proposed functionality
       description: >
-        Describe in detail the new feature or behavior you are proposing. Include any specific changes
-        to work flows, data models, and/or dependencies. The more detail you provide here, the
-        greater chance your proposal has of being discussed. Feature requests which don't include an
+        Describe in detail the new feature or behavior you are proposing.
+        Include any specific changes to work flows, data models, and/or the user
+        interface. The more detail you provide here, the greater chance your
+        proposal has of being discussed. Feature requests which don't include an
         actionable implementation plan will be rejected.
     validations:
       required: true
@@ -42,13 +51,16 @@ body:
     attributes:
       label: Use case
       description: >
-        Explain how adding this functionality would benefit NetBox users & specifically this plugin. What need does it address?
+        Explain how adding this functionality would benefit NetBox ACLs Plugin
+        users. What need does it address?
     validations:
       required: true
   - type: textarea
     attributes:
       label: External dependencies
       description: >
-        List any new dependencies on external libraries or services that this new feature would
-        introduce. For example, does the proposal require the installation of a new Python package?
+        List any new dependencies on external libraries or services that this
+        new feature would introduce. For example, does the proposal require the
+        installation of a new Python package?
         (Not all new features introduce new dependencies.)
+...

--- a/.github/ISSUE_TEMPLATE/housekeeping.yml
+++ b/.github/ISSUE_TEMPLATE/housekeeping.yml
@@ -7,14 +7,16 @@ body:
   - type: markdown
     attributes:
       value: >
-        **NOTE:** This template is for use by maintainers only. Please do not submit
-        an issue using this template unless you have been specifically asked to do so.
+        **NOTE:** This template is for use by maintainers only. Please do not
+        submit an issue using this template unless you have been specifically
+        asked to do so.
   - type: textarea
     attributes:
       label: Proposed Changes
       description: >
         Describe in detail the new feature or behavior you'd like to propose.
-        Include any specific changes to work flows, data models, or the user interface.
+        Include any specific changes to work flows, data models, or the user
+        interface.
     validations:
       required: true
   - type: textarea
@@ -23,3 +25,4 @@ body:
       description: Please provide justification for the proposed change(s).
     validations:
       required: true
+...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.6"
+    rev: "v0.15.7"
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/README.md
+++ b/README.md
@@ -1,73 +1,66 @@
 # NetBox Access Lists Plugin
 
-A [Netbox](https://github.com/netbox-community/netbox) plugin for Access List management.
+A [NetBox](https://github.com/netbox-community/netbox) plugin for managing
+Access Lists.
 
 ## Features
 
-This plugin provides the following models:
-
-- Access Lists
-- Access List to Interface Assignment
-- Access List Rules (abstract model basis for other rules)
-- Access List Standard Rules
-- Access List Extended Rules
-
-## Origin
-
-Based on the NetBox plugin tutorial by [jeremystretch](https://github.com/jeremystretch):
-
-- [demo repository](https://github.com/netbox-community/netbox-plugin-demo)
-- [tutorial](https://github.com/netbox-community/netbox-plugin-tutorial)
-
-All credit should go to Jeremy. Thanks, Jeremy!
-
-This project just looks to build on top of this framework and model presented.
-
-## Contributing
-
-This project is currently maintained by the [netbox-community](https://github.com/netbox-community).
-
-See the [CONTRIBUTING](CONTRIBUTING.md) for more information.
+- **Access Lists** (Standard and Extended)
+- **Standard Rules** for Access Lists
+- **Extended Rules** for Access Lists
+- **Interface Assignment** for Access Lists
 
 ## Compatibility
 
-Each Plugin Version listed below has been tested with its corresponding NetBox Version.
+The following table details the tested plugin versions for each NetBox version:
 
-| NetBox Version      | Plugin Version |
+|   NetBox Version    | Plugin Version |
 |:-------------------:|:--------------:|
-|      4.4.x          |     1.9.1      |
-|      4.3.x          |     1.9.1      |
-|      4.2.x          |     1.8.1      |
-|      4.1.x          |     1.7.0      |
-|   >= 4.0.2 < 4.1.0  |     1.6.1      |
-|      3.7.x          |     1.5.0      |
-|      3.6.x          |     1.4.0      |
-|      3.5.x          |     1.3.0      |
-|      3.4.x          |     1.2.2      |
-|      3.3.x          |     1.1.0      |
-|      3.2.x          |     1.0.1      |
+|        4.5.x        |     2.0.0      |
+|        4.4.x        |     1.9.1      |
+|        4.3.x        |     1.9.1      |
+|        4.2.x        |     1.8.1      |
+|        4.1.x        |     1.7.0      |
+|  >= 4.0.2 < 4.1.0   |     1.6.1      |
+|        3.7.x        |     1.5.0      |
+|        3.6.x        |     1.4.0      |
+|        3.5.x        |     1.3.0      |
+|        3.4.x        |     1.2.2      |
+|        3.3.x        |     1.1.0      |
+|        3.2.x        |     1.0.1      |
 
 ## Installing
 
-For adding to a NetBox Docker setup see
-[the general instructions for using netbox-docker with plugins](https://github.com/netbox-community/netbox-docker/wiki/Using-Netbox-Plugins).
+### For Docker Setups
 
-You can install with pip:
+For instructions specific to NetBox Docker setups,
+see the [netbox-docker plugin documentation](https://github.com/netbox-community/netbox-docker/wiki/Using-Netbox-Plugins).
+
+### Via pip
+
+Activate your NetBox Python virtual environment and run:
 
 ```bash
+source /opt/netbox/venv/bin/activate
+
 pip install netbox-acls
 ```
 
-or by adding to your `local_requirements.txt` or `plugin_requirements.txt` (netbox-docker):
+**Important:** When using NetBox's `upgrade.sh`, the virtual environment is
+deleted and recreated.
+To ensure that the ACL plugin is reinstalled during an upgrade,
+add it to your `local_requirements.txt` (for local installations) or
+`plugin_requirements.txt` (for container-based installations).
 
-```bash
+```txt
 netbox-acls
 ```
 
 ## Configuration
 
-Enable the plugin in `/opt/netbox/netbox/netbox/configuration.py`,
- or if you use netbox-docker, your `/configuration/plugins.py` file :
+Enable the plugin by editing the NetBox configuration file.
+For local installations, update `/opt/netbox/netbox/netbox/configuration.py`;
+for Docker setups, modify `/configuration/plugins.py`:
 
 ```python
 PLUGINS = [
@@ -76,7 +69,8 @@ PLUGINS = [
 
 PLUGINS_CONFIG = {
     "netbox_acls": {
-        # Display the plugin in the top-level menu (True) or under the Plugins menu (False)
+        # Set to True to add a top-level menu item, or False to place it
+        # under the Plugins menu. Default is True.
         "top_level_menu": True,
         # Sequence number increment for new ACL rules (e.g., 10, 20, 30...)
         "rule_sequence_step": 10,
@@ -84,48 +78,76 @@ PLUGINS_CONFIG = {
 }
 ```
 
-To add the required `netbox-acls` tables to your NetBox database, run the `migrate` manager subcommand in the NetBox virtual environment:
-```
+After configuration, apply the changes by running the database migrations:
+
+```bash
+source /opt/netbox/venv/bin/activate
 cd /opt/netbox
-sudo ./venv/bin/python3 netbox/manage.py migrate
+python3 netbox/manage.py migrate
 ```
+
+## Screenshots
+
+- **Access List** (List View)
+  ![Access List - List View](docs/img/access_lists.png)
+
+- **Access List (Standard)** (Detail View)
+  ![Access List Type Standard - Detail View](docs/img/access_list_type_standard.png)
+
+- **Access List (Extended)** (Detail View)
+  ![Access List Type Extended - Detail View](docs/img/access_list_type_extended.png)
+
+- **Standard Access List Rules** (List View)
+  ![Standard Access List Rules - List View](docs/img/acl_standard_rules.png)
+
+- **Extended Access List Rules** (List View)
+  ![Extended Access List Rules - List View](docs/img/acl_extended_rules.png)
+
+- **Interface Assignments** (List View)
+  ![Access List Interface Assignments - List View](docs/img/acl_interface_assignments.png)
+
+- **Host Access Lists** (New Card for Devices, Virtual Chassis, Virtual Machines)
+  ![Host Access Lists - New Card](docs/img/acl_host_view.png)
+
+- **Host Interface Access Lists** (New Card for Device and VM Interfaces)
+  ![Host Interface Access Lists - New Card](docs/img/access_list_type_standard.png)
 
 ## Developing
 
 ### VSCode + Docker + Dev Containers
 
-To develop this plugin further one can use the included .devcontainer configuration. This configuration creates a docker container which includes a fully working netbox installation. Currently it should work when using WSL 2. For this to work make sure you have Docker Desktop installed and the WSL 2 integrations activated.
+You can use the provided `.devcontainer` configuration
+to set up a development environment with a fully functional NetBox
+installation.
+This configuration works best with WSL 2.
+For this to work, make sure you have Docker Desktop installed and the WSL 2
+integrations activated.
 
-1. In the WSL terminal, enter `code` to run Visual studio code.
-2. Install the devcontainer extension "ms-vscode-remote.remote-containers"
-3. Press Ctrl+Shift+P and use the "Dev Container: Clone Repository in Container Volume" function to clone this repository. This will take a while depending on your computer
-4. If you'd like the netbox instance to be prepopulated with example data from [netbox-initializers](https://github.com/tobiasge/netbox-initializers) run `make  initializers`
-5. Start the netbox instance using `make all`
+1. Open a WSL terminal and run `code` to launch Visual Studio Code.
+2. Install the **ms-vscode-remote.remote-containers** extension.
+3. Press `Ctrl+Shift+P` and select
+   **Dev Container: Clone Repository in Container Volume** to start cloning the
+   repository. The process may take some time.
+4. (Optional) To prepopulate NetBox with example data from
+   [netbox-initializers](https://github.com/tobiasge/netbox-initializers),
+   run: `make initializers`
+5. Start the NetBox instance: `make all`
 
-Your netbox instance will be served under 0.0.0.0:8000, so it should now be available under localhost:8000.
+After these steps, NetBox will be available at [http://localhost:8000](http://localhost:8000).
 
-## Screenshots
+## Contributing
 
-Access List - List View
-![Access List - List View](docs/img/access_lists.png)
+This project is maintained by the [netbox-community](https://github.com/netbox-community).
+For contribution guidelines, please see the [CONTRIBUTING](CONTRIBUTING.md)
+document.
 
-Access List (Type Extended) - Individual View
-![Access List Type Extended - Individual View](docs/img/access_list_type_extended.png)
+## Credits
 
-Access List (Type Standard) - Individual View
-![Access List Type Standard - Individual View](docs/img/access_list_type_standard.png)
+This plugin is based on the NetBox plugin tutorial by [jeremystretch](https://github.com/jeremystretch):
 
-Extended Access List Rules - List View
-![Extended Access List Rules - List View](docs/img/acl_extended_rules.png)
+- [Demo Repository](https://github.com/netbox-community/netbox-plugin-demo)
+- [Tutorial](https://github.com/netbox-community/netbox-plugin-tutorial)
 
-Standard Access List Rules - List View
-![Standard Access List Rules - List View](docs/img/acl_standard_rules.png)
+All credit should go to Jeremy. Thanks, Jeremy!
 
-Access List Interface Assignments- List View
-![Access List Interface Assignments- List View](docs/img/acl_interface_assignments.png)
-
-Host (device, virtual_chassis, virtual_machine) Access Lists - New Card
-![Host Access Lists - New Card](docs/img/acl_host_view.png)
-
-Host Interface (vminterface interface) Access Lists - New Card
-![Host Interface Access Lists - New Card](docs/img/access_list_type_standard.png)
+This project aims to build upon the framework and model presented there.

--- a/TODO
+++ b/TODO
@@ -1,7 +1,0 @@
-- TODO: ACL Form Bubble/ICON Extended/Standard
-- TODO: Add an Access List to an Interface Custom Fields after comments - DONE
-- TODO: ACL rules, look at last number and increment to next 10
-- TODO: Clone for ACL Interface should include device
-- TODO: Inconsistent errors for add/edit (where model is using a generic page)
-- TODO: Check Constants across codebase for consistency.
-- TODO: Test API, Forms, & Models - https://github.com/k01ek/netbox-bgp/tree/main/netbox_bgp/tests , https://github.com/DanSheps/netbox-secretstore/tree/develop/netbox_secretstore/tests & https://github.com/FlxPeters/netbox-plugin-prometheus-sd/tree/main/netbox_prometheus_sd/tests

--- a/netbox_acls/migrations/0001_squashed_0013_acl_owner.py
+++ b/netbox_acls/migrations/0001_squashed_0013_acl_owner.py
@@ -1,0 +1,436 @@
+import re
+
+import django.contrib.postgres.fields
+import django.contrib.postgres.fields.ranges
+import django.core.validators
+import django.db.models.deletion
+import taggit.managers
+from django.db import migrations, models
+
+import utilities.json
+
+
+class Migration(migrations.Migration):
+    replaces = [
+        ("netbox_acls", "0001_initial"),
+        ("netbox_acls", "0002_alter_accesslist_options_and_more"),
+        ("netbox_acls", "0003_netbox_acls"),
+        ("netbox_acls", "0004_netbox_acls"),
+        ("netbox_acls", "0005_preflight_validate_upgrade"),
+        ("netbox_acls", "0006_alter_accesslist_name"),
+        ("netbox_acls", "0007_acl_rule_sequence_unique"),
+        ("netbox_acls", "0008_acl_assignments"),
+        ("netbox_acls", "0009_accesslist_ip_family"),
+        ("netbox_acls", "0010_acl_rule_source_and_destination_objects"),
+        ("netbox_acls", "0011_acl_rule_copy_prefix_assignments"),
+        ("netbox_acls", "0012_aclextendedrule_port_ranges"),
+        ("netbox_acls", "0013_acl_owner"),
+    ]
+
+    initial = True
+
+    dependencies = [
+        ("contenttypes", "0002_remove_content_type_name"),
+        ("extras", "0072_created_datetimefield"),
+        ("extras", "0128_tableconfig"),
+        ("ipam", "0081_remove_service_device_virtual_machine_add_parent_gfk_index"),
+        ("users", "0015_owner"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="AccessList",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False)),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(blank=True, default=dict, encoder=utilities.json.CustomFieldJSONEncoder),
+                ),
+                (
+                    "name",
+                    models.CharField(
+                        max_length=500,
+                        validators=[
+                            django.core.validators.RegexValidator(
+                                re.compile("^[-a-zA-Z0-9_]+\\Z"),
+                                "Enter a valid “slug” consisting of letters, numbers, underscores or hyphens.",
+                                "invalid",
+                            )
+                        ],
+                    ),
+                ),
+                ("type", models.CharField(max_length=30)),
+                ("default_action", models.CharField(default="deny", max_length=30)),
+                ("comments", models.TextField(blank=True)),
+                ("tags", taggit.managers.TaggableManager(through="extras.TaggedItem", to="extras.Tag")),
+                ("family", models.CharField(db_index=True, default="ipv4", max_length=8)),
+                ("description", models.CharField(blank=True, max_length=200)),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to="users.owner"
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ("name",),
+                "verbose_name": "Access List",
+                "verbose_name_plural": "Access Lists",
+            },
+        ),
+        migrations.CreateModel(
+            name="ACLAssignment",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False)),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(blank=True, default=dict, encoder=utilities.json.CustomFieldJSONEncoder),
+                ),
+                (
+                    "access_list",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="aclassignments",
+                        to="netbox_acls.accesslist",
+                    ),
+                ),
+                ("direction", models.CharField(max_length=30)),
+                ("assigned_object_id", models.PositiveBigIntegerField()),
+                (
+                    "assigned_object_type",
+                    models.ForeignKey(
+                        limit_choices_to=models.Q(
+                            models.Q(
+                                models.Q(
+                                    ("app_label", "dcim"), ("model__in", ("device", "interface", "virtualchassis"))
+                                ),
+                                models.Q(
+                                    ("app_label", "virtualization"), ("model__in", ("virtualmachine", "vminterface"))
+                                ),
+                                _connector="OR",
+                            )
+                        ),
+                        on_delete=django.db.models.deletion.PROTECT,
+                        to="contenttypes.contenttype",
+                    ),
+                ),
+                ("comments", models.TextField(blank=True)),
+                ("tags", taggit.managers.TaggableManager(through="extras.TaggedItem", to="extras.Tag")),
+                ("family", models.CharField(db_index=True, editable=False, max_length=8)),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to="users.owner"
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["assigned_object_type", "assigned_object_id", "access_list", "family", "direction"],
+                "unique_together": set(),
+                "verbose_name": "ACL Interface Assignment",
+                "verbose_name_plural": "ACL Interface Assignments",
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("access_list", "assigned_object_type", "assigned_object_id", "direction"),
+                        name="netbox_acls_aclassignment_unique_object_direction_family_per_access_list",
+                        violation_error_message="ACL Assignment for the given object and direction.",
+                    ),
+                    models.UniqueConstraint(
+                        condition=models.Q(("direction", "none"), _negated=True),
+                        fields=("assigned_object_type", "assigned_object_id", "direction", "family"),
+                        name="netbox_acls_aclassignment_unique_object_direction_family_interface_only",
+                        violation_error_message="ACL Assignment for the given object, direction and family exists.",
+                    ),
+                ],
+            },
+        ),
+        migrations.CreateModel(
+            name="ACLExtendedRule",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False)),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(blank=True, default=dict, encoder=utilities.json.CustomFieldJSONEncoder),
+                ),
+                ("tags", taggit.managers.TaggableManager(through="extras.TaggedItem", to="extras.Tag")),
+                (
+                    "access_list",
+                    models.ForeignKey(
+                        limit_choices_to={"type": "extended"},
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="aclextendedrules",
+                        to="netbox_acls.accesslist",
+                    ),
+                ),
+                ("sequence", models.PositiveIntegerField()),
+                ("description", models.CharField(blank=True, max_length=500)),
+                ("action", models.CharField(max_length=30)),
+                ("remark", models.CharField(blank=True, max_length=500)),
+                (
+                    "_source_prefix",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="_%(class)s_sources",
+                        to="ipam.prefix",
+                    ),
+                ),
+                (
+                    "_destination_prefix",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="_%(class)s_destinations",
+                        to="ipam.prefix",
+                    ),
+                ),
+                ("protocol", models.CharField(blank=True, max_length=30)),
+                (
+                    "_destination_aggregate",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="_%(class)s_destinations",
+                        to="ipam.aggregate",
+                    ),
+                ),
+                (
+                    "_destination_ipaddress",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="_%(class)s_destinations",
+                        to="ipam.ipaddress",
+                    ),
+                ),
+                (
+                    "_destination_iprange",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="_%(class)s_destinations",
+                        to="ipam.iprange",
+                    ),
+                ),
+                (
+                    "_source_aggregate",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="_%(class)s_sources",
+                        to="ipam.aggregate",
+                    ),
+                ),
+                (
+                    "_source_ipaddress",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="_%(class)s_sources",
+                        to="ipam.ipaddress",
+                    ),
+                ),
+                (
+                    "_source_iprange",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="_%(class)s_sources",
+                        to="ipam.iprange",
+                    ),
+                ),
+                ("destination_id", models.PositiveBigIntegerField(blank=True, null=True)),
+                (
+                    "destination_type",
+                    models.ForeignKey(
+                        blank=True,
+                        limit_choices_to=models.Q(
+                            models.Q(
+                                ("app_label", "ipam"), ("model__in", ("aggregate", "ipaddress", "iprange", "prefix"))
+                            )
+                        ),
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="+",
+                        to="contenttypes.contenttype",
+                    ),
+                ),
+                ("source_id", models.PositiveBigIntegerField(blank=True, null=True)),
+                (
+                    "source_type",
+                    models.ForeignKey(
+                        blank=True,
+                        limit_choices_to=models.Q(
+                            models.Q(
+                                ("app_label", "ipam"), ("model__in", ("aggregate", "ipaddress", "iprange", "prefix"))
+                            )
+                        ),
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="+",
+                        to="contenttypes.contenttype",
+                    ),
+                ),
+                (
+                    "destination_port_ranges",
+                    django.contrib.postgres.fields.ArrayField(
+                        base_field=django.contrib.postgres.fields.ranges.IntegerRangeField(),
+                        blank=True,
+                        default=list,
+                        size=None,
+                    ),
+                ),
+                (
+                    "source_port_ranges",
+                    django.contrib.postgres.fields.ArrayField(
+                        base_field=django.contrib.postgres.fields.ranges.IntegerRangeField(),
+                        blank=True,
+                        default=list,
+                        size=None,
+                    ),
+                ),
+                ("comments", models.TextField(blank=True)),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to="users.owner"
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ("access_list", "sequence", "-action"),
+                "verbose_name": "ACL Extended Rule",
+                "verbose_name_plural": "ACL Extended Rules",
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("access_list", "sequence"),
+                        name="netbox_acls_aclextendedrule_unique_aclrule_sequence",
+                        violation_error_message="Unique ACL rule sequence already exists.",
+                    )
+                ],
+                "indexes": [
+                    models.Index(
+                        fields=["destination_type", "destination_id", "source_type", "source_id"],
+                        name="netbox_acls_destina_8f93b4_idx",
+                    )
+                ],
+            },
+        ),
+        migrations.CreateModel(
+            name="ACLStandardRule",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False)),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(blank=True, default=dict, encoder=utilities.json.CustomFieldJSONEncoder),
+                ),
+                ("tags", taggit.managers.TaggableManager(through="extras.TaggedItem", to="extras.Tag")),
+                (
+                    "access_list",
+                    models.ForeignKey(
+                        limit_choices_to={"type": "standard"},
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="aclstandardrules",
+                        to="netbox_acls.accesslist",
+                    ),
+                ),
+                ("sequence", models.PositiveIntegerField()),
+                ("description", models.CharField(blank=True, max_length=500)),
+                ("action", models.CharField(max_length=30)),
+                ("remark", models.CharField(blank=True, max_length=500)),
+                (
+                    "_source_prefix",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="_%(class)s_sources",
+                        to="ipam.prefix",
+                    ),
+                ),
+                (
+                    "_source_aggregate",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="_%(class)s_sources",
+                        to="ipam.aggregate",
+                    ),
+                ),
+                (
+                    "_source_ipaddress",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="_%(class)s_sources",
+                        to="ipam.ipaddress",
+                    ),
+                ),
+                (
+                    "_source_iprange",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="_%(class)s_sources",
+                        to="ipam.iprange",
+                    ),
+                ),
+                ("source_id", models.PositiveBigIntegerField(blank=True, null=True)),
+                (
+                    "source_type",
+                    models.ForeignKey(
+                        blank=True,
+                        limit_choices_to=models.Q(
+                            models.Q(
+                                ("app_label", "ipam"), ("model__in", ("aggregate", "ipaddress", "iprange", "prefix"))
+                            )
+                        ),
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="+",
+                        to="contenttypes.contenttype",
+                    ),
+                ),
+                ("comments", models.TextField(blank=True)),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to="users.owner"
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ("access_list", "sequence", "-action"),
+                "unique_together": set(),
+                "verbose_name": "ACL Standard Rule",
+                "verbose_name_plural": "ACL Standard Rules",
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("access_list", "sequence"),
+                        name="netbox_acls_aclstandardrule_unique_aclrule_sequence",
+                        violation_error_message="Unique ACL rule sequence already exists.",
+                    )
+                ],
+                "indexes": [models.Index(fields=["source_type", "source_id"], name="netbox_acls_source__01d2fa_idx")],
+            },
+        ),
+    ]

--- a/netbox_acls/navigation.py
+++ b/netbox_acls/navigation.py
@@ -73,7 +73,7 @@ aclassignment_item = PluginMenuItem(
 )
 
 
-if plugin_settings.get("top_level_menu"):
+if plugin_settings.get("top_level_menu", True):
     menu = PluginMenu(
         label="Access Lists",
         groups=(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = [
     "check-manifest==0.51",
     "pre-commit==4.5.1",
     "pytest==9.0.2",
-    "ruff==0.15.6",
+    "ruff==0.15.7",
     "yamllint==1.38.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,32 +1,36 @@
-[build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+# See PEP 518 for the spec of this file
+# https://www.python.org/dev/peps/pep-0518/
 
-[tool.setuptools]
-packages = ["netbox_acls"]
-package-data = {"netbox_acls" = ["**/*", "templates/**"]}
+[build-system]
+requires = ["setuptools >= 77.0.3"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-acls"
 version = "1.9.1"
-readme = "README.md"
 requires-python = ">=3.12.0"
-classifiers=[
-    'Development Status :: 5 - Production/Stable',
-    'Intended Audience :: Developers',
-    'Natural Language :: English',
-    "Programming Language :: Python :: 3 :: Only",
-    'Programming Language :: Python :: 3.12',
-    'Programming Language :: Python :: 3.13',
-    'Programming Language :: Python :: 3.14',
-    'Intended Audience :: System Administrators',
-    'Intended Audience :: Telecommunications Industry',
-    'Framework :: Django',
-    'Topic :: System :: Networking',
-    'Topic :: Internet',
-]
+description = "NetBox plugin for plugin for managing Access Control Lists (ACLs)."
+readme = { file = "README.md", content-type = "text/markdown" }
+license = "Apache-2.0"
+license-files = ["LICENSE.txt"]
 keywords = ["netbox", "netbox-plugin"]
-license = {file = "LICENSE.txt"}
+classifiers=[
+    "Development Status :: 5 - Production/Stable",
+    "Framework :: Django",
+    "Framework :: Django :: 5.2",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: System :: Networking",
+    "Topic :: Internet",
+]
 
 [project.optional-dependencies]
 test = [
@@ -38,6 +42,12 @@ test = [
 ]
 
 [project.urls]
+Homepage = "https://github.com/netbox-community/netbox-acls/"
 Documentation = "https://github.com/netbox-community/netbox-acls/blob/dev/README.md"
 Source = "https://github.com/netbox-community/netbox-acls/"
-Tracker = "https://github.com/netbox-community/netbox-acls/issues"
+Issues = "https://github.com/netbox-community/netbox-acls/issues"
+Changelog = "https://github.com/netbox-community/netbox-acls/releases"
+
+[tool.setuptools]
+packages = ["netbox_acls"]
+package-data = {"netbox_acls" = ["**/*", "templates/**"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-acls"
-version = "1.9.1"
+version = "2.0.0"
 requires-python = ">=3.12.0"
 description = "NetBox plugin for plugin for managing Access Control Lists (ACLs)."
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #289

## New Behavior

This PR finalizes the v2.0 release preparation work on top of the feature and migration changes that have already landed in `dev`. It refreshes the README and project metadata, cleans up outdated repository housekeeping, adds a squashed initial migration for fresh installs, fixes the default handling of the `top_level_menu` plugin setting, and consolidates the final v2.0 changelog in one place.

## Contrast to Current Behavior

Before this PR, the functional v2.0 work was already merged into `dev`, but the release was not yet packaged and documented as a coherent milestone. The README still reflected older structure and compatibility details, some repository templates and metadata were outdated, fresh installs still depended on the longer historical migration chain, and the navigation setting could raise a `KeyError` when `top_level_menu` was not explicitly configured.

## Discussion: Benefits and Drawbacks

This PR makes the upcoming 2.0 release easier to understand, test, and consume. It improves the release story for users and maintainers by aligning the documentation with the actual codebase, reducing setup friction for fresh installs, and closing a small but user-facing configuration bug in navigation handling.

The main drawback is that this is a broad release-preparation PR rather than a narrowly scoped feature change. It also accompanies a release that includes several intentional breaking changes, especially around models, API fields, GraphQL, and migrations. Those compatibility impacts are already captured below in the changelog and migration notes.

## Changes to the Documentation

- Rewrite the README to match the current v2.0 feature set, compatibility targets, installation flow, and project structure.
- Keep the release changelog in sync with the final set of merged v2.0 changes.
- Update GitHub issue templates and project metadata to reflect the current repository and release line.
- No wiki changes are proposed in this PR.

## Proposed Release Note Entry

Prepare the v2.0 release by refreshing the README and repository metadata, adding a squashed initial migration for fresh installs, fixing default handling of `top_level_menu`, and consolidating the final changelog and upgrade notes for all changes merged since v1.9.1.

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.

---

Changelog:

## [2.0.0] - Unreleased

### Added
- Added support for assigning a single ACL to multiple devices, virtual chassis, virtual machines, and interfaces through a unified `ACLAssignment` model.
- Added GraphQL support for `assigned_object` relations, aligned with the REST API.
- Added an ACL assignments view so an ACL’s applied objects can be inspected directly from the ACL page.
- Added generic source and destination object support for ACL rules across the UI, REST API, and GraphQL. Rules can now reference Prefixes, IP Addresses, IP Ranges, and Aggregates.
- Added NetBox global search support for `AccessList`, `ACLStandardRule`, and `ACLExtendedRule`.
- Added ACL `family` support with `IPv4`, `IPv6`, and `Dual` values across models, forms, filters, tables, serializers, and GraphQL.
- Added support for the generic `IP` protocol in extended ACL rules.
- Added support for attached remarks on `permit` and `deny` ACL rules.
- Added parent ACL changelog entries for ACL rule changes.
- Added source and destination port range support for extended ACL rules.
- Added normalized serializer helper fields `source_port_terms` and `destination_port_terms`.
- Added native owner support to ACL objects.
- Added automatic ACL rule sequence suggestions for new rules.
- Added the `rule_sequence_step` plugin setting to control the increment used for suggested rule sequences.
- Added BulkEdit support for all editable plugin models.
- Added a read-only preflight migration check for incompatible legacy data before the v2.0 migration chain runs.
- Added a squashed initial migration for fresh installs, consolidating the early schema migration chain.

### Changed
- Updated compatibility to NetBox 4.5.x and Python 3.12+.
- **Breaking:** Replaced `ACLInterfaceAssignment` with a unified `ACLAssignment` model. The API route changes from `interface-assignments` to `assignments`, GraphQL assignment names were updated, and existing assignment data is migrated.
- **Breaking:** Replaced prefix-only rule endpoints (`source_prefix` / `destination_prefix`) with generic `source` / `destination` relations backed by `*_type` / `*_id`.
- **Breaking:** Renamed ACL rule field `index` to `sequence`.
- **Breaking:** Added an ACL `family` field with `IPv4`, `IPv6`, and `Dual` values and introduced stricter validation for rules and assignments.
- **Breaking:** Replaced `source_ports` / `destination_ports` on extended ACL rules with `source_port_ranges` / `destination_port_ranges`.
- Assignment validation is now family-aware, allowing one IPv4 ACL and one IPv6 ACL per interface and direction while rejecting conflicting same-family or dual assignments.
- Forms now use selectors in place of the previous parameter-based approach.
- `AccessList.name` validation now uses Django’s built-in `validate_slug`.
- Plugin models now rely on NetBox’s default `get_absolute_url()` behavior instead of plugin-specific overrides.
- Extended ACL rule handling now uses port ranges as the authoritative representation for source and destination ports.
- Forms, filters, tables, serializers, GraphQL types, and templates were updated to use the new range-based port fields.
- GraphQL filters were updated to replace deprecated Strawberry Django filter decorators and align with current NetBox patterns.
- Linting and formatting were standardized on Ruff.
- Migration performance was improved with bulk operations and by skipping unchanged rules where possible.

### Fixed
- Fixed assignment uniqueness handling by enforcing family-aware validation.
- Fixed `ACLAssignment` cloning so the assigned object reference is preserved.
- Fixed extended-rule migration behavior when only one legacy prefix side is populated.
- Fixed duplicate standalone `remark` rows sharing a sequence with a `permit` or `deny` rule. Attached remarks remain supported.
- Fixed extended-rule port validation to reject non-TCP/UDP port use, out-of-range values, and invalid normalized port range input.
- Fixed OpenAPI schema generation for `source_port_terms` and `destination_port_terms`.
- Fixed ACL views to hide unsupported actions such as `Import`.
- Fixed navigation settings lookup by defaulting `top_level_menu` to `True` when the setting is not explicitly configured.

### Migration notes
- Existing ACL assignments are migrated to the new unified `ACLAssignment` model.
- Existing prefix-based rule endpoints are migrated to the new generic `source` / `destination` relations.
- Existing ACL rule field `index` is migrated to `sequence`.
- Existing ACLs are assigned a `family` value during migration based on their current rules and assignments.
- Existing `source_ports` / `destination_ports` data is migrated automatically to `source_port_ranges` / `destination_port_ranges`.
- The preflight migration checks ACL name format, orphaned generic foreign key references, and family-related assignment conflicts before schema-changing v2.0 migrations continue.
- API and GraphQL consumers should review changes to assignment, rule, sequence, and port field names before upgrading.
- Test upgrades against representative datasets, especially installations with legacy or inconsistent data.