### PR TITLE
Fixes #399: Re-record query counts for 4.6.8

### DIFF
--- a/netbox_acls/tests/query_counts.json
+++ b/netbox_acls/tests/query_counts.json
@@ -1,6 +1,6 @@
 {
-  "accesslist:api_list_objects": 13,
-  "aclassignment:api_list_objects": 18,
-  "aclextendedrule:api_list_objects": 18,
-  "aclstandardrule:api_list_objects": 16
+  "accesslist:api_list_objects": 12,
+  "aclassignment:api_list_objects": 17,
+  "aclextendedrule:api_list_objects": 17,
+  "aclstandardrule:api_list_objects": 15
 }


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #399

## New Behavior

Updates the four API list-view query-count baselines to reflect NetBox 4.6.8, which performs one fewer query due to improved custom field lookup caching.

## Contrast to Current Behavior

The existing baselines were recorded against NetBox 4.6.7. After the `v4.6` image moved to 4.6.8, the query-count tests began failing even though no plugin code had changed.

## Discussion: Benefits and Drawbacks

This change aligns the expected query counts with the current NetBox 4.6 behavior and restores a passing CI build. It does not change the plugin's runtime behavior and is fully backwards-compatible.

The query-count baselines remain sensitive to future upstream performance improvements and may need to be updated again when NetBox changes its query behavior.

## Changes to the Documentation

No documentation changes are required.

## Proposed Release Note Entry

Updated API list-view query-count baselines for NetBox 4.6.8.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets `main` (fix to the current release).