### PR TITLE
Closes #362: Add NetBox query-count baselines for ACL API list tests

### DIFF
--- a/netbox_acls/tests/query_counts.json
+++ b/netbox_acls/tests/query_counts.json
@@ -1,0 +1,6 @@
+{
+  "accesslist:api_list_objects": 13,
+  "aclassignment:api_list_objects": 18,
+  "aclextendedrule:api_list_objects": 18,
+  "aclstandardrule:api_list_objects": 16
+}


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #362

## New Behavior

Adds query-count baselines for the ACL API list endpoint tests.

The expected query counts are now tracked for:

- AccessList: 13
- ACLAssignment: 18
- ACLExtendedRule: 18
- ACLStandardRule: 16

## Contrast to Current Behavior

Currently, the test suite has no committed query-count baseline for these API list tests.

With this change, NetBox can compare the current query count against the expected baseline.

## Discussion: Benefits and Drawbacks

This helps detect accidental database query regressions in the ACL API endpoints and keeps the plugin aligned with NetBox’s current test expectations.

There is no functional change for users. The only drawback is that the baseline needs to be updated when an intentional query-count change is introduced.

This is backwards-compatible.

## Changes to the Documentation

No documentation changes are needed.

## Proposed Release Note Entry

Added query-count baselines for ACL API list endpoint tests.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `dev` branch.