### PR TITLE
Closes #345: Update GitHub Actions and dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,16 @@ jobs:
           fetch-depth: 0
 
       - name: Check Python linting & PEP8 compliance
-        uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
+        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
         with:
-          version: "0.15.6"
+          version: "0.15.12"
           args: "check --output-format=github"
           src: "netbox_acls/"
 
       - name: Check Python formatting
-        uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
+        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
         with:
-          version: "0.15.6"
+          version: "0.15.12"
           args: "format --check --diff"
           src: "netbox_acls/"
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,7 +18,6 @@ permissions:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -26,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -34,7 +33,7 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.7"
+    rev: "v0.15.12"
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 name = "netbox-acls"
 version = "2.0.0"
 requires-python = ">=3.12.0"
-description = "NetBox plugin for plugin for managing Access Control Lists (ACLs)."
+description = "NetBox plugin for managing Access Control Lists (ACLs)."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "Apache-2.0"
 license-files = ["LICENSE.txt"]
@@ -35,9 +35,9 @@ classifiers=[
 [project.optional-dependencies]
 test = [
     "check-manifest==0.51",
-    "pre-commit==4.5.1",
-    "pytest==9.0.2",
-    "ruff==0.15.9",
+    "pre-commit==4.6.0",
+    "pytest==9.0.3",
+    "ruff==0.15.12",
     "yamllint==1.38.0",
 ]
 


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #345

Supersedes #334, #335, #336, #339, and #340.

## New Behavior

Updates developer dependencies and related GitHub Actions to keep the project tooling current.

This includes updating Ruff from `0.15.6` to `0.15.12`, `ruff-action` from `v3.6.1` to `v4.0.0`, and `pypa/gh-action-pypi-publish` to `v1.14.0`. Test dependencies have also been updated, and a small typo in the package description has been fixed.

## Contrast to Current Behavior

The project currently uses slightly older versions of some development dependencies and CI actions. This PR brings them up to date without introducing any intended user-facing behavior changes.

## Discussion: Benefits and Drawbacks

Keeping developer dependencies up to date helps reduce technical debt and ensures that local development and CI tooling stay compatible with current versions. It also helps catch potential issues early and keeps maintenance work manageable.

This change should be backwards-compatible, as it only affects developer tooling, test dependencies, CI actions, and a package description typo. No drawbacks are expected, apart from the usual need to verify that the updated tooling continues to behave as expected.

## Changes to the Documentation

No documentation changes are required for this PR.

## Proposed Release Note Entry

Updated developer dependencies, CI actions, and fixed a typo in the package description.

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.