### PR TITLE
Fixes #407: Preserve legacy ID support for ACL Assignment scope filters

### DIFF
--- a/netbox_acls/filtersets.py
+++ b/netbox_acls/filtersets.py
@@ -9,7 +9,7 @@ import django_filters
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
-from dcim.models import Device, Interface, Region, SiteGroup, VirtualChassis
+from dcim.models import Device, Interface, Region, Site, SiteGroup, VirtualChassis
 from ipam.models import Aggregate, IPAddress, IPRange, Prefix
 from netbox.filtersets import NetBoxModelFilterSet, PrimaryModelFilterSet
 from users.filterset_mixins import OwnerFilterMixin
@@ -229,9 +229,38 @@ class ACLAssignmentFilterSet(OwnerFilterMixin, NetBoxModelFilterSet):
             query |= Q(**{f"{path}__{lookup}__in": values})
         return queryset.filter(query).distinct()
 
+    def _resolve_scope_objects(self, model, values):
+        """
+        Resolve slugs, then primary keys for values no slug claimed.
+
+        The bare names took a primary key before 2.0.3. Numeric values still resolve so
+        those callers keep working. Deprecated, and the fallback goes in the next major.
+        """
+        numeric = {}
+        for value in values:
+            # Not str.isdigit(): it accepts superscript digits that int() then rejects.
+            try:
+                pk = int(value)
+            except ValueError:
+                continue
+            if pk > 0:
+                numeric[value] = pk
+        if not numeric:
+            return model.objects.filter(slug__in=values)
+
+        claimed = set(model.objects.filter(slug__in=list(numeric)).values_list("slug", flat=True))
+        legacy = [pk for value, pk in numeric.items() if value not in claimed]
+        if not legacy:
+            return model.objects.filter(slug__in=values)
+        return model.objects.filter(Q(slug__in=values) | Q(pk__in=legacy))
+
     def _filter_nested_scope(self, queryset, model, path, lookup, values):
+        if lookup == "slug":
+            objects = self._resolve_scope_objects(model, values)
+        else:
+            objects = model.objects.filter(pk__in=values)
         pks = set()
-        for obj in model.objects.filter(**{f"{lookup}__in": values}):
+        for obj in objects:
             pks.update(obj.get_descendants(include_self=True).values_list("pk", flat=True))
         # A value matching no object has to match no assignment either.
         if not pks:
@@ -242,6 +271,9 @@ class ACLAssignmentFilterSet(OwnerFilterMixin, NetBoxModelFilterSet):
         """
         Match a site through every assignable target type.
         """
+        if name == "slug":
+            pks = self._resolve_scope_objects(Site, value).values_list("pk", flat=True)
+            return self._filter_scope(queryset, "site__pk", list(pks))
         return self._filter_scope(queryset, f"site__{name}", value)
 
     def filter_region(self, queryset, name, value):

--- a/netbox_acls/tests/filtersets/test_aclassignments.py
+++ b/netbox_acls/tests/filtersets/test_aclassignments.py
@@ -233,6 +233,41 @@ class ACLAssignmentFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(filterset.errors, {})
         self.assertEqual(filterset.qs.count(), 6)
 
+    # Deprecated: the bare names took a primary key from 2.0.0 to 2.0.2, so both forms resolve.
+
+    def test_scope_filters_accept_legacy_primary_keys(self):
+        for params in (
+            {"site": [str(self.site.pk)]},
+            {"region": [str(self.region.pk)]},
+            {"site_group": [str(self.site_group.pk)]},
+        ):
+            with self.subTest(params=params):
+                filterset = self.filterset(params, self.queryset)
+                self.assertEqual(filterset.errors, {})
+                self.assertEqual(filterset.qs.count(), 6)
+
+    def test_scope_filters_prefer_a_slug_over_a_primary_key(self):
+        """A numeric slug wins over the site whose primary key it collides with."""
+        Site.objects.create(name="Site 2", slug=str(self.site.pk))
+
+        filterset = self.filterset({"site": [str(self.site.pk)]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 0)
+
+    def test_scope_filters_survive_an_out_of_range_number(self):
+        """A value too large for the primary key column matches nothing rather than erroring."""
+        filterset = self.filterset({"site": ["9" * 40]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 0)
+
+    def test_scope_filters_survive_unparsable_numeric_strings(self):
+        """str.isdigit() accepts a superscript, and int() rejects it and over-long strings."""
+        for value in ("²", "9" * 5000):
+            with self.subTest(value=value):
+                filterset = self.filterset({"site": [value]}, self.queryset)
+                self.assertEqual(filterset.errors, {})
+                self.assertEqual(filterset.qs.count(), 0)
+
     def test_scope_filters_ignore_absent_parameters(self):
         """An absent scope parameter filters nothing out."""
         self.assertEqual(self.filterset({}, self.queryset).qs.count(), 6)

--- a/netbox_acls/tests/views/base.py
+++ b/netbox_acls/tests/views/base.py
@@ -103,10 +103,14 @@ class ACLRuleSequenceTestsMixin:
         form = self._get_form("add", self.add_permission)
         self.assertIsNone(form.instance.sequence)
 
-    def test_non_numeric_access_list_is_ignored(self):
+    def test_malformed_access_list_is_ignored(self):
         """Test that a malformed access list id is ignored rather than raising."""
-        form = self._get_form("add", self.add_permission, query="?access_list=notanumber")
-        self.assertIsNone(form.instance.sequence)
+        # str.isdigit() is true for the superscript and the 5000-digit string, and int()
+        # rejects both.
+        for value in ("notanumber", "²", "9" * 5000):
+            with self.subTest(value=value):
+                form = self._get_form("add", self.add_permission, query=f"?access_list={value}")
+                self.assertIsNone(form.instance.sequence)
 
     def test_sequence_untouched_when_editing(self):
         """Test that editing an existing rule does not recompute its sequence."""

--- a/netbox_acls/views.py
+++ b/netbox_acls/views.py
@@ -54,12 +54,14 @@ class ACLRuleSequenceMixin:
         if obj.pk or "sequence" in request.GET:
             return obj
 
-        # Parse access_list ID; bail out gracefully if missing/invalid
-        access_list_id = request.GET.get("access_list")
-        if not access_list_id or not access_list_id.isdigit():
+        # Parse access_list ID; bail out gracefully if missing/invalid.
+        # Not str.isdigit(): it accepts superscript digits that int() then rejects.
+        try:
+            access_list_id = int(request.GET.get("access_list", ""))
+        except ValueError:
             return obj
 
-        obj.sequence = obj.__class__.objects.get_next_sequence(int(access_list_id))
+        obj.sequence = obj.__class__.objects.get_next_sequence(access_list_id)
         return obj
 
 


### PR DESCRIPTION
# Pull Request

## Related Issue

Addresses #407

Follow-up to #408

## New Behavior

Preserves compatibility for callers that pass primary keys through the bare `region`, `site_group`, and `site` ACL assignment filters.

Each value is resolved as a slug first. When no slug claims a numeric value, the filter falls back to the corresponding primary key. The explicit `region_id`, `site_group_id`, and `site_id` parameters remain the preferred way to filter by primary key.

Primary-key values on the bare parameters are deprecated and will be removed in the next major release.

## Contrast to Current Behavior

The initial correction for #407 made the bare parameters slug-only. That would cause callers relying on the behavior released in versions 2.0.0 through 2.0.2 to receive empty results silently after upgrading to 2.0.3.

This follow-up retains the corrected slug behavior and OpenAPI types while providing a temporary compatibility path for those existing callers.

## Discussion: Benefits and Drawbacks

This avoids an unnecessary compatibility break in a patch release and gives API users time to migrate to the explicit `_id` parameters.

When a numeric value matches both a slug and a primary key, the slug takes precedence, matching the documented contract for the bare parameter. The fallback therefore preserves legacy behavior except for this inherently ambiguous case.

The drawback is the temporary dual interpretation of numeric values and a small amount of additional resolver complexity. This compatibility fallback is intentionally deprecated and will be removed in the next major release.

## Changes to the Documentation

No standalone documentation changes are required. The 2.0.3 release notes will document the compatibility fallback and the deprecation of primary-key values on the bare parameters.

## Proposed Release Note Entry

Preserve legacy primary-key support for the bare ACL assignment scope filters while preferring matching slugs. Primary-key values on the bare parameters are deprecated in favor of the corresponding `_id` parameters.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets `main` (fix to the current release).
