### PR TITLE
Closes #387: Add view test coverage for all ACL models

### DIFF
--- a/netbox_acls/tests/query_counts.json
+++ b/netbox_acls/tests/query_counts.json
@@ -1,6 +1,10 @@
 {
   "accesslist:api_list_objects": 12,
+  "accesslist:list_objects_with_permission": 18,
   "aclassignment:api_list_objects": 17,
+  "aclassignment:list_objects_with_permission": 21,
   "aclextendedrule:api_list_objects": 17,
-  "aclstandardrule:api_list_objects": 15
+  "aclextendedrule:list_objects_with_permission": 27,
+  "aclstandardrule:api_list_objects": 15,
+  "aclstandardrule:list_objects_with_permission": 23
 }

--- a/netbox_acls/tests/views/base.py
+++ b/netbox_acls/tests/views/base.py
@@ -1,0 +1,128 @@
+"""
+Shared bases and fixtures for the plugin's view tests.
+"""
+
+from netaddr import IPNetwork
+
+from ipam.models import RIR, Aggregate, IPAddress, IPRange, Prefix
+from utilities.testing import ViewTestCases
+
+__all__ = (
+    "ACLRuleSequenceTestsMixin",
+    "PluginTestCases",
+    "PluginViewTestCase",
+    "build_ipam_objects",
+)
+
+
+class PluginViewTestCase:
+    """
+    Resolve plugin view URLs.
+
+    The shared helper builds "<app_label>:<model>_<action>" and omits the
+    "plugins" namespace every plugin URL is registered under.
+    """
+
+    def _get_base_url(self):
+        return f"plugins:{super()._get_base_url()}"
+
+
+class PluginTestCases:
+    """
+    Composites live nested in this container, never at module level. A composite
+    inherits real test methods but declares no model, so the runner would collect
+    it and every inherited test would error on the missing model.
+    """
+
+    class ObjectViewTestCase(
+        PluginViewTestCase,
+        ViewTestCases.GetObjectViewTestCase,
+        ViewTestCases.GetObjectChangelogViewTestCase,
+        ViewTestCases.CreateObjectViewTestCase,
+        ViewTestCases.EditObjectViewTestCase,
+        ViewTestCases.DeleteObjectViewTestCase,
+        ViewTestCases.ListObjectsViewTestCase,
+        ViewTestCases.BulkEditObjectsViewTestCase,
+        ViewTestCases.BulkDeleteObjectsViewTestCase,
+    ):
+        """
+        Every standard object view except bulk import, which the plugin has no
+        import forms for yet. PluginViewTestCase stays first, so its namespace
+        override wins.
+        """
+
+        maxDiff = None
+
+
+class ACLRuleSequenceTestsMixin:
+    """
+    Cover the automatic sequence assignment on a rule's add and edit views.
+
+    The host test case must declare ``add_permission`` and ``change_permission``. These
+    tests grant them one at a time rather than through ``user_permissions``, which is
+    granted in ``setUp``: the inherited ``test_*_without_permission`` cases assert a 403,
+    and a standing add or change permission turns that into a 200.
+
+    Both rule fixtures seed sequences 10 through 50, so the next one is 60. The mixin is a
+    plain class, not a test case, so the runner never collects it on its own.
+    """
+
+    add_permission = None
+    change_permission = None
+    expected_next_sequence = 60
+
+    def _get_form(self, action, permission, instance=None, query=""):
+        self.add_permissions(permission)
+        response = self.client.get(f"{self._get_url(action, instance)}{query}")
+        self.assertHttpStatus(response, 200)
+        return response.context["form"]
+
+    def test_sequence_prefilled_from_access_list(self):
+        """Test that the add form pre-populates and displays the next sequence."""
+        form = self._get_form(
+            "add",
+            self.add_permission,
+            query=f"?access_list={self.access_list.pk}",
+        )
+        self.assertEqual(form.instance.sequence, self.expected_next_sequence)
+        self.assertEqual(form["sequence"].value(), self.expected_next_sequence)
+
+    def test_explicit_sequence_is_preserved(self):
+        """Test that a supplied sequence reaches the form instead of being replaced."""
+        form = self._get_form(
+            "add",
+            self.add_permission,
+            query=f"?access_list={self.access_list.pk}&sequence=99",
+        )
+        self.assertIsNone(form.instance.sequence)
+        # normalize_querydict yields strings, and initial wins over the instance.
+        self.assertEqual(form["sequence"].value(), "99")
+
+    def test_sequence_not_assigned_without_access_list(self):
+        """Test that adding a rule with no access list chosen leaves the sequence empty."""
+        form = self._get_form("add", self.add_permission)
+        self.assertIsNone(form.instance.sequence)
+
+    def test_non_numeric_access_list_is_ignored(self):
+        """Test that a malformed access list id is ignored rather than raising."""
+        form = self._get_form("add", self.add_permission, query="?access_list=notanumber")
+        self.assertIsNone(form.instance.sequence)
+
+    def test_sequence_untouched_when_editing(self):
+        """Test that editing an existing rule does not recompute its sequence."""
+        rule = self.model.objects.filter(access_list=self.access_list).earliest("sequence")
+        form = self._get_form("edit", self.change_permission, instance=rule)
+        self.assertEqual(form.instance.sequence, rule.sequence)
+
+
+def build_ipam_objects():
+    """Create one of each source and destination type an ACL rule accepts."""
+    rir = RIR.objects.create(name="RIR 1", slug="rir-1")
+    aggregate = Aggregate.objects.create(prefix=IPNetwork("10.0.0.0/8"), rir=rir)
+    prefix = Prefix.objects.create(prefix=IPNetwork("10.1.0.0/16"))
+    ip_address = IPAddress.objects.create(address=IPNetwork("10.0.0.1/24"))
+    ip_range = IPRange.objects.create(
+        start_address=IPNetwork("10.0.1.1/24"),
+        end_address=IPNetwork("10.0.1.254/24"),
+    )
+    return aggregate, prefix, ip_address, ip_range

--- a/netbox_acls/tests/views/test_accesslists.py
+++ b/netbox_acls/tests/views/test_accesslists.py
@@ -1,0 +1,134 @@
+from utilities.testing import create_tags
+
+from ...choices import (
+    ACLActionChoices,
+    ACLFamilyChoices,
+    ACLRuleActionChoices,
+    ACLTypeChoices,
+)
+from ...models import AccessList, ACLExtendedRule, ACLStandardRule
+from ...tables import ACLExtendedRuleTable, ACLStandardRuleTable
+from .base import PluginTestCases
+
+
+class AccessListViewTestCase(PluginTestCases.ObjectViewTestCase):
+    """View tests for AccessList."""
+
+    model = AccessList
+
+    @classmethod
+    def setUpTestData(cls):
+        AccessList.objects.bulk_create(
+            (
+                AccessList(
+                    name="testacl1",
+                    type=ACLTypeChoices.TYPE_STANDARD,
+                    family=ACLFamilyChoices.FAMILY_IPV4,
+                    default_action=ACLActionChoices.ACTION_DENY,
+                ),
+                AccessList(
+                    name="testacl2",
+                    type=ACLTypeChoices.TYPE_EXTENDED,
+                    family=ACLFamilyChoices.FAMILY_IPV4,
+                    default_action=ACLActionChoices.ACTION_PERMIT,
+                ),
+                AccessList(
+                    name="testacl3",
+                    type=ACLTypeChoices.TYPE_EXTENDED,
+                    family=ACLFamilyChoices.FAMILY_IPV6,
+                    default_action=ACLActionChoices.ACTION_DENY,
+                ),
+                # A second list of each type, so both branches of the rules table have
+                # same-relation rules to exclude. Both sort after testacl4, which
+                # form_data creates, so the name-ordered first() that the inherited view
+                # tests act on stays testacl1.
+                AccessList(
+                    name="testacl5",
+                    type=ACLTypeChoices.TYPE_STANDARD,
+                    family=ACLFamilyChoices.FAMILY_IPV4,
+                    default_action=ACLActionChoices.ACTION_DENY,
+                ),
+                AccessList(
+                    name="testacl6",
+                    type=ACLTypeChoices.TYPE_EXTENDED,
+                    family=ACLFamilyChoices.FAMILY_IPV4,
+                    default_action=ACLActionChoices.ACTION_DENY,
+                ),
+            ),
+        )
+
+        # create() not bulk_create(): save() populates the shadow source columns.
+        standard, other_standard = (
+            AccessList.objects.get(name="testacl1"),
+            AccessList.objects.get(name="testacl5"),
+        )
+        extended = AccessList.objects.get(name="testacl2")
+        cls.standard_rules = [
+            ACLStandardRule.objects.create(
+                access_list=standard,
+                sequence=sequence,
+                action=ACLRuleActionChoices.ACTION_REMARK,
+                remark=f"standard remark {sequence}",
+            )
+            for sequence in (10, 20)
+        ]
+        cls.extended_rules = [
+            ACLExtendedRule.objects.create(
+                access_list=extended,
+                sequence=10,
+                action=ACLRuleActionChoices.ACTION_REMARK,
+                remark="extended remark 10",
+            ),
+        ]
+        ACLStandardRule.objects.create(
+            access_list=other_standard,
+            sequence=10,
+            action=ACLRuleActionChoices.ACTION_REMARK,
+            remark="a rule on another standard list",
+        )
+        ACLExtendedRule.objects.create(
+            access_list=AccessList.objects.get(name="testacl6"),
+            sequence=10,
+            action=ACLRuleActionChoices.ACTION_REMARK,
+            remark="a rule on another extended list",
+        )
+
+        tags = create_tags("Alpha", "Bravo", "Charlie")
+
+        cls.form_data = {
+            "name": "testacl4",
+            "type": ACLTypeChoices.TYPE_STANDARD,
+            "family": ACLFamilyChoices.FAMILY_IPV4,
+            "default_action": ACLActionChoices.ACTION_DENY,
+            "description": "A new access list",
+            "comments": "",
+            "tags": [t.pk for t in tags],
+        }
+
+        cls.bulk_edit_data = {
+            "description": "Bulk edited",
+        }
+
+    def test_rules_table_matches_access_list_type(self):
+        """Test that the detail view renders the rule table matching the ACL's type."""
+        self.add_permissions("netbox_acls.view_accesslist")
+
+        for name, table_class, expected_rules in (
+            ("testacl1", ACLStandardRuleTable, self.standard_rules),
+            ("testacl2", ACLExtendedRuleTable, self.extended_rules),
+        ):
+            with self.subTest(access_list=name):
+                access_list = AccessList.objects.get(name=name)
+                response = self.client.get(access_list.get_absolute_url())
+                self.assertHttpStatus(response, 200)
+
+                table = response.context["rules_table"]
+                self.assertIsInstance(table, table_class)
+                # Scoped to this list, not every rule of that type.
+                self.assertEqual(
+                    {rule.pk for rule in table.data},
+                    {rule.pk for rule in expected_rules},
+                )
+                # The column is redundant on an access list's own detail page.
+                visible = [column.name for column in table.columns.itervisible()]
+                self.assertNotIn("access_list", visible)

--- a/netbox_acls/tests/views/test_aclassignments.py
+++ b/netbox_acls/tests/views/test_aclassignments.py
@@ -1,0 +1,120 @@
+from django.contrib.contenttypes.models import ContentType
+
+from dcim.choices import InterfaceTypeChoices
+from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
+from utilities.testing import create_tags
+from virtualization.models import Cluster, ClusterType, VirtualMachine, VMInterface
+
+from ...choices import (
+    ACLActionChoices,
+    ACLAssignmentDirectionChoices,
+    ACLFamilyChoices,
+    ACLTypeChoices,
+)
+from ...models import AccessList, ACLAssignment
+from .base import PluginTestCases
+
+
+class ACLAssignmentViewTestCase(PluginTestCases.ObjectViewTestCase):
+    """View tests for ACLAssignment."""
+
+    model = ACLAssignment
+    user_permissions = (
+        "dcim.view_site",
+        "dcim.view_devicetype",
+        "dcim.view_device",
+        "dcim.view_interface",
+        "virtualization.view_cluster",
+        "virtualization.view_clustergroup",
+        "virtualization.view_clustertype",
+        "virtualization.view_virtualmachine",
+        "virtualization.view_vminterface",
+        "netbox_acls.view_accesslist",
+    )
+
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.create(name="Site 1", slug="site-1")
+        manufacturer = Manufacturer.objects.create(name="Manufacturer 1", slug="manufacturer-1")
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="Device Type 1")
+        device_role = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1")
+        device = Device.objects.create(
+            name="Device 1",
+            site=site,
+            device_type=device_type,
+            role=device_role,
+        )
+        interface1 = device.interfaces.create(
+            name="DeviceInterface1",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+        )
+        interface2 = device.interfaces.create(
+            name="DeviceInterface2",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+        )
+        cls.interface3 = device.interfaces.create(
+            name="DeviceInterface3",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+        )
+
+        cluster_type = ClusterType.objects.create(name="Cluster Type 1", slug="cluster-type-1")
+        cluster = Cluster.objects.create(name="Cluster 1", type=cluster_type)
+        virtual_machine = VirtualMachine.objects.create(name="VM 1", cluster=cluster)
+        vminterface1 = virtual_machine.interfaces.create(name="eth0")
+
+        cls.acl1 = AccessList.objects.create(
+            name="testacl1",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        acl2 = AccessList.objects.create(
+            name="testacl2",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV6,
+            default_action=ACLActionChoices.ACTION_PERMIT,
+        )
+
+        # bulk_create skips save(), where family is copied from the access list.
+        ACLAssignment.objects.bulk_create(
+            (
+                ACLAssignment(
+                    access_list=cls.acl1,
+                    direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+                    assigned_object_type=ContentType.objects.get_for_model(Interface),
+                    assigned_object_id=interface1.pk,
+                    family=cls.acl1.family,
+                ),
+                ACLAssignment(
+                    access_list=cls.acl1,
+                    direction=ACLAssignmentDirectionChoices.DIRECTION_EGRESS,
+                    assigned_object_type=ContentType.objects.get_for_model(Interface),
+                    assigned_object_id=interface2.pk,
+                    family=cls.acl1.family,
+                ),
+                ACLAssignment(
+                    access_list=acl2,
+                    direction=ACLAssignmentDirectionChoices.DIRECTION_EGRESS,
+                    assigned_object_type=ContentType.objects.get_for_model(VMInterface),
+                    assigned_object_id=vminterface1.pk,
+                    family=acl2.family,
+                ),
+            ),
+        )
+
+        tags = create_tags("Alpha", "Bravo", "Charlie")
+
+        # The object picker's queryset comes from the posted type, so both keys
+        # have to arrive together.
+        cls.form_data = {
+            "access_list": cls.acl1.pk,
+            "assigned_object_type": ContentType.objects.get_for_model(Interface).pk,
+            "assigned_object": cls.interface3.pk,
+            "direction": ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+            "comments": "",
+            "tags": [t.pk for t in tags],
+        }
+
+        cls.bulk_edit_data = {
+            "comments": "Bulk edited",
+        }

--- a/netbox_acls/tests/views/test_extendedrules.py
+++ b/netbox_acls/tests/views/test_extendedrules.py
@@ -1,0 +1,115 @@
+from django.contrib.contenttypes.models import ContentType
+from django.db.backends.postgresql.psycopg_any import NumericRange
+from netaddr import IPNetwork
+
+from ipam.models import Prefix
+from utilities.testing import create_tags
+
+from ...choices import (
+    ACLActionChoices,
+    ACLFamilyChoices,
+    ACLProtocolChoices,
+    ACLRuleActionChoices,
+    ACLTypeChoices,
+)
+from ...models import AccessList, ACLExtendedRule
+from ...utils import normalize_port_ranges
+from .base import ACLRuleSequenceTestsMixin, PluginTestCases, build_ipam_objects
+
+
+class ACLExtendedRuleViewTestCase(ACLRuleSequenceTestsMixin, PluginTestCases.ObjectViewTestCase):
+    """View tests for ACLExtendedRule."""
+
+    model = ACLExtendedRule
+    add_permission = "netbox_acls.add_aclextendedrule"
+    change_permission = "netbox_acls.change_aclextendedrule"
+    user_permissions = (
+        "ipam.view_aggregate",
+        "ipam.view_ipaddress",
+        "ipam.view_iprange",
+        "ipam.view_prefix",
+        "netbox_acls.view_accesslist",
+    )
+
+    @classmethod
+    def setUpTestData(cls):
+        aggregate, cls.source_prefix, ip_address, ip_range = build_ipam_objects()
+        cls.destination_prefix = Prefix.objects.create(prefix=IPNetwork("10.2.0.0/16"))
+
+        cls.access_list = AccessList.objects.create(
+            name="testextendedacl",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+
+        # Stored half-open, so an inclusive 80 to 80 becomes [80, 81).
+        ACLExtendedRule.objects.create(
+            access_list=cls.access_list,
+            sequence=10,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            protocol=ACLProtocolChoices.PROTOCOL_TCP,
+            source=cls.source_prefix,
+            destination=cls.destination_prefix,
+            source_port_ranges=normalize_port_ranges([NumericRange(1024, 2048, bounds="[]")]),
+            destination_port_ranges=normalize_port_ranges([NumericRange(80, 80, bounds="[]")]),
+            description="permit web",
+        )
+        ACLExtendedRule.objects.create(
+            access_list=cls.access_list,
+            sequence=20,
+            action=ACLRuleActionChoices.ACTION_DENY,
+            protocol=ACLProtocolChoices.PROTOCOL_UDP,
+            source=ip_address,
+            destination=ip_range,
+            destination_port_ranges=normalize_port_ranges([NumericRange(53, 53, bounds="[]")]),
+            description="deny dns",
+        )
+        ACLExtendedRule.objects.create(
+            access_list=cls.access_list,
+            sequence=30,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            protocol=ACLProtocolChoices.PROTOCOL_ICMP,
+            source=aggregate,
+            destination=ip_address,
+        )
+        ACLExtendedRule.objects.create(
+            access_list=cls.access_list,
+            sequence=40,
+            action=ACLRuleActionChoices.ACTION_REMARK,
+            remark="an extended remark",
+        )
+        ACLExtendedRule.objects.create(
+            access_list=cls.access_list,
+            sequence=50,
+            action=ACLRuleActionChoices.ACTION_DENY,
+            protocol=ACLProtocolChoices.PROTOCOL_IP,
+            source=ip_range,
+            destination=aggregate,
+            description="deny the range",
+        )
+
+        tags = create_tags("Alpha", "Bravo", "Charlie")
+
+        # Ports are posted inclusively and need protocol tcp or udp. These values
+        # round-trip unchanged: no single ports, no adjacent pairs to merge.
+        cls.form_data = {
+            "access_list": cls.access_list.pk,
+            "sequence": 60,
+            "action": ACLRuleActionChoices.ACTION_PERMIT,
+            "remark": "",
+            "protocol": ACLProtocolChoices.PROTOCOL_TCP,
+            "source_type": ContentType.objects.get_for_model(Prefix).pk,
+            "source": cls.source_prefix.pk,
+            "source_port_ranges": "1024-2048",
+            "destination_type": ContentType.objects.get_for_model(Prefix).pk,
+            "destination": cls.destination_prefix.pk,
+            "destination_port_ranges": "8080-8081",
+            "description": "A new extended rule",
+            "comments": "",
+            "tags": [t.pk for t in tags],
+        }
+
+        cls.bulk_edit_data = {
+            "description": "Bulk edited",
+        }

--- a/netbox_acls/tests/views/test_standardrules.py
+++ b/netbox_acls/tests/views/test_standardrules.py
@@ -1,0 +1,93 @@
+from django.contrib.contenttypes.models import ContentType
+
+from ipam.models import Prefix
+from utilities.testing import create_tags
+
+from ...choices import (
+    ACLActionChoices,
+    ACLFamilyChoices,
+    ACLRuleActionChoices,
+    ACLTypeChoices,
+)
+from ...models import AccessList, ACLStandardRule
+from .base import ACLRuleSequenceTestsMixin, PluginTestCases, build_ipam_objects
+
+
+class ACLStandardRuleViewTestCase(ACLRuleSequenceTestsMixin, PluginTestCases.ObjectViewTestCase):
+    """View tests for ACLStandardRule."""
+
+    model = ACLStandardRule
+    add_permission = "netbox_acls.add_aclstandardrule"
+    change_permission = "netbox_acls.change_aclstandardrule"
+    user_permissions = (
+        "ipam.view_aggregate",
+        "ipam.view_ipaddress",
+        "ipam.view_iprange",
+        "ipam.view_prefix",
+        "netbox_acls.view_accesslist",
+    )
+
+    @classmethod
+    def setUpTestData(cls):
+        aggregate, cls.prefix, ip_address, ip_range = build_ipam_objects()
+
+        cls.access_list = AccessList.objects.create(
+            name="teststandardacl",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+
+        # create() not bulk_create(): save() populates the _source_* columns.
+        ACLStandardRule.objects.create(
+            access_list=cls.access_list,
+            sequence=10,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=cls.prefix,
+            description="permit the prefix",
+        )
+        ACLStandardRule.objects.create(
+            access_list=cls.access_list,
+            sequence=20,
+            action=ACLRuleActionChoices.ACTION_DENY,
+            source=ip_address,
+            description="deny the address",
+        )
+        ACLStandardRule.objects.create(
+            access_list=cls.access_list,
+            sequence=30,
+            action=ACLRuleActionChoices.ACTION_DENY,
+            source=ip_range,
+            description="deny the range",
+        )
+        ACLStandardRule.objects.create(
+            access_list=cls.access_list,
+            sequence=40,
+            action=ACLRuleActionChoices.ACTION_REMARK,
+            remark="a standard remark",
+        )
+        ACLStandardRule.objects.create(
+            access_list=cls.access_list,
+            sequence=50,
+            action=ACLRuleActionChoices.ACTION_DENY,
+            source=aggregate,
+            description="deny the aggregate",
+        )
+
+        tags = create_tags("Alpha", "Bravo", "Charlie")
+
+        cls.form_data = {
+            "access_list": cls.access_list.pk,
+            "sequence": 60,
+            "action": ACLRuleActionChoices.ACTION_PERMIT,
+            "remark": "",
+            "source_type": ContentType.objects.get_for_model(Prefix).pk,
+            "source": cls.prefix.pk,
+            "description": "A new standard rule",
+            "comments": "",
+            "tags": [t.pk for t in tags],
+        }
+
+        cls.bulk_edit_data = {
+            "description": "Bulk edited",
+        }

--- a/netbox_acls/tests/views/test_tabs.py
+++ b/netbox_acls/tests/views/test_tabs.py
@@ -1,0 +1,211 @@
+"""
+Tests for the ACL assignment tabs contributed to plugin and core objects.
+
+These views sit outside every standard NetBox test base, so nothing else reaches them.
+"""
+
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from dcim.choices import InterfaceTypeChoices
+from dcim.models import (
+    Device,
+    DeviceRole,
+    DeviceType,
+    Manufacturer,
+    Site,
+    VirtualChassis,
+)
+from utilities.testing import TestCase
+from virtualization.models import Cluster, ClusterType, VirtualMachine
+
+from ...choices import (
+    ACLActionChoices,
+    ACLAssignmentDirectionChoices,
+    ACLFamilyChoices,
+    ACLTypeChoices,
+)
+from ...models import AccessList, ACLAssignment
+from ...views import (
+    AccessListACLAssignmentView,
+    DeviceACLAssignmentView,
+    InterfaceACLAssignmentView,
+    VirtualChassisACLAssignmentView,
+    VirtualMachineACLAssignmentView,
+    VMInterfaceACLAssignmentView,
+)
+
+
+class ACLAssignmentTabTestCase(TestCase):
+    """Each assignment tab lists its own parent's assignments and nothing else."""
+
+    user_permissions = (
+        "netbox_acls.view_aclassignment",
+        "netbox_acls.view_accesslist",
+        "dcim.view_device",
+        "dcim.view_interface",
+        "dcim.view_virtualchassis",
+        "virtualization.view_virtualmachine",
+        "virtualization.view_vminterface",
+    )
+
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.create(name="Site 1", slug="site-1")
+        manufacturer = Manufacturer.objects.create(name="Manufacturer 1", slug="manufacturer-1")
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="Device Type 1")
+        role = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1")
+
+        cls.device = Device.objects.create(
+            name="Device 1",
+            site=site,
+            device_type=device_type,
+            role=role,
+        )
+        cls.interface = cls.device.interfaces.create(
+            name="eth0",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+        )
+        cls.virtual_chassis = VirtualChassis.objects.create(name="Virtual Chassis 1")
+
+        cluster_type = ClusterType.objects.create(name="Cluster Type 1", slug="cluster-type-1")
+        cluster = Cluster.objects.create(name="Cluster 1", type=cluster_type)
+        cls.virtual_machine = VirtualMachine.objects.create(name="VM 1", cluster=cluster)
+        cls.vminterface = cls.virtual_machine.interfaces.create(name="eth0")
+
+        # A second of every assignable object, so each tab has a same-model sibling to
+        # exclude. Without one, a tab filtering only by content type, or not filtering at
+        # all, returns the same single row as a correct one.
+        cls.device2 = Device.objects.create(
+            name="Device 2",
+            site=site,
+            device_type=device_type,
+            role=role,
+        )
+        cls.interface2 = cls.device2.interfaces.create(
+            name="eth0",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+        )
+        cls.virtual_chassis2 = VirtualChassis.objects.create(name="Virtual Chassis 2")
+        cls.virtual_machine2 = VirtualMachine.objects.create(name="VM 2", cluster=cluster)
+        cls.vminterface2 = cls.virtual_machine2.interfaces.create(name="eth0")
+
+        cls.access_list = AccessList.objects.create(
+            name="testacl1",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        # A second access list, so the access list tab has assignments to exclude too.
+        cls.access_list2 = AccessList.objects.create(
+            name="testacl2",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_PERMIT,
+        )
+
+        cls.assignments = cls.build_assignments(
+            cls.access_list,
+            (cls.device, cls.interface, cls.virtual_chassis, cls.virtual_machine, cls.vminterface),
+        )
+        cls.other_assignments = cls.build_assignments(
+            cls.access_list2,
+            (
+                cls.device2,
+                cls.interface2,
+                cls.virtual_chassis2,
+                cls.virtual_machine2,
+                cls.vminterface2,
+            ),
+        )
+
+    @staticmethod
+    def build_assignments(access_list, targets):
+        """Attach the access list to one of each assignable target type."""
+        device, interface, virtual_chassis, virtual_machine, vminterface = targets
+        assignments = {}
+        for key, target, direction in (
+            ("device", device, ACLAssignmentDirectionChoices.DIRECTION_NONE),
+            ("interface", interface, ACLAssignmentDirectionChoices.DIRECTION_INGRESS),
+            ("virtual_chassis", virtual_chassis, ACLAssignmentDirectionChoices.DIRECTION_NONE),
+            ("virtual_machine", virtual_machine, ACLAssignmentDirectionChoices.DIRECTION_NONE),
+            ("vminterface", vminterface, ACLAssignmentDirectionChoices.DIRECTION_EGRESS),
+        ):
+            assignments[key] = ACLAssignment.objects.create(
+                access_list=access_list,
+                direction=direction,
+                assigned_object_type=ContentType.objects.get_for_model(target),
+                assigned_object_id=target.pk,
+            )
+        return assignments
+
+    def tab_cases(self):
+        """
+        Yield (view class, url name, parent, expected assignments) for every tab.
+
+        Only the access list tab lives under the plugins namespace. The other five are
+        registered against core models and resolve under dcim and virtualization.
+        """
+        return (
+            (
+                DeviceACLAssignmentView,
+                "dcim:device_aclassignments",
+                self.device,
+                [self.assignments["device"]],
+            ),
+            (
+                InterfaceACLAssignmentView,
+                "dcim:interface_aclassignments",
+                self.interface,
+                [self.assignments["interface"]],
+            ),
+            (
+                VirtualChassisACLAssignmentView,
+                "dcim:virtualchassis_aclassignments",
+                self.virtual_chassis,
+                [self.assignments["virtual_chassis"]],
+            ),
+            (
+                VirtualMachineACLAssignmentView,
+                "virtualization:virtualmachine_aclassignments",
+                self.virtual_machine,
+                [self.assignments["virtual_machine"]],
+            ),
+            (
+                VMInterfaceACLAssignmentView,
+                "virtualization:vminterface_aclassignments",
+                self.vminterface,
+                [self.assignments["vminterface"]],
+            ),
+            (
+                AccessListACLAssignmentView,
+                "plugins:netbox_acls:accesslist_aclassignments",
+                self.access_list,
+                list(self.assignments.values()),
+            ),
+            (
+                AccessListACLAssignmentView,
+                "plugins:netbox_acls:accesslist_aclassignments",
+                self.access_list2,
+                list(self.other_assignments.values()),
+            ),
+        )
+
+    def test_tab_lists_only_its_own_assignments(self):
+        """Test that each tab narrows its children to the parent it hangs off."""
+        for _view_class, url_name, parent, expected in self.tab_cases():
+            with self.subTest(view=url_name, parent=parent):
+                response = self.client.get(reverse(url_name, kwargs={"pk": parent.pk}))
+                self.assertHttpStatus(response, 200)
+                self.assertEqual(
+                    {row.pk for row in response.context["table"].data},
+                    {assignment.pk for assignment in expected},
+                )
+
+    def test_tab_badge_counts_the_assignments(self):
+        """Test that the tab badge callback reports what the tab lists."""
+        for view_class, url_name, parent, expected in self.tab_cases():
+            with self.subTest(view=url_name, parent=parent):
+                rendered = view_class.tab.render(parent)
+                self.assertIsNotNone(rendered)
+                self.assertEqual(rendered["badge"], len(expected))


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #387

## New Behavior

Adds comprehensive UI view test coverage for `AccessList`, `ACLAssignment`, `ACLStandardRule`, and `ACLExtendedRule`, including detail and changelog pages, create, edit, and delete workflows, list and export views, and bulk edit and delete actions.

Adds focused regression tests for:

* selecting and correctly scoping the rule table shown on an Access List
* automatically prefilling rule sequences while preserving supplied or existing values
* displaying and filtering ACL assignment tabs, including their badge counts, on Access Lists and all supported NetBox objects

Introduces shared plugin-aware view helpers and reusable ACL rule fixtures. The corresponding list-view query-count baselines are also recorded.

## Contrast to Current Behavior

The plugin previously had no dedicated UI view tests. Regressions in URL resolution, permissions, form handling, rule-table selection, automatic sequence handling, assignment tabs, and page rendering could therefore go undetected.

## Discussion: Benefits and Drawbacks

This establishes broad regression coverage for the existing UI and provides reusable foundations for future view tests.

Bulk-import tests are intentionally excluded because the plugin does not currently provide bulk-import forms. The additional coverage also adds a small amount of test runtime and maintenance, particularly for query-count baselines.

There are no user-facing or backwards-incompatible changes.

## Changes to the Documentation

No documentation changes are required because this PR only adds automated test coverage.

## Proposed Release Note Entry

Add comprehensive UI view test coverage for all ACL plugin models, including rule-table selection, rule sequencing, and assignment tabs.

## Double Check

* [x] I have explained my PR according to the information in the comments
  or in a linked issue.
* [x] My PR targets `main` (fix to the current release).