### PR TITLE
Closes #389: Add table test coverage

### DIFF
--- a/netbox_acls/tests/tables/base.py
+++ b/netbox_acls/tests/tables/base.py
@@ -1,0 +1,15 @@
+"""
+Shim for NetBox's table test base, which arrived in NetBox 4.5.8.
+
+The plugin's floor is 4.5.0, so it cannot be imported unconditionally. Import this
+module and subclass ``base.StandardTableTestCase``. Importing the name into a test
+module instead makes the runner collect the base as a test case of its own, where its
+setUpClass errors for want of a table.
+"""
+
+try:
+    from utilities.testing import TableTestCases
+
+    StandardTableTestCase = TableTestCases.StandardTableTestCase
+except ImportError:  # NetBox < 4.5.8 ships no table test base
+    from django.test import SimpleTestCase as StandardTableTestCase  # noqa: F401

--- a/netbox_acls/tests/tables/test_accesslists.py
+++ b/netbox_acls/tests/tables/test_accesslists.py
@@ -1,12 +1,6 @@
 from ...tables import AccessListTable
-
-try:
-    from utilities.testing import TableTestCases
-except ImportError:  # NetBox < ~4.5.8 (aci's shim cites 4.5.10) ships no table-test base
-    TableTestCases = None
+from . import base
 
 
-if TableTestCases is not None:
-
-    class AccessListTableTestCase(TableTestCases.StandardTableTestCase):
-        table = AccessListTable
+class AccessListTableTestCase(base.StandardTableTestCase):
+    table = AccessListTable

--- a/netbox_acls/tests/tables/test_aclassignments.py
+++ b/netbox_acls/tests/tables/test_aclassignments.py
@@ -1,0 +1,6 @@
+from ...tables import ACLAssignmentTable
+from . import base
+
+
+class ACLAssignmentTableTestCase(base.StandardTableTestCase):
+    table = ACLAssignmentTable

--- a/netbox_acls/tests/tables/test_extendedrules.py
+++ b/netbox_acls/tests/tables/test_extendedrules.py
@@ -1,0 +1,6 @@
+from ...tables import ACLExtendedRuleTable
+from . import base
+
+
+class ACLExtendedRuleTableTestCase(base.StandardTableTestCase):
+    table = ACLExtendedRuleTable

--- a/netbox_acls/tests/tables/test_standardrules.py
+++ b/netbox_acls/tests/tables/test_standardrules.py
@@ -1,0 +1,6 @@
+from ...tables import ACLStandardRuleTable
+from . import base
+
+
+class ACLStandardRuleTableTestCase(base.StandardTableTestCase):
+    table = ACLStandardRuleTable


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #389

## New Behavior

Adds table test coverage for the plugin’s models using NetBox’s shared `TableTestCases`.

The NetBox version guard is placed in a shared test base module so these test cases are collected only on NetBox 4.5.8 and later, where `utilities.testing.TableTestCases` is available.

## Contrast to Current Behavior

The plugin previously had no dedicated table tests. Collecting the new tests unconditionally would also fail on supported NetBox versions that do not yet provide `TableTestCases`.

## Discussion: Benefits and Drawbacks

This adds regression coverage for the plugin’s table definitions while preserving compatibility with older supported NetBox releases.

The version guard adds a small amount of test infrastructure, and the table tests are skipped on NetBox versions earlier than 4.5.8.

## Changes to the Documentation

No documentation changes are required because this PR only adds test coverage.

## Proposed Release Note Entry

Add table test coverage with compatibility for supported NetBox versions.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets `main` (fix to the current release).