### PR TITLE
Fixes #342: Check Rule `add` Permissions for Add Rule button

### DIFF
--- a/netbox_acls/templates/netbox_acls/accesslist.html
+++ b/netbox_acls/templates/netbox_acls/accesslist.html
@@ -3,17 +3,17 @@
 {% load helpers %}
 
 {% block extra_controls %}
-  {% if perms.netbox_acls.change_policy %}
-    {% with viewname=object|viewname:"" %}
-    {% if object.type == 'extended' %}
+  {% with viewname=object|viewname:"" %}
+    {% if perms.netbox_acls.add_aclextendedrule and object.type == 'extended' %}
       <a href="{% url 'plugins:netbox_acls:aclextendedrule_add' %}?access_list={{ object.pk }}&return_url={% url viewname pk=object.pk %}" class="btn btn-primary">
-    {% elif object.type == 'standard' %}
-      <a href="{% url 'plugins:netbox_acls:aclstandardrule_add' %}?access_list={{ object.pk }}&return_url={% url viewname pk=object.pk %}" class="btn btn-primary">
-    {% endif %}
-        <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Rule
+        <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add Rule
       </a>
-    {% endwith %}
-  {% endif %}
+    {% elif perms.netbox_acls.add_aclstandardrule and object.type == 'standard' %}
+      <a href="{% url 'plugins:netbox_acls:aclstandardrule_add' %}?access_list={{ object.pk }}&return_url={% url viewname pk=object.pk %}" class="btn btn-primary">
+        <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add Rule
+      </a>
+    {% endif %}
+  {% endwith %}
 {% endblock extra_controls %}
 
 {% block content %}


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #342

## New Behavior

The “Add Rule” button on the AccessList detail view is now shown based on the ACL type and the matching rule creation permission.

For standard ACLs, the button requires `netbox_acls.add_aclstandardrule`.
For extended ACLs, the button requires `netbox_acls.add_aclextendedrule`.

## Contrast to Current Behavior

Previously, the “Add Rule” button was controlled by the unrelated `netbox_acls.change_policy` permission. As a result, non-superuser accounts with the correct rule creation permissions could not see the button.

The button label was also updated from “Rule” to “Add Rule” to make the action clearer.

## Discussion: Benefits and Drawbacks

This change makes the AccessList detail view respect the actual permissions required to create ACL rules. It allows non-superuser users with the correct permissions to add rules without requiring unrelated permissions.

The change is small and should be backwards-compatible. I do not see any major drawbacks, as the button visibility now better matches the existing rule creation permissions.

## Changes to the Documentation

No documentation changes are required.

## Proposed Release Note Entry

Fixed the AccessList detail view “Add Rule” button permission check for non-superuser accounts.

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.