### PR TITLE
Fixes #407: Correct ACL Assignment scope filter parameter types and lookups

### DIFF
--- a/netbox_acls/filtersets.py
+++ b/netbox_acls/filtersets.py
@@ -7,11 +7,11 @@ import django_filters
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
-from dcim.models import Device, Interface, Region, Site, SiteGroup, VirtualChassis
+from dcim.models import Device, Interface, Region, SiteGroup, VirtualChassis
 from ipam.models import Aggregate, IPAddress, IPRange, Prefix
 from netbox.filtersets import NetBoxModelFilterSet, PrimaryModelFilterSet
 from users.filterset_mixins import OwnerFilterMixin
-from utilities.filters import ContentTypeFilter
+from utilities.filters import ContentTypeFilter, MultiValueCharFilter, MultiValueNumberFilter
 from utilities.filtersets import register_filterset
 from virtualization.models import VirtualMachine, VMInterface
 
@@ -83,41 +83,35 @@ class ACLAssignmentFilterSet(OwnerFilterMixin, NetBoxModelFilterSet):
     )
 
     # Organization
-    region_id = django_filters.ModelMultipleChoiceFilter(
-        field_name="site__region",
-        queryset=Region.objects.all(),
-        method="filter_nested_scope",
+    region_id = MultiValueNumberFilter(
+        field_name="pk",
+        method="filter_region",
         label=_("Region (ID)"),
     )
-    region = django_filters.ModelMultipleChoiceFilter(
-        field_name="site__region",
-        queryset=Region.objects.all(),
-        method="filter_nested_scope",
-        label=_("Region (ID)"),
+    region = MultiValueCharFilter(
+        field_name="slug",
+        method="filter_region",
+        label=_("Region (slug)"),
     )
-    site_group_id = django_filters.ModelMultipleChoiceFilter(
-        field_name="site__group",
-        queryset=SiteGroup.objects.all(),
-        method="filter_nested_scope",
+    site_group_id = MultiValueNumberFilter(
+        field_name="pk",
+        method="filter_site_group",
         label=_("Site group (ID)"),
     )
-    site_group = django_filters.ModelMultipleChoiceFilter(
-        field_name="site__group",
-        queryset=SiteGroup.objects.all(),
-        method="filter_nested_scope",
-        label=_("Site group (ID)"),
+    site_group = MultiValueCharFilter(
+        field_name="slug",
+        method="filter_site_group",
+        label=_("Site group (slug)"),
     )
-    site_id = django_filters.ModelMultipleChoiceFilter(
-        field_name="site",
-        queryset=Site.objects.all(),
-        method="filter_scope",
+    site_id = MultiValueNumberFilter(
+        field_name="pk",
+        method="filter_site",
         label=_("Site (ID)"),
     )
-    site = django_filters.ModelMultipleChoiceFilter(
-        field_name="site",
-        queryset=Site.objects.all(),
-        method="filter_scope",
-        label=_("Site (ID)"),
+    site = MultiValueCharFilter(
+        field_name="slug",
+        method="filter_site",
+        label=_("Site (slug)"),
     )
 
     # Device
@@ -229,29 +223,38 @@ class ACLAssignmentFilterSet(OwnerFilterMixin, NetBoxModelFilterSet):
         )
         return queryset.filter(query)
 
-    def _filter_scope(self, queryset, lookup, pks):
-        # FilterMethod's own guard misses this: an empty queryset is not in EMPTY_VALUES.
-        if not pks:
-            return queryset
+    def _filter_scope(self, queryset, lookup, values):
         query = Q()
         for path in ACL_ASSIGNMENT_SITE_TRAVERSAL_PATHS:
-            query |= Q(**{f"{path}__{lookup}__in": pks})
+            query |= Q(**{f"{path}__{lookup}__in": values})
         return queryset.filter(query).distinct()
 
-    def filter_scope(self, queryset, name, value):
-        """
-        Match a scope object through every assignable target type.
-        """
-        return self._filter_scope(queryset, name, {obj.pk for obj in value})
-
-    def filter_nested_scope(self, queryset, name, value):
-        """
-        Match a nested scope object and everything below it in the tree.
-        """
+    def _filter_nested_scope(self, queryset, model, path, lookup, values):
         pks = set()
-        for obj in value:
+        for obj in model.objects.filter(**{f"{lookup}__in": values}):
             pks.update(obj.get_descendants(include_self=True).values_list("pk", flat=True))
-        return self._filter_scope(queryset, name, pks)
+        # A value matching no object has to match no assignment either.
+        if not pks:
+            return queryset.none()
+        return self._filter_scope(queryset, f"{path}__pk", pks)
+
+    def filter_site(self, queryset, name, value):
+        """
+        Match a site through every assignable target type.
+        """
+        return self._filter_scope(queryset, f"site__{name}", value)
+
+    def filter_region(self, queryset, name, value):
+        """
+        Match a region and everything below it in the tree.
+        """
+        return self._filter_nested_scope(queryset, Region, "site__region", name, value)
+
+    def filter_site_group(self, queryset, name, value):
+        """
+        Match a site group and everything below it in the tree.
+        """
+        return self._filter_nested_scope(queryset, SiteGroup, "site__group", name, value)
 
 
 @register_filterset

--- a/netbox_acls/tests/filtersets/test_aclassignments.py
+++ b/netbox_acls/tests/filtersets/test_aclassignments.py
@@ -179,35 +179,64 @@ class ACLAssignmentFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {"virtual_chassis": [self.virtual_chassis.name]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
-    # Every assignment in this fixture resolves to Site 1, each by a different relation,
-    # so all six counts are the full 6.
+    # Every assignment resolves to Site 1 by a different relation, so each scope filter matches all 6.
+    # A rejected value leaves the count at 6 too, so the errors assertions are what make these bite.
 
     def test_site(self):
-        params = {"site": [self.site.pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
-        params = {"site_id": [self.site.pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+        filterset = self.filterset({"site": [self.site.slug]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 6)
+
+        filterset = self.filterset({"site_id": [self.site.pk]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 6)
 
     def test_region(self):
-        params = {"region": [self.region.pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
-        params = {"region_id": [self.region.pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+        filterset = self.filterset({"region": [self.region.slug]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 6)
+
+        filterset = self.filterset({"region_id": [self.region.pk]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 6)
 
     def test_site_group(self):
-        params = {"site_group": [self.site_group.pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
-        params = {"site_group_id": [self.site_group.pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+        filterset = self.filterset({"site_group": [self.site_group.slug]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 6)
+
+        filterset = self.filterset({"site_group_id": [self.site_group.pk]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 6)
 
     def test_region_matches_descendants(self):
         """Selecting a parent region matches assignments sited in its children."""
-        params = {"region_id": [self.parent_region.pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+        filterset = self.filterset({"region": [self.parent_region.slug]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 6)
+
+        filterset = self.filterset({"region_id": [self.parent_region.pk]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 6)
 
     def test_scope_filters_ignore_absent_parameters(self):
-        """Guards the FilterMethod empty-queryset trap, which silently matched nothing."""
+        """An absent scope parameter filters nothing out."""
         self.assertEqual(self.filterset({}, self.queryset).qs.count(), 6)
+
+    def test_scope_filters_reject_unresolvable_values(self):
+        """A value that resolves to no object matches nothing, not everything."""
+        # The absent ID has to be truthy, since the multi-value field discards falsy entries.
+        absent = 999999
+        for params in (
+            {"site": ["no-such-site"]},
+            {"site_id": [absent]},
+            {"region": ["no-such-region"]},
+            {"region_id": [absent]},
+            {"site_group": ["no-such-group"]},
+            {"site_group_id": [absent]},
+        ):
+            with self.subTest(params=params):
+                self.assertEqual(self.filterset(params, self.queryset).qs.count(), 0)
 
     # direction and family are single-valued ChoiceFilters, so assert one value at a time.
 


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #407

## New Behavior

Uses typed multi-value filters for ACL assignment scope filtering.

The `region`, `site_group`, and `site` parameters now accept slugs, while `region_id`, `site_group_id`, and `site_id` accept primary keys. The generated OpenAPI schema therefore publishes the bare parameters as string arrays and the `_id` parameters as integer arrays without schema-generation warnings.

Region and Site Group filters continue to include assignments from descendant objects.

## Contrast to Current Behavior

Previously, all six scope parameters were published as string arrays because their custom filters could not be typed by `drf-spectacular`.

The bare `region`, `site_group`, and `site` parameters also resolved primary keys rather than slugs, which did not follow NetBox's usual filter convention.

## Discussion: Benefits and Drawbacks

This aligns the assignment scope filters with NetBox's API conventions and provides accurate types for generated API clients.

This is an intentional breaking change for callers that currently pass primary keys through the bare parameter names. Those callers must switch to `region_id`, `site_group_id`, or `site_id`.

## Changes to the Documentation

No standalone documentation changes are required. The generated API schema now reflects the corrected parameter types, and the compatibility impact is documented in the release note below.

## Proposed Release Note Entry

Correct ACL assignment scope filters so `region`, `site_group`, and `site` accept slugs and their `_id` variants accept primary keys. Callers using primary keys with the bare parameter names must switch to the corresponding `_id` parameters.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets `main` (fix to the current release).