### PR TITLE
Fixes #359: Remove stale device and action entries from AccessList table

### DIFF
--- a/netbox_acls/tables.py
+++ b/netbox_acls/tables.py
@@ -29,9 +29,6 @@ class AccessListTable(PrimaryModelTable):
     name = tables.Column(
         linkify=True,
     )
-    device = tables.Column(
-        linkify=True,
-    )
     type = columns.ChoiceFieldColumn()
     family = columns.ChoiceFieldColumn()
     default_action = columns.ChoiceFieldColumn()
@@ -55,7 +52,6 @@ class AccessListTable(PrimaryModelTable):
             "description",
             "comments",
             "tags",
-            "action",
         )
         default_columns = (
             "name",

--- a/netbox_acls/tests/tables/test_accesslists.py
+++ b/netbox_acls/tests/tables/test_accesslists.py
@@ -1,0 +1,12 @@
+from ...tables import AccessListTable
+
+try:
+    from utilities.testing import TableTestCases
+except ImportError:  # NetBox < ~4.5.8 (aci's shim cites 4.5.10) ships no table-test base
+    TableTestCases = None
+
+
+if TableTestCases is not None:
+
+    class AccessListTableTestCase(TableTestCases.StandardTableTestCase):
+        table = AccessListTable


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #359

## New Behavior

Removes the unused `device` column from the AccessList table and removes the stale `action` entry from the table fields list.

The AccessList model does not have a direct `device` field, and the action field is represented by `default_action`.

## Contrast to Current Behavior

Previously, the AccessList table configuration offered a **Device** column even though it did not map to a valid AccessList field. When selected, it rendered as an empty value.

The table fields list also included `action`, which does not correspond to the actual AccessList field name.

With this change, the table definition only exposes valid/intended columns.

## Discussion: Benefits and Drawbacks

This keeps the AccessList table configuration cleaner and avoids exposing columns that do not provide useful information.

The change should be backwards-compatible, as both removed entries were unused/stale and not part of the default table display. I do not see any drawbacks unless either column was intended for a future implementation.

## Changes to the Documentation

No documentation changes are needed.

## Proposed Release Note Entry

Removed stale `device` and `action` entries from the AccessList table definition.

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.