### PR TITLE
Fixes #384: Correct Access List name filtering for Assignments and Rules

### DIFF
--- a/netbox_acls/filtersets.py
+++ b/netbox_acls/filtersets.py
@@ -70,6 +70,7 @@ class ACLAssignmentFilterSet(OwnerFilterMixin, NetBoxModelFilterSet):
 
     # Access List
     access_list = django_filters.ModelMultipleChoiceFilter(
+        field_name="access_list__name",
         queryset=AccessList.objects.all(),
         to_field_name="name",
         label=_("Access List (name)"),
@@ -215,6 +216,7 @@ class ACLStandardRuleFilterSet(PrimaryModelFilterSet):
 
     # Access List
     access_list = django_filters.ModelMultipleChoiceFilter(
+        field_name="access_list__name",
         queryset=AccessList.objects.all(),
         to_field_name="name",
         label=_("Access List (name)"),
@@ -318,6 +320,7 @@ class ACLExtendedRuleFilterSet(PrimaryModelFilterSet):
 
     # Access List
     access_list = django_filters.ModelMultipleChoiceFilter(
+        field_name="access_list__name",
         queryset=AccessList.objects.filter(type=ACLTypeChoices.TYPE_EXTENDED),
         to_field_name="name",
         label=_("Access List (name)"),


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #384

## New Behavior

Updates the access list name filters for assignments, standard rules, and extended rules to explicitly query `access_list__name`.

## Contrast to Current Behavior

Previously, filtering with the `access_list` parameter attempted to compare the provided name with the access list ID, causing a `ValueError`.

Filtering by access list name now works as intended. The existing `access_list_id` filters remain unchanged.

## Discussion: Benefits and Drawbacks

This fixes the affected filters and brings them in line with the other name-based filters in the same module.

The change is backwards-compatible, and no drawbacks are expected. Automated filterset tests will be added separately as part of a dedicated issue and PR.

## Changes to the Documentation

No documentation changes are required. This corrects the behavior of existing filters.

## Proposed Release Note Entry

Fixed filtering assignments and rules by access list name.

## Double Check

- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR targets `feature` (next minor release) or `main` (fix to the current release).