### PR TITLE
Fixes #132: Add test coverage for ACL forms

### DIFF
--- a/netbox_acls/tests/forms/base.py
+++ b/netbox_acls/tests/forms/base.py
@@ -1,0 +1,27 @@
+"""
+Shared bases for the plugin's form tests.
+"""
+
+__all__ = ("BulkEditFieldsetTestMixin",)
+
+
+class BulkEditFieldsetTestMixin:
+    """
+    Assert every field a bulk edit form names in its fieldsets exists on the form.
+
+    A fieldset entry with no matching field is dropped silently when the form renders.
+    """
+
+    bulk_edit_form = None
+
+    def test_bulkedit_fieldset_fields_all_defined(self):
+        """Test that every field named in the bulk-edit fieldsets exists on the form."""
+        form = self.bulk_edit_form()
+        for fieldset in form.fieldsets:
+            for item in fieldset.items:
+                if isinstance(item, str):
+                    self.assertIn(
+                        item,
+                        form.fields,
+                        msg=f"Fieldset '{fieldset.name}' references undefined field '{item}'",
+                    )

--- a/netbox_acls/tests/forms/test_accesslists.py
+++ b/netbox_acls/tests/forms/test_accesslists.py
@@ -1,0 +1,67 @@
+from django.test import TestCase
+
+from ...choices import ACLActionChoices, ACLFamilyChoices, ACLRuleActionChoices, ACLTypeChoices
+from ...forms import AccessListBulkEditForm, AccessListForm
+from ...models import AccessList, ACLStandardRule
+from .base import BulkEditFieldsetTestMixin
+
+
+class AccessListFormTestCase(BulkEditFieldsetTestMixin, TestCase):
+    """Form tests for AccessList forms."""
+
+    bulk_edit_form = AccessListBulkEditForm
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.access_list = AccessList.objects.create(
+            name="testacl1",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        ACLStandardRule.objects.create(
+            access_list=cls.access_list,
+            sequence=10,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            remark="",
+        )
+
+    def test_valid_minimal_form(self):
+        """Test that a name, type, family and default action alone validate."""
+        form = AccessListForm(
+            data={
+                "name": "testacl2",
+                "type": ACLTypeChoices.TYPE_EXTENDED,
+                "family": ACLFamilyChoices.FAMILY_IPV6,
+                "default_action": ACLActionChoices.ACTION_PERMIT,
+            },
+        )
+        self.assertTrue(form.is_valid(), msg=form.errors.as_text())
+
+    def test_type_change_blocked_with_rules(self):
+        """Test that the type cannot be changed once rules are associated."""
+        form = AccessListForm(
+            data={
+                "name": self.access_list.name,
+                "type": ACLTypeChoices.TYPE_EXTENDED,
+                "family": self.access_list.family,
+                "default_action": self.access_list.default_action,
+            },
+            instance=self.access_list,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("type", form.errors)
+
+    def test_family_change_blocked_with_rules(self):
+        """Test that the family cannot be changed once rules are associated."""
+        form = AccessListForm(
+            data={
+                "name": self.access_list.name,
+                "type": self.access_list.type,
+                "family": ACLFamilyChoices.FAMILY_IPV6,
+                "default_action": self.access_list.default_action,
+            },
+            instance=self.access_list,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("family", form.errors)

--- a/netbox_acls/tests/forms/test_aclassignments.py
+++ b/netbox_acls/tests/forms/test_aclassignments.py
@@ -1,0 +1,130 @@
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+
+from dcim.choices import InterfaceTypeChoices
+from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
+from virtualization.models import Cluster, ClusterType, VirtualMachine, VMInterface
+
+from ...choices import (
+    ACLActionChoices,
+    ACLAssignmentDirectionChoices,
+    ACLFamilyChoices,
+    ACLTypeChoices,
+)
+from ...constants import ACL_ASSIGNMENT_MODELS
+from ...forms import ACLAssignmentBulkEditForm, ACLAssignmentForm
+from ...models import AccessList
+from .base import BulkEditFieldsetTestMixin
+
+UNRESOLVABLE_CONTENT_TYPE_ID = 99999999
+
+
+class ACLAssignmentFormTestCase(BulkEditFieldsetTestMixin, TestCase):
+    """Form tests for ACLAssignment forms."""
+
+    bulk_edit_form = ACLAssignmentBulkEditForm
+
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.create(name="Site 1", slug="site-1")
+        manufacturer = Manufacturer.objects.create(name="Manufacturer 1", slug="manufacturer-1")
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="Device Type 1")
+        device_role = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1")
+        cls.device = Device.objects.create(
+            name="Device 1",
+            site=site,
+            device_type=device_type,
+            role=device_role,
+        )
+        cls.interface = cls.device.interfaces.create(
+            name="DeviceInterface1",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+        )
+
+        cluster_type = ClusterType.objects.create(name="Cluster Type 1", slug="cluster-type-1")
+        cluster = Cluster.objects.create(name="Cluster 1", type=cluster_type)
+        virtual_machine = VirtualMachine.objects.create(name="VM 1", cluster=cluster)
+        cls.vminterface = virtual_machine.interfaces.create(name="eth0")
+
+        cls.access_list = AccessList.objects.create(
+            name="testacl1",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+
+    def _bound_form(self, model, obj, direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS):
+        """Bind the form, so the posted type reaches __init__."""
+        return ACLAssignmentForm(
+            data={
+                "access_list": self.access_list.pk,
+                "assigned_object_type": ContentType.objects.get_for_model(model).pk,
+                "assigned_object": obj.pk,
+                "direction": direction,
+            },
+        )
+
+    def test_assigned_object_queryset_follows_type(self):
+        """Test that the object picker's queryset is resolved from the posted content type."""
+        form = self._bound_form(Interface, self.interface)
+        self.assertEqual(form.fields["assigned_object"].queryset.model, Interface)
+        self.assertFalse(form.fields["assigned_object"].disabled)
+
+    def test_direction_enabled_for_interface_types(self):
+        """Test that the direction is enabled and required for both interface types."""
+        for model, obj in ((Interface, self.interface), (VMInterface, self.vminterface)):
+            with self.subTest(model=model._meta.label_lower):
+                form = self._bound_form(model, obj)
+                self.assertFalse(form.fields["direction"].disabled)
+                self.assertTrue(form.fields["direction"].required)
+
+    def test_direction_disabled_for_host_types(self):
+        """Test that the direction is disabled for host assignments."""
+        form = self._bound_form(
+            Device,
+            self.device,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+        )
+        self.assertTrue(form.fields["direction"].disabled)
+
+    def test_assigned_object_type_choices_limited(self):
+        """Test that the assignment type picker offers only the assignable models."""
+        form = ACLAssignmentForm()
+        self.assertQuerySetEqual(
+            form.fields["assigned_object_type"].queryset.order_by("pk"),
+            ContentType.objects.filter(ACL_ASSIGNMENT_MODELS).order_by("pk"),
+            transform=lambda ct: ct,
+        )
+
+    def test_unresolvable_content_type_is_survivable(self):
+        """
+        Test that a content type id which no longer resolves leaves the form usable.
+
+        The id arrives through initial, not posted data, which is validated against
+        the field's queryset and discarded before __init__ looks it up.
+        """
+        form = ACLAssignmentForm(initial={"assigned_object_type": UNRESOLVABLE_CONTENT_TYPE_ID})
+        self.assertTrue(form.fields["assigned_object"].disabled)
+
+    def test_clean_assigns_object(self):
+        """Test that a valid form assigns the selected object to the instance."""
+        form = self._bound_form(Interface, self.interface)
+        self.assertTrue(form.is_valid(), msg=form.errors.as_text())
+        self.assertEqual(form.instance.assigned_object, self.interface)
+
+    def test_bulkedit_assigned_object_queryset_follows_type(self):
+        """Test that the bulk-edit object picker's queryset is resolved from the posted type."""
+        form = ACLAssignmentBulkEditForm(
+            data={"assigned_object_type": ContentType.objects.get_for_model(Interface).pk},
+        )
+        self.assertEqual(form.fields["assigned_object"].queryset.model, Interface)
+        self.assertFalse(form.fields["assigned_object"].disabled)
+        self.assertFalse(form.fields["direction"].disabled)
+
+    def test_bulkedit_direction_disabled_for_host_types(self):
+        """Test that the bulk-edit direction is disabled for host assignments."""
+        form = ACLAssignmentBulkEditForm(
+            data={"assigned_object_type": ContentType.objects.get_for_model(Device).pk},
+        )
+        self.assertEqual(form.fields["assigned_object"].queryset.model, Device)
+        self.assertTrue(form.fields["direction"].disabled)

--- a/netbox_acls/tests/forms/test_extendedrules.py
+++ b/netbox_acls/tests/forms/test_extendedrules.py
@@ -1,11 +1,53 @@
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
+from netaddr import IPNetwork
 
-from ...choices import ACLTypeChoices
-from ...forms import ACLExtendedRuleBulkEditForm
+from ipam.models import Prefix
+
+from ...choices import (
+    ACLActionChoices,
+    ACLFamilyChoices,
+    ACLProtocolChoices,
+    ACLRuleActionChoices,
+    ACLTypeChoices,
+)
+from ...constants import ACL_RULE_SOURCE_DESTINATION_MODELS
+from ...forms import ACLExtendedRuleBulkEditForm, ACLExtendedRuleForm
+from ...models import AccessList
+from ..views.base import build_ipam_objects
+from .base import BulkEditFieldsetTestMixin
 
 
-class ACLExtendedRuleFormTestCase(TestCase):
+class ACLExtendedRuleFormTestCase(BulkEditFieldsetTestMixin, TestCase):
     """Form tests for ACLExtendedRule forms."""
+
+    bulk_edit_form = ACLExtendedRuleBulkEditForm
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.aggregate, cls.prefix, cls.ip_address, cls.ip_range = build_ipam_objects()
+        cls.destination_prefix = Prefix.objects.create(prefix=IPNetwork("10.2.0.0/16"))
+        cls.access_list = AccessList.objects.create(
+            name="testextendedacl",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+
+    def _bound_form(self, **overrides):
+        """Bind the form, so the posted types reach __init__."""
+        data = {
+            "access_list": self.access_list.pk,
+            "sequence": 10,
+            "action": ACLRuleActionChoices.ACTION_PERMIT,
+            "protocol": ACLProtocolChoices.PROTOCOL_TCP,
+            "source_type": ContentType.objects.get_for_model(Prefix).pk,
+            "source": self.prefix.pk,
+            "destination_type": ContentType.objects.get_for_model(Prefix).pk,
+            "destination": self.destination_prefix.pk,
+        }
+        data.update(overrides)
+        return ACLExtendedRuleForm(data=data)
 
     def test_bulkedit_access_list_filtered_to_extended(self):
         """#360: the extended bulk-edit Access List picker must filter to Extended ACLs."""
@@ -15,14 +57,81 @@ class ACLExtendedRuleFormTestCase(TestCase):
             {"type": ACLTypeChoices.TYPE_EXTENDED},
         )
 
-    def test_bulkedit_fieldset_fields_all_defined(self):
-        """#361: every field named in the extended bulk-edit fieldsets must exist on the form."""
-        form = ACLExtendedRuleBulkEditForm()
-        for fieldset in form.fieldsets:
-            for item in fieldset.items:
-                if isinstance(item, str):
-                    self.assertIn(
-                        item,
-                        form.fields,
-                        msg=f"Fieldset '{fieldset.name}' references undefined field '{item}'",
-                    )
+    def test_access_list_queryset_limited_to_extended(self):
+        """Test that the model form's Access List picker filters to Extended ACLs."""
+        form = ACLExtendedRuleForm()
+        self.assertEqual(
+            form.fields["access_list"].query_params,
+            {"type": ACLTypeChoices.TYPE_EXTENDED},
+        )
+
+    def test_source_queryset_follows_type(self):
+        """Test that the source picker's queryset is resolved from the posted source type."""
+        for source in (self.aggregate, self.prefix, self.ip_address, self.ip_range):
+            with self.subTest(source=source._meta.label_lower):
+                form = self._bound_form(
+                    source_type=ContentType.objects.get_for_model(source).pk,
+                    source=source.pk,
+                )
+                self.assertEqual(form.fields["source"].queryset.model, type(source))
+                self.assertFalse(form.fields["source"].disabled)
+
+    def test_destination_queryset_follows_type(self):
+        """Test that the destination picker's queryset is resolved from the posted type."""
+        for destination in (self.aggregate, self.prefix, self.ip_address, self.ip_range):
+            with self.subTest(destination=destination._meta.label_lower):
+                form = self._bound_form(
+                    destination_type=ContentType.objects.get_for_model(destination).pk,
+                    destination=destination.pk,
+                )
+                self.assertEqual(form.fields["destination"].queryset.model, type(destination))
+                self.assertFalse(form.fields["destination"].disabled)
+
+    def test_source_type_choices_limited(self):
+        """Test that the source type picker offers only the ipam models a rule accepts."""
+        form = ACLExtendedRuleForm()
+        self.assertQuerySetEqual(
+            form.fields["source_type"].queryset.order_by("pk"),
+            ContentType.objects.filter(ACL_RULE_SOURCE_DESTINATION_MODELS).order_by("pk"),
+            transform=lambda ct: ct,
+        )
+
+    def test_destination_type_choices_limited(self):
+        """Test that the destination type picker offers only the ipam models a rule accepts."""
+        form = ACLExtendedRuleForm()
+        self.assertQuerySetEqual(
+            form.fields["destination_type"].queryset.order_by("pk"),
+            ContentType.objects.filter(ACL_RULE_SOURCE_DESTINATION_MODELS).order_by("pk"),
+            transform=lambda ct: ct,
+        )
+
+    def test_clean_assigns_source_and_destination(self):
+        """Test that a valid form assigns both selected objects to the instance."""
+        form = self._bound_form()
+        self.assertTrue(form.is_valid(), msg=form.errors.as_text())
+        self.assertEqual(form.instance.source, self.prefix)
+        self.assertEqual(form.instance.destination, self.destination_prefix)
+
+    def test_bulkedit_source_and_destination_querysets_follow_type(self):
+        """Test that the bulk-edit pickers' querysets are resolved from the posted types."""
+        prefix_type = ContentType.objects.get_for_model(Prefix).pk
+        form = ACLExtendedRuleBulkEditForm(
+            data={"source_type": prefix_type, "destination_type": prefix_type},
+        )
+        self.assertEqual(form.fields["source"].queryset.model, Prefix)
+        self.assertFalse(form.fields["source"].disabled)
+        self.assertEqual(form.fields["destination"].queryset.model, Prefix)
+        self.assertFalse(form.fields["destination"].disabled)
+
+    def test_port_ranges_round_trip_inclusive(self):
+        """Test that port ranges posted inclusively are stored half-open and shown inclusively."""
+        form = self._bound_form(source_port_ranges="80-81", destination_port_ranges="8080-8081")
+        self.assertTrue(form.is_valid(), msg=form.errors.as_text())
+
+        instance = form.save()
+        self.assertEqual(
+            [(r.lower, r.upper) for r in instance.source_port_ranges],
+            [(80, 82)],
+        )
+        self.assertEqual(instance.source_port_ranges_list, ["80-81"])
+        self.assertEqual(instance.destination_port_ranges_list, ["8080-8081"])

--- a/netbox_acls/tests/forms/test_standardrules.py
+++ b/netbox_acls/tests/forms/test_standardrules.py
@@ -1,11 +1,40 @@
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
-from ...choices import ACLTypeChoices
-from ...forms import ACLStandardRuleBulkEditForm
+from ...choices import ACLActionChoices, ACLFamilyChoices, ACLRuleActionChoices, ACLTypeChoices
+from ...constants import ACL_RULE_SOURCE_DESTINATION_MODELS
+from ...forms import ACLStandardRuleBulkEditForm, ACLStandardRuleForm
+from ...models import AccessList
+from ..views.base import build_ipam_objects
+from .base import BulkEditFieldsetTestMixin
 
 
-class ACLStandardRuleFormTestCase(TestCase):
+class ACLStandardRuleFormTestCase(BulkEditFieldsetTestMixin, TestCase):
     """Form tests for ACLStandardRule forms."""
+
+    bulk_edit_form = ACLStandardRuleBulkEditForm
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.aggregate, cls.prefix, cls.ip_address, cls.ip_range = build_ipam_objects()
+        cls.access_list = AccessList.objects.create(
+            name="teststandardacl",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+
+    def _bound_form(self, source):
+        """Bind the form, so the posted source type reaches __init__."""
+        return ACLStandardRuleForm(
+            data={
+                "access_list": self.access_list.pk,
+                "sequence": 10,
+                "action": ACLRuleActionChoices.ACTION_PERMIT,
+                "source_type": ContentType.objects.get_for_model(source).pk,
+                "source": source.pk,
+            },
+        )
 
     def test_bulkedit_access_list_filtered_to_standard(self):
         """Guard the standard bulk-edit picker the extended form (#360) was copied from."""
@@ -14,3 +43,42 @@ class ACLStandardRuleFormTestCase(TestCase):
             form.fields["access_list"].query_params,
             {"type": ACLTypeChoices.TYPE_STANDARD},
         )
+
+    def test_access_list_queryset_limited_to_standard(self):
+        """Test that the model form's Access List picker filters to Standard ACLs."""
+        form = ACLStandardRuleForm()
+        self.assertEqual(
+            form.fields["access_list"].query_params,
+            {"type": ACLTypeChoices.TYPE_STANDARD},
+        )
+
+    def test_source_queryset_follows_type(self):
+        """Test that the source picker's queryset is resolved from the posted source type."""
+        for source in (self.aggregate, self.prefix, self.ip_address, self.ip_range):
+            with self.subTest(source=source._meta.label_lower):
+                form = self._bound_form(source)
+                self.assertEqual(form.fields["source"].queryset.model, type(source))
+                self.assertFalse(form.fields["source"].disabled)
+
+    def test_source_type_choices_limited(self):
+        """Test that the source type picker offers only the ipam models a rule accepts."""
+        form = ACLStandardRuleForm()
+        self.assertQuerySetEqual(
+            form.fields["source_type"].queryset.order_by("pk"),
+            ContentType.objects.filter(ACL_RULE_SOURCE_DESTINATION_MODELS).order_by("pk"),
+            transform=lambda ct: ct,
+        )
+
+    def test_clean_assigns_source(self):
+        """Test that a valid form assigns the selected source to the instance."""
+        form = self._bound_form(self.prefix)
+        self.assertTrue(form.is_valid(), msg=form.errors.as_text())
+        self.assertEqual(form.instance.source, self.prefix)
+
+    def test_bulkedit_source_queryset_follows_type(self):
+        """Test that the bulk-edit source picker's queryset is resolved from the posted type."""
+        form = ACLStandardRuleBulkEditForm(
+            data={"source_type": ContentType.objects.get_for_model(type(self.prefix)).pk},
+        )
+        self.assertEqual(form.fields["source"].queryset.model, type(self.prefix))
+        self.assertFalse(form.fields["source"].disabled)


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #132

## New Behavior

Adds test coverage for the Access List, ACL Assignment, and ACL Rule forms. The tests cover dynamic queryset resolution, field validation, and the fieldsets used by bulk-edit forms.

This PR also introduces `BulkEditFieldsetTestMixin`, which can be reused to verify that bulk-edit fieldsets reference valid form fields.

## Contrast to Current Behavior

The plugin previously had limited automated coverage for its forms. In particular, invalid fieldset entries could render nothing without causing a test failure.

The new tests exercise the relevant form behavior and detect missing or incorrectly referenced bulk-edit fields.

## Discussion: Benefits and Drawbacks

This improves confidence when changing forms and helps catch regressions in validation, dynamic querysets, and bulk-edit layouts. The reusable fieldset test mixin also makes it easier to apply the same checks to additional forms in the future.

There are no user-facing or backwards-incompatible changes. The main drawback is a modest increase in test-suite size and maintenance.

## Changes to the Documentation

No documentation changes are required.

## Proposed Release Note Entry

Add comprehensive test coverage for Access List, ACL Assignment, and ACL Rule forms, including reusable validation for bulk-edit fieldsets.

## Double Check

* [x] I have explained my PR according to the information in the comments
  or in a linked issue.
* [x] My PR targets `main` (fix to the current release).