### PR TITLE
Fixes #361: Remove stale sequence field reference from Extended Rule bulk-edit form

### DIFF
--- a/netbox_acls/forms/bulk_edit.py
+++ b/netbox_acls/forms/bulk_edit.py
@@ -322,7 +322,6 @@ class ACLExtendedRuleBulkEditForm(PrimaryModelBulkEditForm):
             name=_("Access List Details"),
         ),
         FieldSet(
-            "sequence",
             "action",
             name=_("Rule Definition"),
         ),

--- a/netbox_acls/tests/forms/test_extendedrules.py
+++ b/netbox_acls/tests/forms/test_extendedrules.py
@@ -14,3 +14,15 @@ class ACLExtendedRuleFormTestCase(TestCase):
             form.fields["access_list"].query_params,
             {"type": ACLTypeChoices.TYPE_EXTENDED},
         )
+
+    def test_bulkedit_fieldset_fields_all_defined(self):
+        """#361: every field named in the extended bulk-edit fieldsets must exist on the form."""
+        form = ACLExtendedRuleBulkEditForm()
+        for fieldset in form.fieldsets:
+            for item in fieldset.items:
+                if isinstance(item, str):
+                    self.assertIn(
+                        item,
+                        form.fields,
+                        msg=f"Fieldset '{fieldset.name}' references undefined field '{item}'",
+                    )


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #361

## New Behavior

Removes the stale `sequence` reference from the `ACLExtendedRuleBulkEditForm` **Rule Definition** fieldset.

The fieldset now only references fields that are actually defined on the form. This PR also adds a test to make sure bulk-edit form fieldsets do not reference undefined fields.

## Contrast to Current Behavior

Currently, `ACLExtendedRuleBulkEditForm.fieldsets` references `sequence`, but the form does not define a `sequence` field.

NetBox silently ignores fieldset entries that are not present in `form.fields`, so this does not currently cause a visible error. However, the reference is dead code and makes the form definition inconsistent.

## Discussion: Benefits and Drawbacks

This keeps the extended rule bulk-edit form definition consistent with the fields that are actually available on the form.

The added test should also help catch similar fieldset inconsistencies in the future.

There are no known drawbacks. This should be backwards-compatible because `sequence` was not rendered or editable in the current bulk-edit form.

## Changes to the Documentation

No documentation changes are needed, as this is a small internal cleanup and does not change user-facing functionality.

## Proposed Release Note Entry

Removed a stale `sequence` field reference from the extended ACL rule bulk-edit form fieldset.

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.