### PR TITLE
Closes #388: Add test coverage for all ACL filtersets

### DIFF
--- a/netbox_acls/tests/filtersets/test_accesslists.py
+++ b/netbox_acls/tests/filtersets/test_accesslists.py
@@ -1,0 +1,92 @@
+from django.test import TestCase
+
+from utilities.testing import ChangeLoggedFilterSetTests
+
+from ...choices import ACLActionChoices, ACLFamilyChoices, ACLTypeChoices
+from ...filtersets import AccessListFilterSet
+from ...models import AccessList
+
+
+class AccessListFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
+    """FilterSet tests for AccessList."""
+
+    queryset = AccessList.objects.all()
+    filterset = AccessListFilterSet
+
+    @classmethod
+    def setUpTestData(cls):
+        access_lists = (
+            AccessList(
+                name="testacl1",
+                type=ACLTypeChoices.TYPE_STANDARD,
+                family=ACLFamilyChoices.FAMILY_IPV4,
+                default_action=ACLActionChoices.ACTION_DENY,
+                description="first list",
+                comments="managed by the network team",
+            ),
+            AccessList(
+                name="testacl2",
+                type=ACLTypeChoices.TYPE_EXTENDED,
+                family=ACLFamilyChoices.FAMILY_IPV6,
+                default_action=ACLActionChoices.ACTION_PERMIT,
+                description="second list",
+                comments="managed by the security team",
+            ),
+            AccessList(
+                name="testacl3",
+                type=ACLTypeChoices.TYPE_EXTENDED,
+                family=ACLFamilyChoices.FAMILY_DUAL,
+                default_action=ACLActionChoices.ACTION_REJECT,
+                description="third list",
+                comments="unmanaged",
+            ),
+        )
+        AccessList.objects.bulk_create(access_lists)
+
+    def test_q(self):
+        params = {"q": "testacl1"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_q_matches_default_action(self):
+        params = {"q": ACLActionChoices.ACTION_REJECT}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_name(self):
+        params = {"name": ["testacl1", "testacl2"]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {"description": ["first list"]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    # comments is a TextField, which django-filter maps to a single-valued CharFilter
+    # matching exactly, unlike the CharField-backed description above. Pass a scalar and
+    # the whole value, and use the generated comments__ic lookup for a substring match.
+
+    def test_comments(self):
+        params = {"comments": "unmanaged"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"comments__ic": "managed by"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    # type, family and default_action are single-valued ChoiceFilters, matching the
+    # single-select widgets in AccessListFilterForm. Passing a list silently matches
+    # everything, so these must be asserted one value at a time.
+
+    def test_type(self):
+        params = {"type": ACLTypeChoices.TYPE_EXTENDED}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {"type": ACLTypeChoices.TYPE_STANDARD}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_family(self):
+        params = {"family": ACLFamilyChoices.FAMILY_IPV4}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"family": ACLFamilyChoices.FAMILY_DUAL}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_default_action(self):
+        params = {"default_action": ACLActionChoices.ACTION_DENY}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"default_action": ACLActionChoices.ACTION_PERMIT}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)

--- a/netbox_acls/tests/filtersets/test_aclassignments.py
+++ b/netbox_acls/tests/filtersets/test_aclassignments.py
@@ -1,0 +1,224 @@
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+
+from dcim.choices import InterfaceTypeChoices
+from dcim.models import (
+    Device,
+    DeviceRole,
+    DeviceType,
+    Interface,
+    Manufacturer,
+    Region,
+    Site,
+    SiteGroup,
+    VirtualChassis,
+)
+from utilities.testing import ChangeLoggedFilterSetTests
+from virtualization.models import Cluster, ClusterType, VirtualMachine, VMInterface
+
+from ...choices import (
+    ACLActionChoices,
+    ACLAssignmentDirectionChoices,
+    ACLFamilyChoices,
+    ACLTypeChoices,
+)
+from ...filtersets import ACLAssignmentFilterSet
+from ...models import AccessList, ACLAssignment
+
+
+class ACLAssignmentFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
+    """FilterSet tests for ACLAssignment."""
+
+    queryset = ACLAssignment.objects.all()
+    filterset = ACLAssignmentFilterSet
+    ignore_fields = ("assigned_object_id",)
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.parent_region = Region.objects.create(name="Region 0", slug="region-0")
+        cls.region = Region.objects.create(name="Region 1", slug="region-1", parent=cls.parent_region)
+        cls.site_group = SiteGroup.objects.create(name="Site Group 1", slug="site-group-1")
+        cls.site = Site.objects.create(
+            name="Site 1",
+            slug="site-1",
+            region=cls.region,
+            group=cls.site_group,
+        )
+        manufacturer = Manufacturer.objects.create(name="Manufacturer 1", slug="manufacturer-1")
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="Device Type 1")
+        device_role = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1")
+        cls.device = Device.objects.create(
+            name="Device 1",
+            site=cls.site,
+            device_type=device_type,
+            role=device_role,
+        )
+        cls.interface1 = cls.device.interfaces.create(
+            name="DeviceInterface1",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+        )
+        cls.interface2 = cls.device.interfaces.create(
+            name="DeviceInterface2",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+        )
+
+        # The chassis master and the VM site exist so the scope filters can be proven
+        # through all five assignable target types, not just the two device-backed ones.
+        cls.virtual_chassis = VirtualChassis.objects.create(name="Virtual Chassis 1", master=cls.device)
+
+        cluster_type = ClusterType.objects.create(name="Cluster Type 1", slug="cluster-type-1")
+        cluster = Cluster.objects.create(name="Cluster 1", type=cluster_type)
+        cls.virtual_machine = VirtualMachine.objects.create(name="VM 1", cluster=cluster, site=cls.site)
+        cls.vminterface1 = cls.virtual_machine.interfaces.create(name="eth0")
+
+        cls.acl1 = AccessList.objects.create(
+            name="testacl1",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        cls.acl2 = AccessList.objects.create(
+            name="testacl2",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV6,
+            default_action=ACLActionChoices.ACTION_PERMIT,
+        )
+
+        # The device/interface/virtual_machine/vminterface filters traverse the reverse
+        # GenericRelation query names contributed in models/access_lists.py, so each
+        # assignable type needs its own assignment to be reachable. Host assignments
+        # carry direction=none, interface assignments carry ingress or egress.
+        # family is denormalized from the access list in save(), which bulk_create skips.
+        assignments = (
+            ACLAssignment(
+                access_list=cls.acl1,
+                direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+                assigned_object_type=ContentType.objects.get_for_model(Interface),
+                assigned_object_id=cls.interface1.pk,
+                family=cls.acl1.family,
+            ),
+            ACLAssignment(
+                access_list=cls.acl1,
+                direction=ACLAssignmentDirectionChoices.DIRECTION_EGRESS,
+                assigned_object_type=ContentType.objects.get_for_model(Interface),
+                assigned_object_id=cls.interface2.pk,
+                family=cls.acl1.family,
+            ),
+            ACLAssignment(
+                access_list=cls.acl2,
+                direction=ACLAssignmentDirectionChoices.DIRECTION_EGRESS,
+                assigned_object_type=ContentType.objects.get_for_model(VMInterface),
+                assigned_object_id=cls.vminterface1.pk,
+                family=cls.acl2.family,
+            ),
+            ACLAssignment(
+                access_list=cls.acl1,
+                direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+                assigned_object_type=ContentType.objects.get_for_model(Device),
+                assigned_object_id=cls.device.pk,
+                family=cls.acl1.family,
+            ),
+            ACLAssignment(
+                access_list=cls.acl1,
+                direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+                assigned_object_type=ContentType.objects.get_for_model(VirtualChassis),
+                assigned_object_id=cls.virtual_chassis.pk,
+                family=cls.acl1.family,
+            ),
+            ACLAssignment(
+                access_list=cls.acl2,
+                direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+                assigned_object_type=ContentType.objects.get_for_model(VirtualMachine),
+                assigned_object_id=cls.virtual_machine.pk,
+                family=cls.acl2.family,
+            ),
+        )
+        ACLAssignment.objects.bulk_create(assignments)
+
+    def test_q(self):
+        params = {"q": "testacl2"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_q_matches_interface_name(self):
+        params = {"q": "DeviceInterface1"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_access_list(self):
+        params = {"access_list_id": [self.acl1.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
+        params = {"access_list": [self.acl2.name]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_interface(self):
+        params = {"interface_id": [self.interface1.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"interface": [self.interface1.name, self.interface2.name]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_vminterface(self):
+        params = {"vminterface_id": [self.vminterface1.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"vminterface": [self.vminterface1.name]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_device(self):
+        params = {"device_id": [self.device.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"device": [self.device.name]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_virtual_machine(self):
+        params = {"virtual_machine_id": [self.virtual_machine.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"virtual_machine": [self.virtual_machine.name]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_virtual_chassis(self):
+        params = {"virtual_chassis_id": [self.virtual_chassis.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"virtual_chassis": [self.virtual_chassis.name]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    # Every assignment in this fixture resolves to Site 1, each by a different relation,
+    # so all six counts are the full 6.
+
+    def test_site(self):
+        params = {"site": [self.site.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+        params = {"site_id": [self.site.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+
+    def test_region(self):
+        params = {"region": [self.region.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+        params = {"region_id": [self.region.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+
+    def test_site_group(self):
+        params = {"site_group": [self.site_group.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+        params = {"site_group_id": [self.site_group.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+
+    def test_region_matches_descendants(self):
+        """Selecting a parent region matches assignments sited in its children."""
+        params = {"region_id": [self.parent_region.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+
+    def test_scope_filters_ignore_absent_parameters(self):
+        """Guards the FilterMethod empty-queryset trap, which silently matched nothing."""
+        self.assertEqual(self.filterset({}, self.queryset).qs.count(), 6)
+
+    # direction and family are single-valued ChoiceFilters, so assert one value at a time.
+
+    def test_direction(self):
+        params = {"direction": ACLAssignmentDirectionChoices.DIRECTION_EGRESS}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {"direction": ACLAssignmentDirectionChoices.DIRECTION_INGRESS}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_family(self):
+        params = {"family": ACLFamilyChoices.FAMILY_IPV4}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
+        params = {"family": ACLFamilyChoices.FAMILY_IPV6}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)

--- a/netbox_acls/tests/filtersets/test_extendedrules.py
+++ b/netbox_acls/tests/filtersets/test_extendedrules.py
@@ -1,0 +1,247 @@
+from django.db.backends.postgresql.psycopg_any import NumericRange
+from django.test import TestCase
+from netaddr import IPNetwork
+
+from ipam.models import RIR, Aggregate, IPAddress, IPRange, Prefix
+from utilities.testing import ChangeLoggedFilterSetTests
+
+from ...choices import (
+    ACLActionChoices,
+    ACLFamilyChoices,
+    ACLProtocolChoices,
+    ACLRuleActionChoices,
+    ACLTypeChoices,
+)
+from ...filtersets import ACLExtendedRuleFilterSet
+from ...models import AccessList, ACLExtendedRule
+from ...utils import normalize_port_ranges
+
+
+class ACLExtendedRuleFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
+    """FilterSet tests for ACLExtendedRule."""
+
+    queryset = ACLExtendedRule.objects.all()
+    filterset = ACLExtendedRuleFilterSet
+    # Reverse GenericRel accessors are not filterable fields, and the shared
+    # test_missing_filters check skips GenericForeignKey and GenericRelation but not
+    # GenericRel. These four are named differently from the filters that cover them,
+    # source_ipaddress, source_iprange, destination_ipaddress and destination_iprange.
+    # The port range columns are covered by the source_port and destination_port
+    # filters, which ask whether any stored range contains a given port. That is the
+    # useful question, so there is deliberately no filter named after the raw column.
+    ignore_fields = (
+        "source_ip_address",
+        "source_ip_range",
+        "destination_ip_address",
+        "destination_ip_range",
+        "source_port_ranges",
+        "destination_port_ranges",
+    )
+
+    @classmethod
+    def setUpTestData(cls):
+        rir = RIR.objects.create(name="RIR 1", slug="rir-1")
+        cls.aggregate = Aggregate.objects.create(prefix=IPNetwork("10.0.0.0/8"), rir=rir)
+        cls.source_prefix = Prefix.objects.create(prefix=IPNetwork("10.1.0.0/16"))
+        cls.destination_prefix = Prefix.objects.create(prefix=IPNetwork("10.2.0.0/16"))
+        cls.ip_address = IPAddress.objects.create(address=IPNetwork("10.0.0.1/24"))
+        cls.ip_range = IPRange.objects.create(
+            start_address=IPNetwork("10.0.1.1/24"),
+            end_address=IPNetwork("10.0.1.254/24"),
+        )
+
+        cls.access_list = AccessList.objects.create(
+            name="testextendedacl",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+
+        # Port ranges are stored half-open. normalize_port_ranges turns the inclusive
+        # form the UI shows into what the column holds, so 80 to 80 becomes [80, 81).
+        ACLExtendedRule.objects.create(
+            access_list=cls.access_list,
+            sequence=10,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            protocol=ACLProtocolChoices.PROTOCOL_TCP,
+            source=cls.source_prefix,
+            destination=cls.destination_prefix,
+            source_port_ranges=normalize_port_ranges([NumericRange(1024, 2048, bounds="[]")]),
+            destination_port_ranges=normalize_port_ranges([NumericRange(80, 80, bounds="[]")]),
+            description="permit web",
+            comments="reviewed quarterly",
+        )
+        ACLExtendedRule.objects.create(
+            access_list=cls.access_list,
+            sequence=20,
+            action=ACLRuleActionChoices.ACTION_DENY,
+            protocol=ACLProtocolChoices.PROTOCOL_UDP,
+            source=cls.ip_address,
+            destination=cls.ip_range,
+            destination_port_ranges=normalize_port_ranges([NumericRange(53, 53, bounds="[]")]),
+            description="deny dns",
+        )
+        ACLExtendedRule.objects.create(
+            access_list=cls.access_list,
+            sequence=30,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            protocol=ACLProtocolChoices.PROTOCOL_ICMP,
+            source=cls.aggregate,
+            destination=cls.ip_address,
+        )
+        ACLExtendedRule.objects.create(
+            access_list=cls.access_list,
+            sequence=40,
+            action=ACLRuleActionChoices.ACTION_REMARK,
+            remark="an extended remark",
+        )
+        ACLExtendedRule.objects.create(
+            access_list=cls.access_list,
+            sequence=50,
+            action=ACLRuleActionChoices.ACTION_DENY,
+            protocol=ACLProtocolChoices.PROTOCOL_IP,
+            source=cls.ip_range,
+            destination=cls.aggregate,
+            description="deny the range",
+        )
+
+    def test_q(self):
+        params = {"q": "an extended remark"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_q_matches_protocol(self):
+        params = {"q": ACLProtocolChoices.PROTOCOL_ICMP}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_access_list(self):
+        params = {"access_list_id": [self.access_list.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
+        params = {"access_list": [self.access_list.name]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
+
+    def test_sequence(self):
+        params = {"sequence": [10, 20]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_remark(self):
+        params = {"remark": ["an extended remark"]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_description(self):
+        params = {"description": ["permit web"]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_source_type(self):
+        params = {"source_type": "ipam.prefix"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"source_type": "ipam.aggregate"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"source_type": "ipam.iprange"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_source_id_is_type_agnostic(self):
+        """source_id filters the raw generic FK column, so it needs source_type to narrow."""
+        params = {"source_id": [self.source_prefix.pk], "source_type": "ipam.prefix"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_source_prefix(self):
+        params = {"source_prefix_id": [self.source_prefix.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"source_prefix": [self.source_prefix.prefix]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_source_ipaddress(self):
+        params = {"source_ipaddress_id": [self.ip_address.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"source_ipaddress": [self.ip_address.address]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_source_iprange(self):
+        params = {"source_iprange_id": [self.ip_range.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"source_iprange": [self.ip_range.start_address]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_source_aggregate(self):
+        params = {"source_aggregate_id": [self.aggregate.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"source_aggregate": [self.aggregate.prefix]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_destination_type(self):
+        params = {"destination_type": "ipam.prefix"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"destination_type": "ipam.iprange"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"destination_type": "ipam.aggregate"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_destination_id_is_type_agnostic(self):
+        """destination_id filters the raw generic FK column, so it needs destination_type."""
+        params = {
+            "destination_id": [self.destination_prefix.pk],
+            "destination_type": "ipam.prefix",
+        }
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_destination_prefix(self):
+        params = {"destination_prefix_id": [self.destination_prefix.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"destination_prefix": [self.destination_prefix.prefix]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_destination_iprange(self):
+        params = {"destination_iprange_id": [self.ip_range.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"destination_iprange": [self.ip_range.start_address]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_destination_ipaddress(self):
+        params = {"destination_ipaddress_id": [self.ip_address.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"destination_ipaddress": [self.ip_address.address]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_destination_aggregate(self):
+        params = {"destination_aggregate_id": [self.aggregate.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"destination_aggregate": [self.aggregate.prefix]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    # comments is a TextField, which django-filter maps to a single-valued CharFilter
+    # matching exactly, unlike the CharField-backed description above.
+
+    def test_comments(self):
+        params = {"comments": "reviewed quarterly"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_source_port(self):
+        params = {"source_port": 1500}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"source_port": 3000}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 0)
+
+    def test_destination_port(self):
+        params = {"destination_port": 80}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"destination_port": 53}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_destination_port_excludes_half_open_upper_bound(self):
+        """81 is the stored exclusive upper bound of an inclusive 80 to 80 range."""
+        params = {"destination_port": 81}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 0)
+
+    # action and protocol are single-valued ChoiceFilters, so assert one value at a time.
+
+    def test_action(self):
+        params = {"action": ACLRuleActionChoices.ACTION_PERMIT}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {"action": ACLRuleActionChoices.ACTION_DENY}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_protocol(self):
+        params = {"protocol": ACLProtocolChoices.PROTOCOL_TCP}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"protocol": ACLProtocolChoices.PROTOCOL_UDP}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)

--- a/netbox_acls/tests/filtersets/test_standardrules.py
+++ b/netbox_acls/tests/filtersets/test_standardrules.py
@@ -1,0 +1,153 @@
+from django.test import TestCase
+from netaddr import IPNetwork
+
+from ipam.models import RIR, Aggregate, IPAddress, IPRange, Prefix
+from utilities.testing import ChangeLoggedFilterSetTests
+
+from ...choices import ACLActionChoices, ACLFamilyChoices, ACLRuleActionChoices, ACLTypeChoices
+from ...filtersets import ACLStandardRuleFilterSet
+from ...models import AccessList, ACLStandardRule
+
+
+class ACLStandardRuleFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
+    """FilterSet tests for ACLStandardRule."""
+
+    queryset = ACLStandardRule.objects.all()
+    filterset = ACLStandardRuleFilterSet
+    # Reverse GenericRel accessors are not filterable fields, and the shared
+    # test_missing_filters check skips GenericForeignKey and GenericRelation but not
+    # GenericRel. These two are named differently from the filters that cover them,
+    # source_ipaddress and source_iprange, so they surface as false positives.
+    ignore_fields = ("source_ip_address", "source_ip_range")
+
+    @classmethod
+    def setUpTestData(cls):
+        rir = RIR.objects.create(name="RIR 1", slug="rir-1")
+        cls.aggregate = Aggregate.objects.create(prefix=IPNetwork("10.0.0.0/8"), rir=rir)
+        cls.prefix = Prefix.objects.create(prefix=IPNetwork("10.1.0.0/16"))
+        cls.ip_address = IPAddress.objects.create(address=IPNetwork("10.0.0.1/24"))
+        cls.ip_range = IPRange.objects.create(
+            start_address=IPNetwork("10.0.1.1/24"),
+            end_address=IPNetwork("10.0.1.254/24"),
+        )
+
+        cls.access_list = AccessList.objects.create(
+            name="teststandardacl",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+
+        # create() rather than bulk_create(), because save() is what runs
+        # cache_related_source_object() to populate the _source_* shadow columns
+        # that the source_prefix and friends filters actually query.
+        ACLStandardRule.objects.create(
+            access_list=cls.access_list,
+            sequence=10,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=cls.prefix,
+            description="permit the prefix",
+            comments="reviewed quarterly",
+        )
+        ACLStandardRule.objects.create(
+            access_list=cls.access_list,
+            sequence=20,
+            action=ACLRuleActionChoices.ACTION_DENY,
+            source=cls.ip_address,
+            description="deny the address",
+        )
+        ACLStandardRule.objects.create(
+            access_list=cls.access_list,
+            sequence=30,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=cls.ip_range,
+        )
+        ACLStandardRule.objects.create(
+            access_list=cls.access_list,
+            sequence=40,
+            action=ACLRuleActionChoices.ACTION_REMARK,
+            remark="a standard remark",
+        )
+        ACLStandardRule.objects.create(
+            access_list=cls.access_list,
+            sequence=50,
+            action=ACLRuleActionChoices.ACTION_DENY,
+            source=cls.aggregate,
+            description="deny the aggregate",
+        )
+
+    def test_q(self):
+        params = {"q": "a standard remark"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_q_matches_access_list_name(self):
+        params = {"q": "teststandardacl"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
+
+    def test_access_list(self):
+        params = {"access_list_id": [self.access_list.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
+        params = {"access_list": [self.access_list.name]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
+
+    def test_sequence(self):
+        params = {"sequence": [10, 20]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_remark(self):
+        params = {"remark": ["a standard remark"]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_description(self):
+        params = {"description": ["permit the prefix", "deny the address"]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_source_type(self):
+        params = {"source_type": "ipam.prefix"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"source_type": "ipam.iprange"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_source_id_is_type_agnostic(self):
+        """source_id filters the raw generic FK column, so it needs source_type to narrow."""
+        params = {"source_id": [self.prefix.pk], "source_type": "ipam.prefix"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_source_prefix(self):
+        params = {"source_prefix_id": [self.prefix.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"source_prefix": [self.prefix.prefix]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_source_ipaddress(self):
+        params = {"source_ipaddress_id": [self.ip_address.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"source_ipaddress": [self.ip_address.address]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_source_iprange(self):
+        params = {"source_iprange_id": [self.ip_range.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"source_iprange": [self.ip_range.start_address]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_source_aggregate(self):
+        params = {"source_aggregate_id": [self.aggregate.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"source_aggregate": [self.aggregate.prefix]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    # comments is a TextField, which django-filter maps to a single-valued CharFilter
+    # matching exactly, unlike the CharField-backed description above.
+
+    def test_comments(self):
+        params = {"comments": "reviewed quarterly"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    # action is a single-valued ChoiceFilter, so assert one value at a time.
+
+    def test_action(self):
+        params = {"action": ACLRuleActionChoices.ACTION_PERMIT}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {"action": ACLRuleActionChoices.ACTION_REMARK}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #388

## New Behavior

Adds dedicated tests for all four plugin filtersets, covering every declared filter and its expected queryset behavior.

This includes value-based lookups for all four source and destination shadow fields, assignment scope filters across all five supported target types, and verification that standard-rule filters only offer standard access lists.

## Contrast to Current Behavior

The plugin previously had no dedicated filterset tests, so regressions affecting filter results in the UI or REST API could go undetected.

## Discussion: Benefits and Drawbacks

This makes the expected filter behavior explicit and provides regression coverage for the repeated source, destination, and assignment scope logic. It also provides a safer foundation for future filterset refactoring.

The change is backwards-compatible and does not alter the user-facing interface. The additional tests add a small amount of test runtime and maintenance.

## Changes to the Documentation

No documentation changes are required because this PR only adds test coverage.

## Proposed Release Note Entry

Add comprehensive test coverage for all plugin filtersets.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets `main` (fix to the current release).