### PR TITLE
Fixes #360: Fix Extended Rule bulk-edit ACL type filter

### DIFF
--- a/netbox_acls/forms/bulk_edit.py
+++ b/netbox_acls/forms/bulk_edit.py
@@ -249,7 +249,7 @@ class ACLExtendedRuleBulkEditForm(PrimaryModelBulkEditForm):
     access_list = DynamicModelChoiceField(
         queryset=AccessList.objects.all(),
         query_params={
-            "type": ACLTypeChoices.TYPE_STANDARD,
+            "type": ACLTypeChoices.TYPE_EXTENDED,
         },
         required=False,
         label=_("Access List"),

--- a/netbox_acls/tests/forms/test_extendedrules.py
+++ b/netbox_acls/tests/forms/test_extendedrules.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+
+from ...choices import ACLTypeChoices
+from ...forms import ACLExtendedRuleBulkEditForm
+
+
+class ACLExtendedRuleFormTestCase(TestCase):
+    """Form tests for ACLExtendedRule forms."""
+
+    def test_bulkedit_access_list_filtered_to_extended(self):
+        """#360: the extended bulk-edit Access List picker must filter to Extended ACLs."""
+        form = ACLExtendedRuleBulkEditForm()
+        self.assertEqual(
+            form.fields["access_list"].query_params,
+            {"type": ACLTypeChoices.TYPE_EXTENDED},
+        )

--- a/netbox_acls/tests/forms/test_standardrules.py
+++ b/netbox_acls/tests/forms/test_standardrules.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+
+from ...choices import ACLTypeChoices
+from ...forms import ACLStandardRuleBulkEditForm
+
+
+class ACLStandardRuleFormTestCase(TestCase):
+    """Form tests for ACLStandardRule forms."""
+
+    def test_bulkedit_access_list_filtered_to_standard(self):
+        """Guard the standard bulk-edit picker the extended form (#360) was copied from."""
+        form = ACLStandardRuleBulkEditForm()
+        self.assertEqual(
+            form.fields["access_list"].query_params,
+            {"type": ACLTypeChoices.TYPE_STANDARD},
+        )


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #360

## New Behavior

This PR updates the `ACLExtendedRuleBulkEditForm` access list filter to use `ACLTypeChoices.TYPE_EXTENDED` instead of `ACLTypeChoices.TYPE_STANDARD`.

It also adds tests for both the standard and extended rule bulk-edit forms to make sure each form only offers the correct ACL type.

## Contrast to Current Behavior

Currently, the extended rule bulk-edit form filters the **Access List** selector to Standard ACLs. This means Extended ACLs are not available as valid targets when bulk-editing extended rules.

With this change, the extended rule bulk-edit form correctly lists Extended ACLs, while the standard rule bulk-edit form continues to list Standard ACLs.

## Discussion: Benefits and Drawbacks

This fixes a small copy-paste issue in the extended rule bulk-edit form and makes the UI consistent with the model constraints.

The benefit is that users can now bulk-edit extended rules and reassign them to valid Extended ACLs as expected. The added tests should also help prevent this from regressing in the future.

I do not see any drawbacks. The change is backwards-compatible because it only corrects the queryset filter for the existing form field.

## Changes to the Documentation

No documentation changes are needed. This is a bug fix for the existing bulk-edit behavior.

## Proposed Release Note Entry

Fixed the Extended ACL rule bulk-edit form to list Extended ACLs instead of Standard ACLs in the Access List selector.

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.