### PR TITLE
Fixes #341: Use port range fields in ACL Rule results

### DIFF
--- a/netbox_acls/models/access_list_rules.py
+++ b/netbox_acls/models/access_list_rules.py
@@ -543,22 +543,46 @@ class ACLExtendedRule(ACLRule):
     cache_related_destination_objects.alters_data = True
 
     @property
-    def source_port_ranges_list(self):
-        """
-        Gets the list representation of source port ranges.
-        """
-        return ranges_to_string_list(self.source_port_ranges)
-
-    @property
     def destination_port_ranges_list(self):
         """
-        Gets the list representation of destination port ranges.
+        Return destination port ranges as a list of strings.
+
+        Ranges are formatted as a single port or as an inclusive
+        `"<start>-<end>"` range, e.g. `["22", "80-81", "443"]`.
         """
         return ranges_to_string_list(self.destination_port_ranges)
 
+    @property
+    def source_port_ranges_list(self):
+        """
+        Return source port ranges as a list of strings.
+
+        Ranges are formatted as a single port or as an inclusive
+        `"<start>-<end>"` range, e.g. `["22", "80-81", "443"]`.
+        """
+        return ranges_to_string_list(self.source_port_ranges)
+
+    def get_destination_port_ranges_display(self):
+        """
+        Return destination port ranges as a comma-separated string.
+
+        Example:
+            `"22, 80-81, 443"`
+        """
+        return ", ".join(self.destination_port_ranges_list)
+
+    def get_source_port_ranges_display(self):
+        """
+        Return source port ranges as a comma-separated string.
+
+        Example:
+            `"22, 80-81, 443"`
+        """
+        return ", ".join(self.source_port_ranges_list)
+
     def get_protocol_color(self):
         """
-        Returns the color associated with the protocol of an ACL rule.
+        Return the display color associated with the rule protocol.
         """
         return ACLProtocolChoices.colors.get(self.protocol)
 

--- a/netbox_acls/search.py
+++ b/netbox_acls/search.py
@@ -73,8 +73,8 @@ class ACLExtendedRuleIndex(SearchIndex):
         "protocol",
         "source_type",
         "source",
-        "source_ports",
+        "source_port_ranges",
         "destination",
         "destination_type",
-        "destination_ports",
+        "destination_port_ranges",
     )


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #341

## New Behavior

This PR updates the ACL extended rule search result display to use the correct port range model fields.

Port ranges are now rendered as human-readable, comma-separated values such as `22` or `80-81` instead of raw range objects like `Range(22, 23, '[)')`.

## Contrast to Current Behavior

Currently, the search index references the outdated `source_ports` and `destination_ports` field names. This can cause server errors when ACL extended rules appear in NetBox search results.

In addition, port ranges may be displayed as raw Python/PostgreSQL range objects instead of a readable format.

## Discussion: Benefits and Drawbacks

This change fixes the search result rendering for ACL extended rules and makes the displayed port range values easier to read.

It also aligns the search index with the actual model field names, which should make the code clearer and less error-prone.

The change is backwards-compatible and does not require a database migration. I do not see any drawbacks beyond the small code change needed to format the existing port range fields for display.

## Changes to the Documentation

No user-facing documentation changes are required.

The related model property docstrings were updated to better describe the port range formatting behavior.

## Proposed Release Note Entry

Fixed ACL extended rule search results by using the correct port range fields and displaying port ranges in a human-readable format.

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.