### PR TITLE
Release v2.0.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
     attributes:
       label: NetBox ACLs Plugin version
       description: What version of NetBox ACLs are you currently running?
-      placeholder: v2.0.2
+      placeholder: v2.0.3
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -17,7 +17,7 @@ body:
     attributes:
       label: NetBox ACLs Plugin version
       description: What version of NetBox ACLs are you currently running?
-      placeholder: v2.0.2
+      placeholder: v2.0.3
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
-          version: "0.16.2"
+          version: "0.16.3"
           args: "check --output-format=github"
           src: "netbox_acls/"
 
@@ -33,7 +33,7 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
-          version: "0.16.2"
+          version: "0.16.3"
           args: "format --check --diff"
           src: "netbox_acls/"
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         # yamllint disable-line rule:line-length
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in
@@ -62,7 +62,7 @@ jobs:
       # (see below).
       - name: Autobuild
         # yamllint disable-line rule:line-length
-        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See:
@@ -78,4 +78,4 @@ jobs:
 
       - name: Perform CodeQL Analysis
         # yamllint disable-line rule:line-length
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.16.2"
+    rev: "v0.16.3"
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The following table details the tested plugin versions for each NetBox version:
 
 |   NetBox Version    | Plugin Version |
 |:-------------------:|:--------------:|
-|        4.6.x        |     2.0.2      |
-|        4.5.x        |     2.0.2      |
+|        4.6.x        |     2.0.3      |
+|        4.5.x        |     2.0.3      |
 |        4.4.x        |     1.9.1      |
 |        4.3.x        |     1.9.1      |
 |        4.2.x        |     1.8.1      |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,9 @@ classifiers=[
 [project.optional-dependencies]
 test = [
     "check-manifest==0.51",
-    "pre-commit==4.6.1",
+    "pre-commit==4.6.2",
     "pytest==9.1.1",
-    "ruff==0.16.2",
+    "ruff==0.16.3",
     "yamllint==1.38.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-acls"
-version = "2.0.2"
+version = "2.0.3"
 requires-python = ">=3.12.0"
 description = "NetBox plugin for managing Access Control Lists (ACLs)."
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
This patch release corrects ACL Assignment scope filtering, improves quick-search results, restores compatibility with early NetBox 4.5 releases, and fixes several filtering and form issues.

### Compatibility

* NetBox 4.6.x
* NetBox 4.5.x

### Bug Fixes

* Restored plugin loading on NetBox 4.5.0 and 4.5.1 by supporting the earlier `OwnerFilterMixin` import location. (#397)
* Fixed the Region, Site Group, and Site filters on ACL Assignments so they work from the UI and across all supported assignment targets. Region and Site Group filters now also include assignments within descendant scopes. (#394)
* Corrected the ACL Assignment scope filter contract and OpenAPI types. The bare `region`, `site_group`, and `site` parameters resolve slugs first, while `region_id`, `site_group_id`, and `site_id` explicitly filter by primary key. Numeric values passed through the bare parameters continue to fall back to primary keys for compatibility with versions 2.0.0 through 2.0.2. (#407)
* Corrected ACL quick search so that it searches textual content rather than choice values, matches rule sequence numbers as whole numbers, and includes comments on assignments and both rule types. (#395)
* Fixed filtering ACL Assignments and rules by Access List name, which previously returned a server error. (#384)
* Removed the stale `name` field reference from the Access List bulk-edit form. (#396)

### Other Changes

* Expanded regression test coverage across views, forms, filter sets, and tables for every plugin model, including assignment scope filters and bulk-edit fieldsets. (#387, #132, #388, #389)
* Re-recorded the API list-view query-count baselines for NetBox 4.6.8. (#399)

No database migrations are required for this release.
