### PR TITLE
Fixes #395: Fix ACL quick search matching and comment lookup

### DIFF
--- a/netbox_acls/filtersets.py
+++ b/netbox_acls/filtersets.py
@@ -3,6 +3,8 @@ Filters enable users to request only a specific subset of objects matching a que
 when filtering the site list by status or region, for instance.
 """
 
+import contextlib
+
 import django_filters
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
@@ -53,13 +55,9 @@ class AccessListFilterSet(PrimaryModelFilterSet):
         """
         Override the default search behavior for the django model.
         """
-        query = (
-            Q(name__icontains=value)
-            | Q(type__icontains=value)
-            | Q(default_action__icontains=value)
-            | Q(description__icontains=value)
-            | Q(comments__icontains=value)
-        )
+        if not value.strip():
+            return queryset
+        query = Q(name__icontains=value) | Q(description__icontains=value) | Q(comments__icontains=value)
         return queryset.filter(query)
 
 
@@ -212,14 +210,16 @@ class ACLAssignmentFilterSet(OwnerFilterMixin, NetBoxModelFilterSet):
         """
         Override the default search behavior for the django model.
         """
+        if not value.strip():
+            return queryset
         query = (
             Q(access_list__name__icontains=value)
-            | Q(direction__icontains=value)
             | Q(interface__name__icontains=value)
             | Q(vminterface__name__icontains=value)
             | Q(device__name__icontains=value)
             | Q(virtual_chassis__name__icontains=value)
             | Q(virtual_machine__name__icontains=value)
+            | Q(comments__icontains=value)
         )
         return queryset.filter(query)
 
@@ -351,13 +351,17 @@ class ACLStandardRuleFilterSet(PrimaryModelFilterSet):
         """
         Override the default search behavior for the django model.
         """
+        if not value.strip():
+            return queryset
         query = (
             Q(access_list__name__icontains=value)
-            | Q(sequence__icontains=value)
-            | Q(action__icontains=value)
             | Q(remark__icontains=value)
             | Q(description__icontains=value)
+            | Q(comments__icontains=value)
         )
+        # Whole number, not a substring: q=1 must not return sequence 10.
+        with contextlib.suppress(ValueError):
+            query |= Q(sequence=int(value.strip()))
         return queryset.filter(query)
 
 
@@ -523,12 +527,15 @@ class ACLExtendedRuleFilterSet(PrimaryModelFilterSet):
         """
         Override the default search behavior for the django model.
         """
+        if not value.strip():
+            return queryset
         query = (
             Q(access_list__name__icontains=value)
-            | Q(sequence__icontains=value)
-            | Q(action__icontains=value)
             | Q(remark__icontains=value)
-            | Q(protocol__icontains=value)
             | Q(description__icontains=value)
+            | Q(comments__icontains=value)
         )
+        # Whole number, not a substring: q=1 must not return sequence 10.
+        with contextlib.suppress(ValueError):
+            query |= Q(sequence=int(value.strip()))
         return queryset.filter(query)

--- a/netbox_acls/tests/filtersets/test_accesslists.py
+++ b/netbox_acls/tests/filtersets/test_accesslists.py
@@ -47,9 +47,14 @@ class AccessListFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {"q": "testacl1"}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
-    def test_q_matches_default_action(self):
+    def test_q_ignores_choice_values(self):
+        """Zero is correct here. The default action has its own filter."""
         params = {"q": ACLActionChoices.ACTION_REJECT}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 0)
+
+    def test_q_ignores_blank_terms(self):
+        """Ignoring a blank term means returning everything, not nothing."""
+        self.assertEqual(self.filterset({"q": "   "}, self.queryset).qs.count(), 3)
 
     def test_name(self):
         params = {"name": ["testacl1", "testacl2"]}

--- a/netbox_acls/tests/filtersets/test_aclassignments.py
+++ b/netbox_acls/tests/filtersets/test_aclassignments.py
@@ -96,6 +96,7 @@ class ACLAssignmentFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
                 assigned_object_type=ContentType.objects.get_for_model(Interface),
                 assigned_object_id=cls.interface1.pk,
                 family=cls.acl1.family,
+                comments="reviewed quarterly",
             ),
             ACLAssignment(
                 access_list=cls.acl1,
@@ -142,6 +143,19 @@ class ACLAssignmentFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
     def test_q_matches_interface_name(self):
         params = {"q": "DeviceInterface1"}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_q_matches_comments(self):
+        params = {"q": "reviewed"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_q_ignores_choice_values(self):
+        """Zero is correct here. The direction has its own filter."""
+        params = {"q": ACLAssignmentDirectionChoices.DIRECTION_EGRESS}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 0)
+
+    def test_q_ignores_blank_terms(self):
+        """Ignoring a blank term means returning everything, not nothing."""
+        self.assertEqual(self.filterset({"q": "   "}, self.queryset).qs.count(), 6)
 
     def test_access_list(self):
         params = {"access_list_id": [self.acl1.pk]}

--- a/netbox_acls/tests/filtersets/test_extendedrules.py
+++ b/netbox_acls/tests/filtersets/test_extendedrules.py
@@ -109,9 +109,24 @@ class ACLExtendedRuleFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {"q": "an extended remark"}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
-    def test_q_matches_protocol(self):
+    def test_q_ignores_choice_values(self):
+        """Zero is correct here. The protocol has its own filter."""
         params = {"q": ACLProtocolChoices.PROTOCOL_ICMP}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 0)
+
+    def test_q_matches_sequence_exactly(self):
+        """A digit must not match every sequence that contains it."""
+        self.assertEqual(self.filterset({"q": "10"}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"q": "1"}, self.queryset).qs.count(), 0)
+        self.assertEqual(self.filterset({"q": "0"}, self.queryset).qs.count(), 0)
+
+    def test_q_matches_comments(self):
+        params = {"q": "reviewed"}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_q_ignores_blank_terms(self):
+        """Ignoring a blank term means returning everything, not nothing."""
+        self.assertEqual(self.filterset({"q": "   "}, self.queryset).qs.count(), 5)
 
     def test_access_list(self):
         params = {"access_list_id": [self.access_list.pk]}

--- a/netbox_acls/tests/filtersets/test_standardrules.py
+++ b/netbox_acls/tests/filtersets/test_standardrules.py
@@ -84,6 +84,24 @@ class ACLStandardRuleFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {"q": "teststandardacl"}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
 
+    def test_q_matches_comments(self):
+        params = {"q": "reviewed"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_q_ignores_choice_values(self):
+        """Two rules carry the Permit action, only one says permit in its text."""
+        self.assertEqual(self.filterset({"q": "permit"}, self.queryset).qs.count(), 1)
+
+    def test_q_matches_sequence_exactly(self):
+        """A digit must not match every sequence that contains it."""
+        self.assertEqual(self.filterset({"q": "10"}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"q": "1"}, self.queryset).qs.count(), 0)
+        self.assertEqual(self.filterset({"q": "0"}, self.queryset).qs.count(), 0)
+
+    def test_q_ignores_blank_terms(self):
+        """Ignoring a blank term means returning everything, not nothing."""
+        self.assertEqual(self.filterset({"q": "   "}, self.queryset).qs.count(), 5)
+
     def test_access_list(self):
         params = {"access_list_id": [self.access_list.pk]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #395

## New Behavior

Refines ACL quick search to use relevant names and free-text fields. Choice-backed fields such as ACL type, default action, rule action, protocol, and direction remain available through their dedicated filters instead of general search.

Numeric search terms now match rule sequence numbers exactly rather than as substrings. Comments are also searchable on ACL assignments and both standard and extended rules. A defensive blank-term guard returns the unmodified queryset.

## Contrast to Current Behavior

Quick search previously included several choice fields, so a term such as `deny` could match rules solely because their action was Deny.

Sequence numbers were matched as text, causing a search such as `q=1` to return sequences including 10 and 100. Comments on assignments and rules were not included in quick search.

## Discussion: Benefits and Drawbacks

This makes quick search results more predictable, avoids false-positive sequence matches, and makes comments discoverable as free text.

Callers that previously searched choice values through `q` must use the corresponding dedicated filters instead. This is an intentional correction to the search behavior and does not change the available API parameters.

## Changes to the Documentation

No documentation changes are required because this PR corrects the existing quick-search behavior.

## Proposed Release Note Entry

Correct ACL quick search to match sequence numbers exactly, exclude choice-backed fields, and include comments.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets `main` (fix to the current release).