### PR TITLE
Fixes #377: Honor update_fields in AccessList and ACLAssignment save

### DIFF
--- a/netbox_acls/models/access_lists.py
+++ b/netbox_acls/models/access_lists.py
@@ -89,66 +89,73 @@ class AccessList(PrimaryModel):
         """
         super().clean()
 
-        if self.pk:
-            original_values = self._get_persisted_values(("name", "type", "family"))
+        original_values = self._get_persisted_values(("name", "type", "family"))
 
+        if original_values:
             # TYPE guard: if any rules exist, forbid changing type
             if original_values["type"] != self.type and self._has_rules():
                 raise ValidationError({"type": _("This ACL has ACL rules associated, CANNOT change ACL type.")})
 
+            family_changed = original_values["family"] != self.family
+
             # FAMILY guard
-            if original_values["family"] != self.family:
+            if family_changed:
                 if self._has_rules():
                     # If any rules exist, forbid changing family
                     raise ValidationError({"family": _("This ACL has ACL rules associated, CANNOT change ACL family.")})
                 # Validate family changes for interface assignments
                 self._validate_interface_family_conflicts(self.family)
                 # Validate host-level duplicate-name constraints under the *new* family
-                self._validate_host_name_family_conflicts(self.family)
+                self._validate_host_name_family_conflicts(self.family, self.name)
 
             # NAME rename guard
-            if original_values["name"] != self.name:
-                self._validate_host_name_family_conflicts(self.family)
+            if not family_changed and original_values["name"] != self.name:
+                self._validate_host_name_family_conflicts(self.family, self.name)
 
     def save(self, *args, **kwargs):
         """
         Override the model's save method for custom validation.
         """
+        # update_fields may be any iterable, including a one-shot generator
+        update_fields = kwargs.get("update_fields")
+        if update_fields is not None:
+            update_fields = frozenset(update_fields)
+            kwargs["update_fields"] = update_fields
+
         # Repeat the critical guards for callers that skip full_clean(), and
         # if family changes without rules, update assignment families atomically.
         with transaction.atomic():
             original_values = self._get_persisted_values(("type", "family", "name"))
+            target_values = self._get_target_values(original_values, update_fields)
             family_changed = False
 
             if original_values:
                 # Re-enforce TYPE guard
-                if original_values["type"] != self.type and self._has_rules():
+                if original_values["type"] != target_values["type"] and self._has_rules():
                     raise ValidationError({"type": _("This ACL has ACL rules associated, CANNOT change ACL type.")})
 
                 # FAMILY change preflight
-                if original_values["family"] != self.family:
+                if original_values["family"] != target_values["family"]:
                     if self._has_rules():
                         raise ValidationError(
                             {"family": _("This ACL has ACL rules associated, CANNOT change ACL family.")}
                         )
                     # Validate family changes for interface assignments
-                    self._validate_interface_family_conflicts(self.family)
+                    self._validate_interface_family_conflicts(target_values["family"])
                     # Validate host-level duplicate-name constraints under the *new* family
-                    self._validate_host_name_family_conflicts(self.family)
+                    self._validate_host_name_family_conflicts(target_values["family"], target_values["name"])
                     family_changed = True
 
                 # NAME rename guard: re-enforce here for callers that skip full_clean().
-                if original_values["name"] != self.name:
-                    self._validate_host_name_family_conflicts(self.family)
+                if not family_changed and original_values["name"] != target_values["name"]:
+                    self._validate_host_name_family_conflicts(target_values["family"], target_values["name"])
 
             rv = super().save(*args, **kwargs)
 
             # If family changed (and we passed preflight), mirror it on assignments now
             if family_changed:
                 # Sync denormalized family on *all* assignments (host + interface)
-                qs = self.aclassignments.select_for_update()
-                if qs.exists():
-                    qs.update(family=self.family)
+                self.aclassignments.update(family=target_values["family"])
 
             return rv
 
@@ -165,6 +172,15 @@ class AccessList(PrimaryModel):
         if not self.pk:
             return {}
         return type(self).objects.filter(pk=self.pk).values(*fields).first() or {}
+
+    def _get_target_values(self, original_values: dict, update_fields: frozenset[str] | None) -> dict:
+        """
+        Returns the values this save will persist, honoring update_fields.
+        """
+        return {
+            field: getattr(self, field) if update_fields is None or field in update_fields else value
+            for field, value in original_values.items()
+        }
 
     def _validate_interface_family_conflicts(self, target_family: str) -> None:
         """
@@ -205,9 +221,9 @@ class AccessList(PrimaryModel):
                         },
                     )
 
-    def _validate_host_name_family_conflicts(self, target_family: str):
+    def _validate_host_name_family_conflicts(self, target_family: str, target_name: str) -> None:
         """
-        Validates that there are no conflicting host assignments for the given target family.
+        Validates that there are no conflicting host assignments for the given target name and family.
 
         This method checks if there are any Access Control List (ACL) assignments with the
         same name, assigned object type, assigned object ID, and target family that conflict
@@ -218,7 +234,7 @@ class AccessList(PrimaryModel):
         host_assignments = self.aclassignments.filter(direction=ACLAssignmentDirectionChoices.DIRECTION_NONE)
         for host_assignment in host_assignments:
             conflicting_host_assignments = ACLAssignment.objects.filter(
-                access_list__name=self.name,
+                access_list__name=target_name,
                 assigned_object_type=host_assignment.assigned_object_type,
                 assigned_object_id=host_assignment.assigned_object_id,
                 family=target_family,
@@ -231,7 +247,7 @@ class AccessList(PrimaryModel):
                             "An {family} Access List with the name "
                             "'{access_list}' is already assigned to the "
                             "{assigned_object} '{assigned_object_name}'.".format(
-                                access_list=self.name,
+                                access_list=target_name,
                                 assigned_object=assigned_object_model._meta.verbose_name,
                                 assigned_object_name=host_assignment.assigned_object.name,
                                 # TODO: Fix formating!
@@ -479,6 +495,15 @@ class ACLAssignment(OwnerMixin, NetBoxModel):
         # Therefore, the direction field is set to "none" in these cases.
         if self.assigned_object_type in host_assigned_object_types:
             self.direction = ACLAssignmentDirectionChoices.DIRECTION_NONE
+
+        # family is a denormalized copy of access_list.family, so persist them together.
+        # direction is derived only for host targets, so it is never promoted here.
+        update_fields = kwargs.get("update_fields")
+        if update_fields is not None:
+            update_fields = frozenset(update_fields)
+            if update_fields & {"access_list", "access_list_id"}:
+                update_fields |= {"family"}
+            kwargs["update_fields"] = update_fields
 
         super().save(*args, **kwargs)
 

--- a/netbox_acls/tests/models/test_accesslists.py
+++ b/netbox_acls/tests/models/test_accesslists.py
@@ -331,3 +331,158 @@ class TestAccessList(BaseTestCase):
         acl_b.name = "ACL1"
         with self.assertRaises(ValidationError):
             acl_b.save()
+
+    def _create_host_assigned_acl_pair(self, family_b=ACLFamilyChoices.FAMILY_IPV4):
+        """
+        Creates ACL1 (IPv4) and ACL2 (in the given family), both assigned to the same host.
+        """
+        acl_a = AccessList.objects.create(
+            name="ACL1",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        acl_b = AccessList.objects.create(
+            name="ACL2",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=family_b,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        for access_list in (acl_a, acl_b):
+            ACLAssignment.objects.create(
+                access_list=access_list,
+                assigned_object=self.device1,
+                direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+            )
+        return acl_a, acl_b
+
+    def test_accesslist_save_update_fields_ignores_unsaved_name(self):
+        """
+        Test that a colliding name left out of update_fields does not trigger the rename guard.
+        """
+        acl_a, acl_b = self._create_host_assigned_acl_pair()
+
+        acl_b.name = acl_a.name
+        acl_b.comments = "Updated"
+        acl_b.save(update_fields={"comments"})
+
+        acl_b.refresh_from_db()
+        self.assertEqual(acl_b.name, "ACL2")
+        self.assertEqual(acl_b.comments, "Updated")
+
+    def test_accesslist_save_update_fields_enforces_saved_name(self):
+        """
+        Test that a colliding name included in update_fields is still rejected.
+        """
+        acl_a, acl_b = self._create_host_assigned_acl_pair()
+
+        acl_b.name = acl_a.name
+        with self.assertRaises(ValidationError):
+            acl_b.save(update_fields={"name"})
+
+    def test_accesslist_save_update_fields_ignores_unsaved_family(self):
+        """
+        Test that a family change left out of update_fields does not re-sync the assignments.
+        """
+        acl = AccessList.objects.create(
+            name="ACL1",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        assignment = ACLAssignment.objects.create(
+            access_list=acl,
+            assigned_object=self.device1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+        )
+
+        acl.family = ACLFamilyChoices.FAMILY_IPV6
+        acl.comments = "Updated"
+        acl.save(update_fields={"comments"})
+
+        acl.refresh_from_db()
+        assignment.refresh_from_db()
+        self.assertEqual(acl.comments, "Updated")
+        self.assertEqual(acl.family, ACLFamilyChoices.FAMILY_IPV4)
+        self.assertEqual(assignment.family, ACLFamilyChoices.FAMILY_IPV4)
+
+    def test_accesslist_save_update_fields_syncs_saved_family(self):
+        """
+        Test that a family change included in update_fields re-syncs the assignments.
+        """
+        acl = AccessList.objects.create(
+            name="ACL1",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        assignment = ACLAssignment.objects.create(
+            access_list=acl,
+            assigned_object=self.device1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+        )
+
+        acl.family = ACLFamilyChoices.FAMILY_IPV6
+        acl.save(update_fields={"family"})
+
+        acl.refresh_from_db()
+        assignment.refresh_from_db()
+        self.assertEqual(acl.family, ACLFamilyChoices.FAMILY_IPV6)
+        self.assertEqual(assignment.family, ACLFamilyChoices.FAMILY_IPV6)
+
+    def test_accesslist_save_update_fields_ignores_unsaved_type(self):
+        """
+        Test that a type change left out of update_fields does not trigger the rules guard.
+        """
+        acl = AccessList.objects.create(
+            name="ACL1",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        ACLStandardRule.objects.create(
+            access_list=acl,
+            sequence=10,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+        )
+
+        acl.type = ACLTypeChoices.TYPE_EXTENDED
+        acl.comments = "Updated"
+        acl.save(update_fields={"comments"})
+
+        acl.refresh_from_db()
+        self.assertEqual(acl.type, ACLTypeChoices.TYPE_STANDARD)
+        self.assertEqual(acl.comments, "Updated")
+
+    def test_accesslist_save_update_fields_validates_name_against_persisted_family(self):
+        """
+        Test that a rename is validated against the stored family, not an unsaved one.
+        """
+        acl_a, acl_b = self._create_host_assigned_acl_pair(family_b=ACLFamilyChoices.FAMILY_IPV6)
+
+        # ACL1 is IPv4 and ACL2 is IPv6, so the rename is allowed
+        acl_b.family = ACLFamilyChoices.FAMILY_IPV4
+        acl_b.name = acl_a.name
+        acl_b.save(update_fields={"name"})
+
+        acl_b.refresh_from_db()
+        self.assertEqual(acl_b.name, "ACL1")
+        self.assertEqual(acl_b.family, ACLFamilyChoices.FAMILY_IPV6)
+        self.assertEqual(
+            ACLAssignment.objects.get(access_list=acl_b).family,
+            ACLFamilyChoices.FAMILY_IPV6,
+        )
+
+    def test_accesslist_clean_tolerates_missing_row_for_pk(self):
+        """
+        Test that clean() skips the change guards when the pk is set but the row is gone.
+        """
+        acl = AccessList.objects.create(
+            name="ACL-GHOST",
+            **self.common_acl_params,
+        )
+        # Delete through the queryset so the in-memory instance keeps its pk
+        AccessList.objects.filter(pk=acl.pk).delete()
+
+        acl.full_clean()

--- a/netbox_acls/tests/models/test_aclassignments.py
+++ b/netbox_acls/tests/models/test_aclassignments.py
@@ -405,3 +405,95 @@ class TestACLAssignment(BaseTestCase):
             direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
         )
         self.assertEqual(assignments.count(), 2)
+
+    def test_acl_assignment_save_update_fields_keeps_family_in_sync(self):
+        """
+        Test that a partial save writes the derived family with the Access List.
+        """
+        assignment = ACLAssignment.objects.create(
+            access_list=self.acl_standard1,
+            assigned_object=self.device_interface1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+        self.assertEqual(assignment.family, ACLFamilyChoices.FAMILY_IPV4)
+
+        assignment.access_list = self.acl_standard_v6
+        assignment.save(update_fields={"access_list"})
+
+        assignment.refresh_from_db()
+        self.assertEqual(assignment.access_list_id, self.acl_standard_v6.pk)
+        self.assertEqual(assignment.family, ACLFamilyChoices.FAMILY_IPV6)
+
+    def test_acl_assignment_save_update_fields_accepts_access_list_attname(self):
+        """
+        Test that the derived family is written when update_fields names the FK attname.
+        """
+        assignment = ACLAssignment.objects.create(
+            access_list=self.acl_standard1,
+            assigned_object=self.device_interface1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+
+        assignment.access_list = self.acl_standard_v6
+        assignment.save(update_fields={"access_list_id"})
+
+        assignment.refresh_from_db()
+        self.assertEqual(assignment.access_list_id, self.acl_standard_v6.pk)
+        self.assertEqual(assignment.family, ACLFamilyChoices.FAMILY_IPV6)
+
+    def test_acl_assignment_save_empty_update_fields_is_a_noop(self):
+        """
+        Test that an empty update_fields performs no write.
+        """
+        assignment = ACLAssignment.objects.create(
+            access_list=self.acl_standard1,
+            assigned_object=self.device_interface1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+
+        assignment.access_list = self.acl_standard_v6
+        assignment.save(update_fields=[])
+
+        assignment.refresh_from_db()
+        self.assertEqual(assignment.access_list_id, self.acl_standard1.pk)
+        self.assertEqual(assignment.family, ACLFamilyChoices.FAMILY_IPV4)
+
+    def test_acl_assignment_save_update_fields_ignores_unsaved_access_list(self):
+        """
+        Test that an unsaved Access List is not persisted through the derived family.
+        """
+        assignment = ACLAssignment.objects.create(
+            access_list=self.acl_standard1,
+            assigned_object=self.device_interface1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+
+        assignment.access_list = self.acl_standard_v6
+        assignment.comments = "Updated"
+        assignment.save(update_fields={"comments"})
+
+        assignment.refresh_from_db()
+        self.assertEqual(assignment.access_list, self.acl_standard1)
+        self.assertEqual(assignment.family, ACLFamilyChoices.FAMILY_IPV4)
+        self.assertEqual(assignment.comments, "Updated")
+
+    def test_acl_assignment_save_update_fields_ignores_unsaved_direction(self):
+        """
+        Test that a partial save leaves an unsaved direction unwritten.
+        """
+        assignment = ACLAssignment.objects.create(
+            access_list=self.acl_standard1,
+            assigned_object=self.device_interface1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+
+        assignment.direction = ACLAssignmentDirectionChoices.DIRECTION_EGRESS
+        assignment.comments = "Updated"
+        assignment.save(update_fields={"comments"})
+
+        assignment.refresh_from_db()
+        self.assertEqual(
+            assignment.direction,
+            ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+        self.assertEqual(assignment.comments, "Updated")


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #377

## New Behavior

Partial updates to an Access List now only consider the fields included in `update_fields`.

Unrelated unsaved changes to the name, family, or type are ignored. When an ACL Assignment explicitly changes its Access List, its stored family is kept in sync.

Regression tests have been added for the affected partial-save scenarios.

## Contrast to Current Behavior

Previously, an unrelated partial update could be rejected because of other unsaved changes on the Access List. An unsaved family change could also update related assignments even though the family itself was not saved.

The updated behavior respects the fields selected for the save and avoids these unexpected side effects.

## Discussion: Benefits and Drawbacks

This makes partial updates more predictable and prevents unrelated unsaved changes from causing validation errors or inconsistent assignment data.

Regular saves continue to behave as before, and the change is backwards-compatible. No known drawbacks are expected.

## Changes to the Documentation

No documentation changes are required, as this corrects internal save behavior and is covered by regression tests.

## Proposed Release Note Entry

Fix partial Access List updates being affected by unrelated unsaved changes and keep ACL Assignment families synchronized when their Access List changes.

## Double Check

* [x] I have explained my PR according to the information in the comments
 or in a linked issue.
* [x] My PR targets the `dev` branch.