### PR TITLE
Fixes #396: Drop stale name from bulk-edit form

### DIFF
--- a/netbox_acls/forms/bulk_edit.py
+++ b/netbox_acls/forms/bulk_edit.py
@@ -61,7 +61,6 @@ class AccessListBulkEditForm(PrimaryModelBulkEditForm):
     model = AccessList
     fieldsets = (
         FieldSet(
-            "name",
             "type",
             "family",
             "default_action",


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #396

## New Behavior

Removes the undefined `name` entry from the Access List bulk-edit form fieldset, keeping the fieldset aligned with the fields provided by `AccessListBulkEditForm`.

## Contrast to Current Behavior

The fieldset currently references `name`, although the bulk-edit form does not define that field. NetBox silently ignores the entry, so it renders nothing and leaves the form configuration inconsistent.

## Discussion: Benefits and Drawbacks

This removes a misleading fieldset entry and makes the form configuration accurately reflect the available bulk-edit fields.

Access List names remain intentionally unavailable for bulk editing because their uniqueness depends on the assigned host and address family. The change is backwards-compatible and does not remove any field currently available to users.

## Changes to the Documentation

No documentation changes are required because this only corrects the internal bulk-edit form configuration.

## Proposed Release Note Entry

Fixed the Access List bulk-edit fieldset referencing an undefined `name` field.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets `main` (fix to the current release).