### PR TITLE
Fixes #358: Prevent ACL renames from bypassing host name/family validation

### DIFF
--- a/netbox_acls/models/access_lists.py
+++ b/netbox_acls/models/access_lists.py
@@ -117,7 +117,7 @@ class AccessList(PrimaryModel):
         # Repeat the critical guards for callers that skip full_clean(), and
         # if family changes without rules, update assignment families atomically.
         with transaction.atomic():
-            original_values = self._get_persisted_values(("type", "family"))
+            original_values = self._get_persisted_values(("type", "family", "name"))
             family_changed = False
 
             if original_values:
@@ -136,6 +136,10 @@ class AccessList(PrimaryModel):
                     # Validate host-level duplicate-name constraints under the *new* family
                     self._validate_host_name_family_conflicts(self.family)
                     family_changed = True
+
+                # NAME rename guard: re-enforce here for callers that skip full_clean().
+                if original_values["name"] != self.name:
+                    self._validate_host_name_family_conflicts(self.family)
 
             rv = super().save(*args, **kwargs)
 

--- a/netbox_acls/tests/models/test_accesslists.py
+++ b/netbox_acls/tests/models/test_accesslists.py
@@ -301,3 +301,33 @@ class TestAccessList(BaseTestCase):
         acl_v6.family = ACLFamilyChoices.FAMILY_IPV4
         with self.assertRaises(ValidationError):
             acl_v6.full_clean()
+
+    def test_accesslist_save_blocks_host_name_rename_collision(self):
+        """#358: save() must re-enforce the host name/family guard for full_clean()-skipping callers."""
+        acl_a = AccessList.objects.create(
+            name="ACL1",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        acl_b = AccessList.objects.create(
+            name="ACL2",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        ACLAssignment.objects.create(
+            access_list=acl_a,
+            assigned_object=self.device1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+        )
+        ACLAssignment.objects.create(
+            access_list=acl_b,
+            assigned_object=self.device1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+        )
+
+        # Rename acl_b to collide with acl_a on the same host + family, bypassing full_clean()
+        acl_b.name = "ACL1"
+        with self.assertRaises(ValidationError):
+            acl_b.save()


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #358

## New Behavior

This PR updates `AccessList.save()` to also track the persisted ACL name, in addition to type and family.

When an Access List is renamed, `save()` now validates host name/family conflicts the same way `clean()` does. This prevents duplicate ACL name + family assignments on the same host, even when `full_clean()` is bypassed.

A regression test is included.

## Contrast to Current Behavior

Currently, `AccessList.save()` re-checks type and family changes, but it does not check whether the ACL name changed.

That means callers using `save()` directly can rename an ACL in a way that creates a host name/family conflict which the UI/`clean()` path would normally reject.

With this change, rename-only updates are validated consistently in both paths.

## Discussion: Benefits and Drawbacks

This closes a small validation gap and keeps the model safeguards consistent for callers that do not run `full_clean()` before saving.

The change should be backwards-compatible for valid data. The only expected behavior change is that direct `save()` calls which would create an invalid host name/family conflict now raise a validation error instead of allowing the invalid state.

There are no known drawbacks beyond the additional validation check when an existing Access List is saved.

## Changes to the Documentation

No documentation changes are needed. This is a bug fix for existing validation behavior.

## Proposed Release Note Entry

Fixed `AccessList.save()` allowing ACL renames to bypass host name/family uniqueness validation when `full_clean()` is not called.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `dev` branch.