### PR TITLE
Closes #67: Reduce duplicate ACL Rule code through shared components

### DIFF
--- a/netbox_acls/api/serializers.py
+++ b/netbox_acls/api/serializers.py
@@ -126,7 +126,7 @@ class ACLRuleSerializerMixin(serializers.Serializer):
     Fields and brief fields shared by both concrete rule serializers.
 
     Validation belongs to the models, which full_clean() reaches through
-    ValidatedModelSerializer. Do not reintroduce it here.
+    ValidatedModelSerializer.
     """
 
     access_list = AccessListSerializer(nested=True, required=True)

--- a/netbox_acls/api/serializers.py
+++ b/netbox_acls/api/serializers.py
@@ -4,7 +4,6 @@ while Django itself handles the database abstraction.
 """
 
 from django.contrib.contenttypes.models import ContentType
-from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
@@ -28,14 +27,9 @@ __all__ = [
     "AccessListSerializer",
 ]
 
-# Sets a standard error message for ACL rules with an action of remark, but no remark set.
-error_message_no_remark = _("Action is set to remark, you MUST add a remark.")
-# Sets a standard error message for ACL rules with an action of remark, but no source is set.
-error_message_action_remark_source_set = _("Action is set to remark, Source CANNOT be set.")
-# Sets a standard error message for ACL rules with an action not set to remark, but no remark is set.
-error_message_remark_without_action_remark = _("CANNOT set remark unless action is set to remark.")
-# Sets a standard error message for ACL rules no associated with an ACL of the same type.
-error_message_acl_type = _("Provided parent Access List is not of right type.")
+#
+# Access Lists
+#
 
 
 class AccessListSerializer(PrimaryModelSerializer):
@@ -73,35 +67,10 @@ class AccessListSerializer(PrimaryModelSerializer):
         )
         brief_fields = ("id", "url", "display", "name")
 
-    def validate(self, data):
-        """
-        Validates api inputs before processing:
-          - Check if Access List has no existing rules before changing the Access List's family.
-          - Check if Access List has no existing rules before changing the Access List's type.
-        """
-        error_message = {}
 
-        if self.instance:
-            target_family = data.get("family", self.instance.family)
-            target_type = data.get("type", self.instance.type)
-            has_rules = getattr(self.instance, "rule_count", 0) > 0
-
-            # Check if Access List has no existing rules before change the Access List's family.
-            if self.instance.family != target_family and has_rules:
-                error_message["family"] = [
-                    _("This ACL has ACL rules associated, CANNOT change ACL family."),
-                ]
-
-            # Check if Access List has no existing rules before change the Access List's type.
-            if self.instance.type != target_type and has_rules:
-                error_message["type"] = [
-                    _("This ACL has ACL rules associated, CANNOT change ACL type."),
-                ]
-
-        if error_message:
-            raise serializers.ValidationError(error_message)
-
-        return super().validate(data)
+#
+# ACL Assignments
+#
 
 
 class ACLAssignmentSerializer(OwnerMixin, NetBoxModelSerializer):
@@ -147,14 +116,19 @@ class ACLAssignmentSerializer(OwnerMixin, NetBoxModelSerializer):
         brief_fields = ("id", "url", "display", "access_list")
 
 
-class ACLStandardRuleSerializer(PrimaryModelSerializer):
+#
+# Access List Rules
+#
+
+
+class ACLRuleSerializerMixin(serializers.Serializer):
     """
-    Defines the serializer for the django ACLStandardRule model and associates it with a view.
+    Fields and brief fields shared by both concrete rule serializers.
+
+    Validation belongs to the models, which full_clean() reaches through
+    ValidatedModelSerializer. Do not reintroduce it here.
     """
 
-    url = serializers.HyperlinkedIdentityField(
-        view_name="plugins-api:netbox_acls-api:aclstandardrule-detail",
-    )
     access_list = AccessListSerializer(nested=True, required=True)
     source_type = ContentTypeField(
         queryset=ContentType.objects.filter(ACL_RULE_SOURCE_DESTINATION_MODELS),
@@ -170,6 +144,25 @@ class ACLStandardRuleSerializer(PrimaryModelSerializer):
     source = GFKSerializerField(read_only=True)
 
     class Meta:
+        brief_fields = (
+            "id",
+            "url",
+            "display",
+            "access_list",
+            "sequence",
+        )
+
+
+class ACLStandardRuleSerializer(ACLRuleSerializerMixin, PrimaryModelSerializer):
+    """
+    Defines the serializer for the django ACLStandardRule model and associates it with a view.
+    """
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_acls-api:aclstandardrule-detail",
+    )
+
+    class Meta(ACLRuleSerializerMixin.Meta):
         """
         Associates the django model ACLStandardRule & fields with the serializer.
         """
@@ -194,41 +187,9 @@ class ACLStandardRuleSerializer(PrimaryModelSerializer):
             "custom_fields",
             "last_updated",
         )
-        brief_fields = (
-            "id",
-            "url",
-            "display",
-            "access_list",
-            "sequence",
-        )
-
-    def validate(self, data):
-        """
-        Validate the ACLStandardRule django model's inputs before allowing it to update the instance:
-          - Check if action set to remark, but no remark set.
-          - Check if action set to remark, but source set.
-        """
-        error_message = {}
-
-        if data.get("action") == "remark":
-            # Check if action set to remark, but no remark set.
-            if data.get("remark") is None:
-                error_message["remark"] = [
-                    error_message_no_remark,
-                ]
-            # Check if action set to remark, but the source set.
-            if data.get("source"):
-                error_message["source"] = [
-                    error_message_action_remark_source_set,
-                ]
-
-        if error_message:
-            raise serializers.ValidationError(error_message)
-
-        return super().validate(data)
 
 
-class ACLExtendedRuleSerializer(PrimaryModelSerializer):
+class ACLExtendedRuleSerializer(ACLRuleSerializerMixin, PrimaryModelSerializer):
     """
     Defines the serializer for the django ACLExtendedRule model and associates it with a view.
     """
@@ -236,19 +197,6 @@ class ACLExtendedRuleSerializer(PrimaryModelSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name="plugins-api:netbox_acls-api:aclextendedrule-detail",
     )
-    access_list = AccessListSerializer(nested=True, required=True)
-    source_type = ContentTypeField(
-        queryset=ContentType.objects.filter(ACL_RULE_SOURCE_DESTINATION_MODELS),
-        required=False,
-        default=None,
-        allow_null=True,
-    )
-    source_id = serializers.IntegerField(
-        required=False,
-        default=None,
-        allow_null=True,
-    )
-    source = GFKSerializerField(read_only=True)
     source_port_ranges = IntegerRangeSerializer(many=True, required=False)
     source_port_terms = serializers.SerializerMethodField(read_only=True)
     destination_type = ContentTypeField(
@@ -266,7 +214,7 @@ class ACLExtendedRuleSerializer(PrimaryModelSerializer):
     destination_port_ranges = IntegerRangeSerializer(many=True, required=False)
     destination_port_terms = serializers.SerializerMethodField(read_only=True)
 
-    class Meta:
+    class Meta(ACLRuleSerializerMixin.Meta):
         """
         Associates the django model ACLExtendedRule & fields to the serializer.
         """
@@ -299,13 +247,6 @@ class ACLExtendedRuleSerializer(PrimaryModelSerializer):
             "custom_fields",
             "last_updated",
         )
-        brief_fields = (
-            "id",
-            "url",
-            "display",
-            "access_list",
-            "sequence",
-        )
 
     @extend_schema_field({"type": "array", "items": {"type": "string"}})
     def get_destination_port_terms(self, obj):
@@ -320,52 +261,3 @@ class ACLExtendedRuleSerializer(PrimaryModelSerializer):
         Fetches the source port terms for the given object.
         """
         return obj.source_port_ranges_list
-
-    def validate(self, data):
-        """
-        Validate the ACLExtendedRule django model's inputs before allowing it to update the instance:
-          - Check if action set to remark, but no remark set.
-          - Check if action set to remark, but source set.
-          - Check if action set to remark, but source_port_ranges set.
-          - Check if action set to remark, but destination set.
-          - Check if action set to remark, but destination_port_ranges set.
-          - Check if action set to remark, but protocol set.
-        """
-        error_message = {}
-
-        if data.get("action") == "remark":
-            # Check if action set to remark, but no remark set.
-            if data.get("remark") is None:
-                error_message["remark"] = [
-                    error_message_no_remark,
-                ]
-            # Check if action set to remark, but the source set.
-            if data.get("source"):
-                error_message["source"] = [
-                    error_message_action_remark_source_set,
-                ]
-            # Check if action set to remark, but source_port_ranges set.
-            if data.get("source_port_ranges"):
-                error_message["source_port_ranges"] = [
-                    _("Action is set to remark, Source Ports CANNOT be set."),
-                ]
-            # Check if action set to remark, but destination set.
-            if data.get("destination"):
-                error_message["destination"] = [
-                    _("Action is set to remark, Destination Prefix CANNOT be set."),
-                ]
-            # Check if action set to remark, but destination_port_ranges set.
-            if data.get("destination_port_ranges"):
-                error_message["destination_port_ranges"] = [
-                    _("Action is set to remark, Destination Ports CANNOT be set."),
-                ]
-            # Check if action set to remark, but protocol set.
-            if data.get("protocol"):
-                error_message["protocol"] = [
-                    _("Action is set to remark, Protocol CANNOT be set."),
-                ]
-
-        if error_message:
-            raise serializers.ValidationError(error_message)
-
-        return super().validate(data)

--- a/netbox_acls/filtersets.py
+++ b/netbox_acls/filtersets.py
@@ -289,13 +289,12 @@ class ACLAssignmentFilterSet(OwnerFilterMixin, NetBoxModelFilterSet):
         return self._filter_nested_scope(queryset, SiteGroup, "site__group", name, value)
 
 
-@register_filterset
-class ACLStandardRuleFilterSet(PrimaryModelFilterSet):
+class ACLRuleFilterSetMixin(django_filters.FilterSet):
     """
-    Define the filter set for the django model ACLStandardRule.
+    Filters shared by both concrete ACL rule filter sets.
     """
 
-    # Access List
+    # Access List. The extended set overrides both to narrow them by ACL type.
     access_list = django_filters.ModelMultipleChoiceFilter(
         field_name="access_list__name",
         queryset=AccessList.objects.all(),
@@ -360,24 +359,6 @@ class ACLStandardRuleFilterSet(PrimaryModelFilterSet):
         to_field_name="id",
         label=_("Source Prefix (ID)"),
     )
-
-    class Meta:
-        """
-        Associates the django model ACLStandardRule & fields with the filter set.
-        """
-
-        model = ACLStandardRule
-        fields = (
-            "id",
-            "access_list",
-            "sequence",
-            "action",
-            "remark",
-            "source_type",
-            "source_id",
-            "description",
-            "comments",
-        )
 
     def search(self, queryset, name, value):
         """
@@ -398,7 +379,32 @@ class ACLStandardRuleFilterSet(PrimaryModelFilterSet):
 
 
 @register_filterset
-class ACLExtendedRuleFilterSet(PrimaryModelFilterSet):
+class ACLStandardRuleFilterSet(ACLRuleFilterSetMixin, PrimaryModelFilterSet):
+    """
+    Define the filter set for the django model ACLStandardRule.
+    """
+
+    class Meta:
+        """
+        Associates the django model ACLStandardRule & fields with the filter set.
+        """
+
+        model = ACLStandardRule
+        fields = (
+            "id",
+            "access_list",
+            "sequence",
+            "action",
+            "remark",
+            "source_type",
+            "source_id",
+            "description",
+            "comments",
+        )
+
+
+@register_filterset
+class ACLExtendedRuleFilterSet(ACLRuleFilterSetMixin, PrimaryModelFilterSet):
     """
     Define the filter set for the django model ACLExtendedRule.
     """
@@ -417,57 +423,6 @@ class ACLExtendedRuleFilterSet(PrimaryModelFilterSet):
     )
 
     # Source
-    source_type = ContentTypeFilter(
-        label=_("Source Type"),
-    )
-    source_aggregate = django_filters.ModelMultipleChoiceFilter(
-        field_name="_source_aggregate__prefix",
-        queryset=Aggregate.objects.all(),
-        to_field_name="prefix",
-        label=_("Source Aggregate (name)"),
-    )
-    source_aggregate_id = django_filters.ModelMultipleChoiceFilter(
-        field_name="_source_aggregate",
-        queryset=Aggregate.objects.all(),
-        to_field_name="id",
-        label=_("Source Aggregate (ID)"),
-    )
-    source_ipaddress = django_filters.ModelMultipleChoiceFilter(
-        field_name="_source_ipaddress__address",
-        queryset=IPAddress.objects.all(),
-        to_field_name="address",
-        label=_("Source IP-Address (name)"),
-    )
-    source_ipaddress_id = django_filters.ModelMultipleChoiceFilter(
-        field_name="_source_ipaddress",
-        queryset=IPAddress.objects.all(),
-        to_field_name="id",
-        label=_("Source IP-Address (ID)"),
-    )
-    source_iprange = django_filters.ModelMultipleChoiceFilter(
-        field_name="_source_iprange__start_address",
-        queryset=IPRange.objects.all(),
-        to_field_name="start_address",
-        label=_("Source IP-Range (name)"),
-    )
-    source_iprange_id = django_filters.ModelMultipleChoiceFilter(
-        field_name="_source_iprange",
-        queryset=IPRange.objects.all(),
-        to_field_name="id",
-        label=_("Source IP-Range (ID)"),
-    )
-    source_prefix = django_filters.ModelMultipleChoiceFilter(
-        field_name="_source_prefix__prefix",
-        queryset=Prefix.objects.all(),
-        to_field_name="prefix",
-        label=_("Source Prefix (name)"),
-    )
-    source_prefix_id = django_filters.ModelMultipleChoiceFilter(
-        field_name="_source_prefix",
-        queryset=Prefix.objects.all(),
-        to_field_name="id",
-        label=_("Source Prefix (ID)"),
-    )
     source_port = django_filters.NumberFilter(
         field_name="source_port_ranges",
         lookup_expr="range_contains",
@@ -554,20 +509,3 @@ class ACLExtendedRuleFilterSet(PrimaryModelFilterSet):
             "description",
             "comments",
         )
-
-    def search(self, queryset, name, value):
-        """
-        Override the default search behavior for the django model.
-        """
-        if not value.strip():
-            return queryset
-        query = (
-            Q(access_list__name__icontains=value)
-            | Q(remark__icontains=value)
-            | Q(description__icontains=value)
-            | Q(comments__icontains=value)
-        )
-        # Whole number, not a substring: q=1 must not return sequence 10.
-        with contextlib.suppress(ValueError):
-            query |= Q(sequence=int(value.strip()))
-        return queryset.filter(query)

--- a/netbox_acls/forms/bulk_edit.py
+++ b/netbox_acls/forms/bulk_edit.py
@@ -1,5 +1,5 @@
 """
-Draft for a possible BulkEditForm, but may not be worth wile.
+Defines each django model's GUI form to edit multiple objects at once.
 """
 
 from django import forms

--- a/netbox_acls/forms/filtersets.py
+++ b/netbox_acls/forms/filtersets.py
@@ -217,7 +217,52 @@ class ACLAssignmentFilterForm(OwnerFilterMixin, NetBoxModelFilterSetForm):
     tag = TagFilterField(model)
 
 
-class ACLStandardRuleFilterForm(PrimaryModelFilterSetForm):
+class ACLRuleFilterFormMixin(forms.Form):
+    """
+    Filter fields shared by both concrete rule filter forms.
+
+    The Access List picker stays on each concrete form, since the two narrow it
+    to different ACL types.
+    """
+
+    sequence = forms.IntegerField(
+        required=False,
+        label=_("Sequence"),
+    )
+    action = forms.ChoiceField(
+        choices=add_blank_choice(ACLRuleActionChoices),
+        required=False,
+        label=_("Action"),
+    )
+    remark = forms.CharField(
+        required=False,
+        label=_("Remark"),
+    )
+
+    # Source selectors
+    source_aggregate_id = DynamicModelMultipleChoiceField(
+        queryset=Aggregate.objects.all(),
+        required=False,
+        label=_("Source Aggregate"),
+    )
+    source_ipaddress_id = DynamicModelMultipleChoiceField(
+        queryset=IPAddress.objects.all(),
+        required=False,
+        label=_("Source IP-Address"),
+    )
+    source_iprange_id = DynamicModelMultipleChoiceField(
+        queryset=IPRange.objects.all(),
+        required=False,
+        label=_("Source IP-Range"),
+    )
+    source_prefix_id = DynamicModelMultipleChoiceField(
+        queryset=Prefix.objects.all(),
+        required=False,
+        label=_("Source Prefix"),
+    )
+
+
+class ACLStandardRuleFilterForm(ACLRuleFilterFormMixin, PrimaryModelFilterSetForm):
     """
     GUI filter form to search the django ACLStandardRule model.
     """
@@ -258,47 +303,12 @@ class ACLStandardRuleFilterForm(PrimaryModelFilterSetForm):
         required=False,
         label=_("Access List"),
     )
-    sequence = forms.IntegerField(
-        required=False,
-        label=_("Sequence"),
-    )
-    action = forms.ChoiceField(
-        choices=add_blank_choice(ACLRuleActionChoices),
-        required=False,
-        label=_("Action"),
-    )
-    remark = forms.CharField(
-        required=False,
-        label=_("Remark"),
-    )
-
-    # Source selectors
-    source_aggregate_id = DynamicModelMultipleChoiceField(
-        queryset=Aggregate.objects.all(),
-        required=False,
-        label=_("Source Aggregate"),
-    )
-    source_ipaddress_id = DynamicModelMultipleChoiceField(
-        queryset=IPAddress.objects.all(),
-        required=False,
-        label=_("Source IP-Address"),
-    )
-    source_iprange_id = DynamicModelMultipleChoiceField(
-        queryset=IPRange.objects.all(),
-        required=False,
-        label=_("Source IP-Range"),
-    )
-    source_prefix_id = DynamicModelMultipleChoiceField(
-        queryset=Prefix.objects.all(),
-        required=False,
-        label=_("Source Prefix"),
-    )
 
     # Tag selector
     tag = TagFilterField(model)
 
 
-class ACLExtendedRuleFilterForm(PrimaryModelFilterSetForm):
+class ACLExtendedRuleFilterForm(ACLRuleFilterFormMixin, PrimaryModelFilterSetForm):
     """
     GUI filter form to search the django ACLExtendedRule model.
     """
@@ -349,46 +359,12 @@ class ACLExtendedRuleFilterForm(PrimaryModelFilterSetForm):
         required=False,
         label=_("Access List"),
     )
-    sequence = forms.IntegerField(
-        required=False,
-        label=_("Sequence"),
-    )
-    action = forms.ChoiceField(
-        choices=add_blank_choice(ACLRuleActionChoices),
-        required=False,
-        label=_("Action"),
-    )
-    remark = forms.CharField(
-        required=False,
-        label=_("Remark"),
-    )
     protocol = forms.ChoiceField(
         choices=add_blank_choice(ACLProtocolChoices),
         required=False,
         label=_("Protocol"),
     )
 
-    # Source selectors
-    source_aggregate_id = DynamicModelMultipleChoiceField(
-        queryset=Aggregate.objects.all(),
-        required=False,
-        label=_("Source Aggregate"),
-    )
-    source_ipaddress_id = DynamicModelMultipleChoiceField(
-        queryset=IPAddress.objects.all(),
-        required=False,
-        label=_("Source IP-Address"),
-    )
-    source_iprange_id = DynamicModelMultipleChoiceField(
-        queryset=IPRange.objects.all(),
-        required=False,
-        label=_("Source IP-Range"),
-    )
-    source_prefix_id = DynamicModelMultipleChoiceField(
-        queryset=Prefix.objects.all(),
-        required=False,
-        label=_("Source Prefix"),
-    )
     source_port = forms.IntegerField(
         label=_("Source Port"),
         required=False,

--- a/netbox_acls/models/access_list_rules.py
+++ b/netbox_acls/models/access_list_rules.py
@@ -69,7 +69,6 @@ class ACLRule(PrimaryModel):
     access_list = models.ForeignKey(
         to=AccessList,
         on_delete=models.CASCADE,
-        related_name="rules",
         verbose_name=_("Access List"),
     )
 

--- a/netbox_acls/models/access_list_rules.py
+++ b/netbox_acls/models/access_list_rules.py
@@ -2,7 +2,6 @@
 Define the django models for this plugin.
 """
 
-from django.apps import apps
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.postgres.fields import ArrayField, IntegerRangeField
 from django.core.exceptions import ValidationError
@@ -12,6 +11,7 @@ from django.utils.translation import gettext_lazy as _
 from ipam.models import Aggregate, IPAddress, IPRange, Prefix
 from netbox.models import PrimaryModel
 from utilities.data import ranges_to_string_list
+from utilities.object_types import object_type_identifier
 
 from ..choices import (
     ACLFamilyChoices,
@@ -157,6 +157,9 @@ class ACLRule(PrimaryModel):
     )
     prerequisite_models: tuple = ("netbox_acls.AccessList",)
 
+    # Generic references mirrored into shadow columns, one set per role.
+    cached_object_roles = ("source",)
+
     class Meta:
         """
         Define the common model properties:
@@ -221,28 +224,28 @@ class ACLRule(PrimaryModel):
         """
         Saves the current instance to the database.
         """
-        # Cache the related source objects for faster access
-        self.cache_related_source_object()
+        # Cache the related objects for faster access
+        for role in self.cached_object_roles:
+            self.cache_related_objects(role)
 
         super().save(*args, **kwargs)
 
-    def cache_related_source_object(self):
+    def cache_related_objects(self, role):
         """
-        Cache the related source objects for faster access.
+        Refresh one role's shadow columns from its generic reference.
         """
-        self._source_aggregate = self._source_ipaddress = self._source_iprange = self._source_prefix = None
-        if self.source_type:
-            source_type = self.source_type.model_class()
-            if source_type == apps.get_model("ipam", "aggregate"):
-                self._source_aggregate = self.source
-            elif source_type == apps.get_model("ipam", "ipaddress"):
-                self._source_ipaddress = self.source
-            elif source_type == apps.get_model("ipam", "iprange"):
-                self._source_iprange = self.source
-            elif source_type == apps.get_model("ipam", "prefix"):
-                self._source_prefix = self.source
+        content_type = getattr(self, f"{role}_type")
+        label = object_type_identifier(content_type) if content_type else None
+        prefix = f"_{role}_"
 
-    cache_related_source_object.alters_data = True
+        # Shadow columns are located by name, so _<role>_<model> is a contract.
+        for field in self._meta.fields:
+            if not field.is_relation or not field.name.startswith(prefix):
+                continue
+            matched = field.related_model._meta.label_lower == label
+            setattr(self, field.name, getattr(self, role) if matched else None)
+
+    cache_related_objects.alters_data = True
 
     def _validate_rule_family(self):
         """
@@ -440,6 +443,8 @@ class ACLExtendedRule(ACLRule):
         "protocol",
     )
 
+    cached_object_roles = ("source", "destination")
+
     class Meta(ACLRule.Meta):
         """
         Define the model properties adding to or overriding the inherited class:
@@ -513,35 +518,6 @@ class ACLExtendedRule(ACLRule):
         validate_port_ranges(self.source_port_ranges, "source_port_ranges")
         validate_port_ranges(self.destination_port_ranges, "destination_port_ranges")
 
-    def save(self, *args, **kwargs):
-        """
-        Saves the current instance to the database.
-        """
-        # Cache the related destination objects for faster access
-        self.cache_related_destination_objects()
-
-        super().save(*args, **kwargs)
-
-    def cache_related_destination_objects(self):
-        """
-        Cache the related destination objects for faster access.
-        """
-        self._destination_aggregate = self._destination_ipaddress = self._destination_iprange = (
-            self._destination_prefix
-        ) = None
-        if self.destination_type:
-            destination_type = self.destination_type.model_class()
-            if destination_type == apps.get_model("ipam", "aggregate"):
-                self._destination_aggregate = self.destination
-            elif destination_type == apps.get_model("ipam", "ipaddress"):
-                self._destination_ipaddress = self.destination
-            elif destination_type == apps.get_model("ipam", "iprange"):
-                self._destination_iprange = self.destination
-            elif destination_type == apps.get_model("ipam", "prefix"):
-                self._destination_prefix = self.destination
-
-    cache_related_destination_objects.alters_data = True
-
     @property
     def destination_port_ranges_list(self):
         """
@@ -588,106 +564,24 @@ class ACLExtendedRule(ACLRule):
 
 
 #
-# Generic Relations: ACLStandardRule
+# Generic Relations
 #
 
-# Source Aggregate
-GenericRelation(
-    to=ACLStandardRule,
-    content_type_field="source_type",
-    object_id_field="source_id",
-    related_query_name="source_aggregate",
-).contribute_to_class(Aggregate, "accesslist_standard_rule_sources")
-
-# Source IPAddress
-GenericRelation(
-    to=ACLStandardRule,
-    content_type_field="source_type",
-    object_id_field="source_id",
-    related_query_name="source_ip_address",
-).contribute_to_class(IPAddress, "accesslist_standard_rule_sources")
-
-# Source IPRange
-GenericRelation(
-    to=ACLStandardRule,
-    content_type_field="source_type",
-    object_id_field="source_id",
-    related_query_name="source_ip_range",
-).contribute_to_class(IPRange, "accesslist_standard_rule_sources")
-
-# Source Prefix
-GenericRelation(
-    to=ACLStandardRule,
-    content_type_field="source_type",
-    object_id_field="source_id",
-    related_query_name="source_prefix",
-).contribute_to_class(Prefix, "accesslist_standard_rule_sources")
-
-
-#
-# Generic Relations: ACLExtendedRule
-#
-
-# Source Aggregate
-GenericRelation(
-    to=ACLExtendedRule,
-    content_type_field="source_type",
-    object_id_field="source_id",
-    related_query_name="source_aggregate",
-).contribute_to_class(Aggregate, "accesslist_extended_rule_sources")
-
-# Source IPAddress
-GenericRelation(
-    to=ACLExtendedRule,
-    content_type_field="source_type",
-    object_id_field="source_id",
-    related_query_name="source_ip_address",
-).contribute_to_class(IPAddress, "accesslist_extended_rule_sources")
-
-# Source IPRange
-GenericRelation(
-    to=ACLExtendedRule,
-    content_type_field="source_type",
-    object_id_field="source_id",
-    related_query_name="source_ip_range",
-).contribute_to_class(IPRange, "accesslist_extended_rule_sources")
-
-# Source Prefix
-GenericRelation(
-    to=ACLExtendedRule,
-    content_type_field="source_type",
-    object_id_field="source_id",
-    related_query_name="source_prefix",
-).contribute_to_class(Prefix, "accesslist_extended_rule_sources")
-
-# Destination Aggregate
-GenericRelation(
-    to=ACLExtendedRule,
-    content_type_field="destination_type",
-    object_id_field="destination_id",
-    related_query_name="destination_aggregate",
-).contribute_to_class(Aggregate, "accesslist_extended_rule_destinations")
-
-# Destination IPAddress
-GenericRelation(
-    to=ACLExtendedRule,
-    content_type_field="destination_type",
-    object_id_field="destination_id",
-    related_query_name="destination_ip_address",
-).contribute_to_class(IPAddress, "accesslist_extended_rule_destinations")
-
-# Destination IPRange
-GenericRelation(
-    to=ACLExtendedRule,
-    content_type_field="destination_type",
-    object_id_field="destination_id",
-    related_query_name="destination_ip_range",
-).contribute_to_class(IPRange, "accesslist_extended_rule_destinations")
-
-# Destination Prefix
-GenericRelation(
-    to=ACLExtendedRule,
-    content_type_field="destination_type",
-    object_id_field="destination_id",
-    related_query_name="destination_prefix",
-).contribute_to_class(Prefix, "accesslist_extended_rule_destinations")
+for _rule_model, _role, _accessor in (
+    (ACLStandardRule, "source", "accesslist_standard_rule_sources"),
+    (ACLExtendedRule, "source", "accesslist_extended_rule_sources"),
+    (ACLExtendedRule, "destination", "accesslist_extended_rule_destinations"),
+):
+    # The query name segment differs from the model name where that runs words together.
+    for _model, _query_name in (
+        (Aggregate, "aggregate"),
+        (IPAddress, "ip_address"),
+        (IPRange, "ip_range"),
+        (Prefix, "prefix"),
+    ):
+        GenericRelation(
+            to=_rule_model,
+            content_type_field=f"{_role}_type",
+            object_id_field=f"{_role}_id",
+            related_query_name=f"{_role}_{_query_name}",
+        ).contribute_to_class(_model, _accessor)

--- a/netbox_acls/models/access_list_rules.py
+++ b/netbox_acls/models/access_list_rules.py
@@ -348,7 +348,7 @@ class ACLExtendedRule(ACLRule):
         to=AccessList,
         on_delete=models.CASCADE,
         related_name="aclextendedrules",
-        limit_choices_to={"type": "extended"},
+        limit_choices_to={"type": ACLTypeChoices.TYPE_EXTENDED},
         verbose_name=_("Extended Access List"),
     )
 

--- a/netbox_acls/tables.py
+++ b/netbox_acls/tables.py
@@ -199,28 +199,12 @@ class ACLExtendedRuleTable(ACLRuleTable):
     Defines the table view for the ACLExtendedRule model.
     """
 
-    access_list = tables.Column(
-        linkify=True,
-    )
-    sequence = tables.Column(
-        verbose_name=_("Seq"),
-        linkify=True,
-    )
-    action = columns.ChoiceFieldColumn()
     tags = columns.TagColumn(
         url_name="plugins:netbox_acls:aclextendedrule_list",
     )
     protocol = columns.ChoiceFieldColumn()
 
     # Source
-    source_type = columns.ContentTypeColumn(
-        verbose_name=_("Source Type"),
-    )
-    source = tables.Column(
-        verbose_name=_("Source"),
-        orderable=False,
-        linkify=True,
-    )
     source_port_ranges_list = columns.ArrayColumn(
         verbose_name=_("Source Ports"),
         orderable=False,

--- a/netbox_acls/tests/api/test_access_list_rules.py
+++ b/netbox_acls/tests/api/test_access_list_rules.py
@@ -132,6 +132,20 @@ class ACLStandardRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
             ["When the action is 'remark', a remark is required."],
         )
 
+    def test_remark_action_accepts_a_rule_that_already_has_a_remark(self):
+        """Test that a partial update need not resend the remark alongside the action."""
+        rule = ACLStandardRule.objects.get(access_list=self.access_list_device, sequence=20)
+        self.assertTrue(rule.remark)
+
+        self.add_permissions("netbox_acls.change_aclstandardrule")
+        response = self.client.patch(
+            self._get_detail_url(rule),
+            {"action": ACLRuleActionChoices.ACTION_REMARK},
+            format="json",
+            **self.header,
+        )
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
     def test_source_fields_are_optional(self):
         """A rule with neither a source type nor a source is valid, only a half-set pair is not."""
         self.add_permissions("netbox_acls.add_aclstandardrule")
@@ -276,6 +290,20 @@ class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
             response.data["remark"],
             ["When the action is 'remark', a remark is required."],
         )
+
+    def test_remark_action_accepts_a_rule_that_already_has_a_remark(self):
+        """Test that a partial update need not resend the remark alongside the action."""
+        rule = ACLExtendedRule.objects.get(access_list=self.access_list_device, sequence=20)
+        self.assertTrue(rule.remark)
+
+        self.add_permissions("netbox_acls.change_aclextendedrule")
+        response = self.client.patch(
+            self._get_detail_url(rule),
+            {"action": ACLRuleActionChoices.ACTION_REMARK},
+            format="json",
+            **self.header,
+        )
+        self.assertHttpStatus(response, status.HTTP_200_OK)
 
     def test_remark_action_rejects_a_protocol(self):
         """One of the four extra conditions only an extended rule can fail."""

--- a/netbox_acls/tests/api/test_access_list_rules.py
+++ b/netbox_acls/tests/api/test_access_list_rules.py
@@ -1,3 +1,5 @@
+from rest_framework import status
+
 from ipam.models import Prefix
 from netbox_acls.choices import (
     ACLActionChoices,
@@ -29,7 +31,7 @@ class ACLStandardRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
         """Set up ACL Standard Rule for API view testing."""
 
         # AccessList
-        access_list_device = AccessList.objects.create(
+        cls.access_list_device = AccessList.objects.create(
             name="testacl1",
             type=ACLTypeChoices.TYPE_STANDARD,
             family=ACLFamilyChoices.FAMILY_IPV4,
@@ -52,14 +54,14 @@ class ACLStandardRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
 
         acl_standard_rules = (
             ACLStandardRule(
-                access_list=access_list_device,
+                access_list=cls.access_list_device,
                 sequence=10,
                 description="Rule 10",
                 action=ACLRuleActionChoices.ACTION_PERMIT,
                 source=prefix1,
             ),
             ACLStandardRule(
-                access_list=access_list_device,
+                access_list=cls.access_list_device,
                 sequence=20,
                 description="Rule 20",
                 action=ACLRuleActionChoices.ACTION_REMARK,
@@ -78,7 +80,7 @@ class ACLStandardRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
 
         cls.create_data = [
             {
-                "access_list": access_list_device.id,
+                "access_list": cls.access_list_device.id,
                 "sequence": 30,
                 "description": "Rule 30",
                 "action": ACLRuleActionChoices.ACTION_DENY,
@@ -106,6 +108,47 @@ class ACLStandardRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
             "description": "Rule bulk update",
         }
 
+    def test_remark_action_requires_a_remark(self):
+        """
+        The model's clean() is the only source of this message, reached via full_clean().
+
+        Sequence 100 stays clear of the rules setUpTestData already created on this
+        access list.
+        """
+        self.add_permissions("netbox_acls.add_aclstandardrule")
+        response = self.client.post(
+            self._get_list_url(),
+            {
+                "access_list": self.access_list_device.pk,
+                "sequence": 100,
+                "action": ACLRuleActionChoices.ACTION_REMARK,
+            },
+            format="json",
+            **self.header,
+        )
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data["remark"],
+            ["When the action is 'remark', a remark is required."],
+        )
+
+    def test_source_fields_are_optional(self):
+        """A rule with neither a source type nor a source is valid, only a half-set pair is not."""
+        self.add_permissions("netbox_acls.add_aclstandardrule")
+        response = self.client.post(
+            self._get_list_url(),
+            {
+                "access_list": self.access_list_device.pk,
+                "sequence": 110,
+                "action": ACLRuleActionChoices.ACTION_PERMIT,
+                "source_type": None,
+                "source_id": None,
+            },
+            format="json",
+            **self.header,
+        )
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+
 
 class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
     """
@@ -125,7 +168,7 @@ class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
         """Set up ACL Extended Rule for API view testing."""
 
         # AccessList
-        access_list_device = AccessList.objects.create(
+        cls.access_list_device = AccessList.objects.create(
             name="testacl1",
             type=ACLTypeChoices.TYPE_EXTENDED,
             family=ACLFamilyChoices.FAMILY_IPV4,
@@ -148,7 +191,7 @@ class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
 
         acl_extended_rules = (
             ACLExtendedRule(
-                access_list=access_list_device,
+                access_list=cls.access_list_device,
                 sequence=10,
                 description="Rule 10",
                 action=ACLRuleActionChoices.ACTION_PERMIT,
@@ -160,7 +203,7 @@ class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
                 destination_port_ranges=[[22, 23], [443, 444]],
             ),
             ACLExtendedRule(
-                access_list=access_list_device,
+                access_list=cls.access_list_device,
                 sequence=20,
                 description="Rule 20",
                 action=ACLRuleActionChoices.ACTION_REMARK,
@@ -179,7 +222,7 @@ class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
 
         cls.create_data = [
             {
-                "access_list": access_list_device.id,
+                "access_list": cls.access_list_device.id,
                 "sequence": 30,
                 "description": "Rule 30",
                 "action": ACLRuleActionChoices.ACTION_DENY,
@@ -214,3 +257,64 @@ class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
         cls.bulk_update_data = {
             "description": "Rule bulk update",
         }
+
+    def test_remark_action_requires_a_remark(self):
+        """The model's clean() is the only source of this message, reached via full_clean()."""
+        self.add_permissions("netbox_acls.add_aclextendedrule")
+        response = self.client.post(
+            self._get_list_url(),
+            {
+                "access_list": self.access_list_device.pk,
+                "sequence": 100,
+                "action": ACLRuleActionChoices.ACTION_REMARK,
+            },
+            format="json",
+            **self.header,
+        )
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data["remark"],
+            ["When the action is 'remark', a remark is required."],
+        )
+
+    def test_remark_action_rejects_a_protocol(self):
+        """One of the four extra conditions only an extended rule can fail."""
+        self.add_permissions("netbox_acls.add_aclextendedrule")
+        response = self.client.post(
+            self._get_list_url(),
+            {
+                "access_list": self.access_list_device.pk,
+                "sequence": 110,
+                "action": ACLRuleActionChoices.ACTION_REMARK,
+                "remark": "Remark",
+                "protocol": ACLProtocolChoices.PROTOCOL_TCP,
+            },
+            format="json",
+            **self.header,
+        )
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data["protocol"],
+            ["When the action is 'remark', Protocol must not be set."],
+        )
+
+    def test_remark_action_rejects_source_ports(self):
+        """Port ranges post as pairs, the shape create_data already uses."""
+        self.add_permissions("netbox_acls.add_aclextendedrule")
+        response = self.client.post(
+            self._get_list_url(),
+            {
+                "access_list": self.access_list_device.pk,
+                "sequence": 120,
+                "action": ACLRuleActionChoices.ACTION_REMARK,
+                "remark": "Remark",
+                "source_port_ranges": [[80, 80]],
+            },
+            format="json",
+            **self.header,
+        )
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data["source_port_ranges"],
+            ["When the action is 'remark', Source Ports must not be set."],
+        )

--- a/netbox_acls/tests/api/test_access_lists.py
+++ b/netbox_acls/tests/api/test_access_lists.py
@@ -1,4 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
+from rest_framework import status
 
 from dcim.choices import InterfaceTypeChoices
 from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
@@ -9,9 +10,10 @@ from ...choices import (
     ACLActionChoices,
     ACLAssignmentDirectionChoices,
     ACLFamilyChoices,
+    ACLRuleActionChoices,
     ACLTypeChoices,
 )
-from ...models import AccessList, ACLAssignment
+from ...models import AccessList, ACLAssignment, ACLStandardRule
 
 
 class AccessListAPIViewTestCase(APIViewTestCases.APIViewTestCase):
@@ -71,6 +73,54 @@ class AccessListAPIViewTestCase(APIViewTestCases.APIViewTestCase):
         cls.bulk_update_data = {
             "comments": "Rule bulk update",
         }
+
+    def test_type_change_blocked_when_rules_exist(self):
+        """
+        The rule is created here rather than in setUpTestData, so the generic
+        battery still sees access lists that carry none.
+        """
+        self.add_permissions("netbox_acls.change_accesslist")
+        access_list = AccessList.objects.get(name="testacl1")
+        ACLStandardRule.objects.create(
+            access_list=access_list,
+            sequence=10,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+        )
+        response = self.client.patch(
+            self._get_detail_url(access_list),
+            {"type": ACLTypeChoices.TYPE_EXTENDED},
+            format="json",
+            **self.header,
+        )
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data["type"],
+            ["This ACL has ACL rules associated, CANNOT change ACL type."],
+        )
+
+    def test_simultaneous_type_and_family_change_reports_type_only(self):
+        """
+        The model raises on the type guard before it evaluates family, so a client
+        changing both is told about them one at a time.
+        """
+        self.add_permissions("netbox_acls.change_accesslist")
+        access_list = AccessList.objects.get(name="testacl1")
+        ACLStandardRule.objects.create(
+            access_list=access_list,
+            sequence=10,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+        )
+        response = self.client.patch(
+            self._get_detail_url(access_list),
+            {
+                "type": ACLTypeChoices.TYPE_EXTENDED,
+                "family": ACLFamilyChoices.FAMILY_IPV6,
+            },
+            format="json",
+            **self.header,
+        )
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(list(response.data), ["type"])
 
 
 class ACLAssignmentAPIViewTestCase(APIViewTestCases.APIViewTestCase):

--- a/netbox_acls/tests/filtersets/test_extendedrules.py
+++ b/netbox_acls/tests/filtersets/test_extendedrules.py
@@ -134,6 +134,21 @@ class ACLExtendedRuleFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {"access_list": [self.access_list.name]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
 
+    def test_access_list_filter_is_limited_to_extended(self):
+        """
+        The extended rule filters reject a standard access list while the standard rule
+        filters accept any type. Pinned so the asymmetry cannot change unnoticed.
+        """
+        standard_acl = AccessList.objects.create(
+            name="astandardacl",
+            type=ACLTypeChoices.TYPE_STANDARD,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        filterset = self.filterset({}, self.queryset)
+        self.assertNotIn(standard_acl, filterset.filters["access_list"].queryset)
+        self.assertNotIn(standard_acl, filterset.filters["access_list_id"].queryset)
+
     def test_sequence(self):
         params = {"sequence": [10, 20]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)

--- a/netbox_acls/tests/filtersets/test_standardrules.py
+++ b/netbox_acls/tests/filtersets/test_standardrules.py
@@ -108,6 +108,21 @@ class ACLStandardRuleFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {"access_list": [self.access_list.name]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
 
+    def test_access_list_filter_accepts_any_acl_type(self):
+        """
+        The standard rule filters accept an extended access list while the extended rule
+        filters reject a standard one. Pinned so the asymmetry cannot change unnoticed.
+        """
+        extended_acl = AccessList.objects.create(
+            name="anextendedacl",
+            type=ACLTypeChoices.TYPE_EXTENDED,
+            family=ACLFamilyChoices.FAMILY_IPV4,
+            default_action=ACLActionChoices.ACTION_DENY,
+        )
+        filterset = self.filterset({}, self.queryset)
+        self.assertIn(extended_acl, filterset.filters["access_list"].queryset)
+        self.assertIn(extended_acl, filterset.filters["access_list_id"].queryset)
+
     def test_sequence(self):
         params = {"sequence": [10, 20]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)

--- a/netbox_acls/tests/filtersets/test_standardrules.py
+++ b/netbox_acls/tests/filtersets/test_standardrules.py
@@ -39,7 +39,7 @@ class ACLStandardRuleFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
         )
 
         # create() rather than bulk_create(), because save() is what runs
-        # cache_related_source_object() to populate the _source_* shadow columns
+        # cache_related_objects() to populate the _source_* shadow columns
         # that the source_prefix and friends filters actually query.
         ACLStandardRule.objects.create(
             access_list=cls.access_list,

--- a/netbox_acls/tests/forms/base.py
+++ b/netbox_acls/tests/forms/base.py
@@ -7,9 +7,10 @@ __all__ = ("BulkEditFieldsetTestMixin",)
 
 class BulkEditFieldsetTestMixin:
     """
-    Assert every field a bulk edit form names in its fieldsets exists on the form.
+    Assert every field a bulk edit form names actually exists on the form.
 
-    A fieldset entry with no matching field is dropped silently when the form renders.
+    A fieldset entry with no matching field is dropped silently when the form
+    renders, and a nullable entry with no matching field never clears anything.
     """
 
     bulk_edit_form = None
@@ -25,3 +26,15 @@ class BulkEditFieldsetTestMixin:
                         form.fields,
                         msg=f"Fieldset '{fieldset.name}' references undefined field '{item}'",
                     )
+
+    def test_bulkedit_nullable_fields_all_defined(self):
+        """Test that every field the bulk-edit form declares as nullable exists on the form."""
+        form = self.bulk_edit_form()
+        # The class attribute, not the instance one: NetBox appends owner and the
+        # custom fields at runtime, and those are core's to guarantee, not ours.
+        for name in self.bulk_edit_form.nullable_fields:
+            self.assertIn(
+                name,
+                form.fields,
+                msg=f"nullable_fields references undefined field '{name}'",
+            )

--- a/netbox_acls/tests/forms/base.py
+++ b/netbox_acls/tests/forms/base.py
@@ -2,7 +2,10 @@
 Shared bases for the plugin's form tests.
 """
 
-__all__ = ("BulkEditFieldsetTestMixin",)
+__all__ = (
+    "BulkEditFieldsetTestMixin",
+    "FilterFormFieldsetTestMixin",
+)
 
 
 class BulkEditFieldsetTestMixin:
@@ -38,3 +41,26 @@ class BulkEditFieldsetTestMixin:
                 form.fields,
                 msg=f"nullable_fields references undefined field '{name}'",
             )
+
+
+class FilterFormFieldsetTestMixin:
+    """
+    Assert every field a filter form names in its fieldsets exists on the form.
+
+    A fieldset entry with no matching field renders as a missing filter, which
+    is silent: the form still works and the filter is simply unavailable.
+    """
+
+    filter_form = None
+
+    def test_filterform_fieldset_fields_all_defined(self):
+        """Test that every field named in the filter form fieldsets exists on the form."""
+        form = self.filter_form()
+        for fieldset in form.fieldsets:
+            for item in fieldset.items:
+                if isinstance(item, str):
+                    self.assertIn(
+                        item,
+                        form.fields,
+                        msg=f"Fieldset '{fieldset.name}' references undefined field '{item}'",
+                    )

--- a/netbox_acls/tests/forms/test_aclassignments.py
+++ b/netbox_acls/tests/forms/test_aclassignments.py
@@ -12,17 +12,18 @@ from ...choices import (
     ACLTypeChoices,
 )
 from ...constants import ACL_ASSIGNMENT_MODELS
-from ...forms import ACLAssignmentBulkEditForm, ACLAssignmentForm
+from ...forms import ACLAssignmentBulkEditForm, ACLAssignmentFilterForm, ACLAssignmentForm
 from ...models import AccessList
-from .base import BulkEditFieldsetTestMixin
+from .base import BulkEditFieldsetTestMixin, FilterFormFieldsetTestMixin
 
 UNRESOLVABLE_CONTENT_TYPE_ID = 99999999
 
 
-class ACLAssignmentFormTestCase(BulkEditFieldsetTestMixin, TestCase):
+class ACLAssignmentFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetTestMixin, TestCase):
     """Form tests for ACLAssignment forms."""
 
     bulk_edit_form = ACLAssignmentBulkEditForm
+    filter_form = ACLAssignmentFilterForm
 
     @classmethod
     def setUpTestData(cls):

--- a/netbox_acls/tests/forms/test_extendedrules.py
+++ b/netbox_acls/tests/forms/test_extendedrules.py
@@ -12,16 +12,17 @@ from ...choices import (
     ACLTypeChoices,
 )
 from ...constants import ACL_RULE_SOURCE_DESTINATION_MODELS
-from ...forms import ACLExtendedRuleBulkEditForm, ACLExtendedRuleForm
+from ...forms import ACLExtendedRuleBulkEditForm, ACLExtendedRuleFilterForm, ACLExtendedRuleForm
 from ...models import AccessList, ACLExtendedRule
 from ..views.base import build_ipam_objects
-from .base import BulkEditFieldsetTestMixin
+from .base import BulkEditFieldsetTestMixin, FilterFormFieldsetTestMixin
 
 
-class ACLExtendedRuleFormTestCase(BulkEditFieldsetTestMixin, TestCase):
+class ACLExtendedRuleFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetTestMixin, TestCase):
     """Form tests for ACLExtendedRule forms."""
 
     bulk_edit_form = ACLExtendedRuleBulkEditForm
+    filter_form = ACLExtendedRuleFilterForm
 
     @classmethod
     def setUpTestData(cls):
@@ -201,4 +202,12 @@ class ACLExtendedRuleFormTestCase(BulkEditFieldsetTestMixin, TestCase):
                 "description",
                 "comments",
             ),
+        )
+
+    def test_filterform_access_list_filtered_to_extended(self):
+        """Test that the filter form's Access List picker filters to Extended ACLs."""
+        form = ACLExtendedRuleFilterForm()
+        self.assertEqual(
+            form.fields["access_list_id"].query_params,
+            {"type": ACLTypeChoices.TYPE_EXTENDED},
         )

--- a/netbox_acls/tests/forms/test_extendedrules.py
+++ b/netbox_acls/tests/forms/test_extendedrules.py
@@ -13,7 +13,7 @@ from ...choices import (
 )
 from ...constants import ACL_RULE_SOURCE_DESTINATION_MODELS
 from ...forms import ACLExtendedRuleBulkEditForm, ACLExtendedRuleForm
-from ...models import AccessList
+from ...models import AccessList, ACLExtendedRule
 from ..views.base import build_ipam_objects
 from .base import BulkEditFieldsetTestMixin
 
@@ -48,6 +48,38 @@ class ACLExtendedRuleFormTestCase(BulkEditFieldsetTestMixin, TestCase):
         }
         data.update(overrides)
         return ACLExtendedRuleForm(data=data)
+
+    def _rule(self, sequence):
+        return ACLExtendedRule.objects.create(
+            access_list=self.access_list,
+            sequence=sequence,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix,
+            destination=self.destination_prefix,
+        )
+
+    def test_instance_seeds_both_object_fields(self):
+        """Both roles reach the form as initial values, not just the source."""
+        form = ACLExtendedRuleForm(instance=self._rule(10))
+        self.assertEqual(form.initial["source"], self.prefix)
+        self.assertEqual(form.initial["destination"], self.destination_prefix)
+
+    def test_changing_the_destination_type_clears_only_the_destination(self):
+        """The roles are independent, so switching one must not disturb the other."""
+        rule = self._rule(20)
+        form = ACLExtendedRuleForm(
+            data={
+                "access_list": self.access_list.pk,
+                "sequence": 20,
+                "action": ACLRuleActionChoices.ACTION_PERMIT,
+                "source_type": ContentType.objects.get_for_model(Prefix).pk,
+                "source": self.prefix.pk,
+                "destination_type": ContentType.objects.get_for_model(self.ip_address).pk,
+            },
+            instance=rule,
+        )
+        self.assertIsNone(form.initial["destination"])
+        self.assertEqual(form.initial["source"], self.prefix)
 
     def test_bulkedit_access_list_filtered_to_extended(self):
         """#360: the extended bulk-edit Access List picker must filter to Extended ACLs."""
@@ -135,3 +167,38 @@ class ACLExtendedRuleFormTestCase(BulkEditFieldsetTestMixin, TestCase):
         )
         self.assertEqual(instance.source_port_ranges_list, ["80-81"])
         self.assertEqual(instance.destination_port_ranges_list, ["8080-8081"])
+
+    def test_bulkedit_type_widgets_swap_the_form_fields(self):
+        """Test that both bulk-edit type pickers post and swap, for either role."""
+        form = ACLExtendedRuleBulkEditForm()
+        for role in ("source", "destination"):
+            with self.subTest(role=role):
+                attrs = form.fields[f"{role}_type"].widget.attrs
+                self.assertEqual(attrs["hx-post"], ".")
+                self.assertEqual(attrs["hx-select"], "#form_fields")
+
+    def test_bulkedit_labels_follow_type(self):
+        """Test that each role's resolved label names that role, so the two cannot be confused."""
+        form = ACLExtendedRuleBulkEditForm(
+            data={
+                "source_type": ContentType.objects.get_for_model(self.ip_range).pk,
+                "destination_type": ContentType.objects.get_for_model(self.aggregate).pk,
+            },
+        )
+        self.assertEqual(form.fields["source"].label, "Source IP Range")
+        self.assertEqual(form.fields["destination"].label, "Destination Aggregate")
+
+    def test_bulkedit_nullable_fields(self):
+        """Test that no field moved to the shared mixin dropped out of the list."""
+        self.assertEqual(
+            ACLExtendedRuleBulkEditForm.nullable_fields,
+            (
+                "remark",
+                "source_type",
+                "source",
+                "destination_type",
+                "destination",
+                "description",
+                "comments",
+            ),
+        )

--- a/netbox_acls/tests/forms/test_extendedrules.py
+++ b/netbox_acls/tests/forms/test_extendedrules.py
@@ -65,22 +65,23 @@ class ACLExtendedRuleFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetT
         self.assertEqual(form.initial["source"], self.prefix)
         self.assertEqual(form.initial["destination"], self.destination_prefix)
 
-    def test_changing_the_destination_type_clears_only_the_destination(self):
-        """The roles are independent, so switching one must not disturb the other."""
+    def test_editing_clears_both_object_fields(self):
+        """Test that an edit drops both selected objects, including the unchanged role."""
+        # Pins a defect: the posted type is text and never equals the integer id.
         rule = self._rule(20)
         form = ACLExtendedRuleForm(
             data={
-                "access_list": self.access_list.pk,
-                "sequence": 20,
+                "access_list": str(self.access_list.pk),
+                "sequence": "20",
                 "action": ACLRuleActionChoices.ACTION_PERMIT,
-                "source_type": ContentType.objects.get_for_model(Prefix).pk,
-                "source": self.prefix.pk,
-                "destination_type": ContentType.objects.get_for_model(self.ip_address).pk,
+                "source_type": str(ContentType.objects.get_for_model(Prefix).pk),
+                "source": str(self.prefix.pk),
+                "destination_type": str(ContentType.objects.get_for_model(self.ip_address).pk),
             },
             instance=rule,
         )
         self.assertIsNone(form.initial["destination"])
-        self.assertEqual(form.initial["source"], self.prefix)
+        self.assertIsNone(form.initial["source"])
 
     def test_bulkedit_access_list_filtered_to_extended(self):
         """#360: the extended bulk-edit Access List picker must filter to Extended ACLs."""
@@ -190,7 +191,7 @@ class ACLExtendedRuleFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetT
         self.assertEqual(form.fields["destination"].label, "Destination Aggregate")
 
     def test_bulkedit_nullable_fields(self):
-        """Test that no field moved to the shared mixin dropped out of the list."""
+        """Test that the nullable list stays exhaustive for this form."""
         self.assertEqual(
             ACLExtendedRuleBulkEditForm.nullable_fields,
             (

--- a/netbox_acls/tests/forms/test_standardrules.py
+++ b/netbox_acls/tests/forms/test_standardrules.py
@@ -3,16 +3,17 @@ from django.test import TestCase
 
 from ...choices import ACLActionChoices, ACLFamilyChoices, ACLRuleActionChoices, ACLTypeChoices
 from ...constants import ACL_RULE_SOURCE_DESTINATION_MODELS
-from ...forms import ACLStandardRuleBulkEditForm, ACLStandardRuleForm
+from ...forms import ACLStandardRuleBulkEditForm, ACLStandardRuleFilterForm, ACLStandardRuleForm
 from ...models import AccessList, ACLStandardRule
 from ..views.base import build_ipam_objects
-from .base import BulkEditFieldsetTestMixin
+from .base import BulkEditFieldsetTestMixin, FilterFormFieldsetTestMixin
 
 
-class ACLStandardRuleFormTestCase(BulkEditFieldsetTestMixin, TestCase):
+class ACLStandardRuleFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetTestMixin, TestCase):
     """Form tests for ACLStandardRule forms."""
 
     bulk_edit_form = ACLStandardRuleBulkEditForm
+    filter_form = ACLStandardRuleFilterForm
 
     @classmethod
     def setUpTestData(cls):
@@ -143,4 +144,20 @@ class ACLStandardRuleFormTestCase(BulkEditFieldsetTestMixin, TestCase):
         self.assertEqual(
             ACLStandardRuleBulkEditForm.nullable_fields,
             ("remark", "source_type", "source", "description", "comments"),
+        )
+
+    def test_filterform_carries_no_extended_filters(self):
+        """Test that the shared mixin leaks no extended-only filter into the standard form."""
+        form = ACLStandardRuleFilterForm()
+        for name in ("protocol", "source_port", "destination_port"):
+            self.assertNotIn(name, form.fields)
+        for model_name in ("aggregate", "ipaddress", "iprange", "prefix"):
+            self.assertNotIn(f"destination_{model_name}_id", form.fields)
+
+    def test_filterform_access_list_filtered_to_standard(self):
+        """Test that the filter form's Access List picker filters to Standard ACLs."""
+        form = ACLStandardRuleFilterForm()
+        self.assertEqual(
+            form.fields["access_list_id"].query_params,
+            {"type": ACLTypeChoices.TYPE_STANDARD},
         )

--- a/netbox_acls/tests/forms/test_standardrules.py
+++ b/netbox_acls/tests/forms/test_standardrules.py
@@ -64,20 +64,21 @@ class ACLStandardRuleFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetT
         )
         self.assertIsNone(form.initial["source"])
 
-    def test_keeping_the_source_type_keeps_the_source(self):
-        """The counterpart to the clear, so the guard cannot fire on every edit."""
+    def test_editing_clears_the_source_even_when_the_type_is_unchanged(self):
+        """Test that an edit drops the selected source whether or not its type changed."""
+        # Pins a defect: the posted type is text and never equals the integer id.
         rule = self._rule(30)
         form = ACLStandardRuleForm(
             data={
-                "access_list": self.access_list.pk,
-                "sequence": 30,
+                "access_list": str(self.access_list.pk),
+                "sequence": "30",
                 "action": ACLRuleActionChoices.ACTION_PERMIT,
-                "source_type": ContentType.objects.get_for_model(self.prefix).pk,
-                "source": self.prefix.pk,
+                "source_type": str(ContentType.objects.get_for_model(self.prefix).pk),
+                "source": str(self.prefix.pk),
             },
             instance=rule,
         )
-        self.assertEqual(form.initial["source"], self.prefix)
+        self.assertIsNone(form.initial["source"])
 
     def test_bulkedit_access_list_filtered_to_standard(self):
         """Guard the standard bulk-edit picker the extended form (#360) was copied from."""
@@ -140,7 +141,7 @@ class ACLStandardRuleFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetT
         self.assertEqual(form.fields["source"].label, "Source IP Range")
 
     def test_bulkedit_nullable_fields(self):
-        """Test that no field moved to the shared mixin dropped out of the list."""
+        """Test that the nullable list stays exhaustive for this form."""
         self.assertEqual(
             ACLStandardRuleBulkEditForm.nullable_fields,
             ("remark", "source_type", "source", "description", "comments"),

--- a/netbox_acls/tests/forms/test_standardrules.py
+++ b/netbox_acls/tests/forms/test_standardrules.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from ...choices import ACLActionChoices, ACLFamilyChoices, ACLRuleActionChoices, ACLTypeChoices
 from ...constants import ACL_RULE_SOURCE_DESTINATION_MODELS
 from ...forms import ACLStandardRuleBulkEditForm, ACLStandardRuleForm
-from ...models import AccessList
+from ...models import AccessList, ACLStandardRule
 from ..views.base import build_ipam_objects
 from .base import BulkEditFieldsetTestMixin
 
@@ -35,6 +35,48 @@ class ACLStandardRuleFormTestCase(BulkEditFieldsetTestMixin, TestCase):
                 "source": source.pk,
             },
         )
+
+    def _rule(self, sequence):
+        return ACLStandardRule.objects.create(
+            access_list=self.access_list,
+            sequence=sequence,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix,
+        )
+
+    def test_instance_seeds_the_source_field(self):
+        """An existing rule's source reaches the form as its initial value."""
+        form = ACLStandardRuleForm(instance=self._rule(10))
+        self.assertEqual(form.initial["source"], self.prefix)
+
+    def test_changing_the_source_type_clears_the_source(self):
+        """Switching type while editing drops the object the old type selected."""
+        rule = self._rule(20)
+        form = ACLStandardRuleForm(
+            data={
+                "access_list": self.access_list.pk,
+                "sequence": 20,
+                "action": ACLRuleActionChoices.ACTION_PERMIT,
+                "source_type": ContentType.objects.get_for_model(self.ip_address).pk,
+            },
+            instance=rule,
+        )
+        self.assertIsNone(form.initial["source"])
+
+    def test_keeping_the_source_type_keeps_the_source(self):
+        """The counterpart to the clear, so the guard cannot fire on every edit."""
+        rule = self._rule(30)
+        form = ACLStandardRuleForm(
+            data={
+                "access_list": self.access_list.pk,
+                "sequence": 30,
+                "action": ACLRuleActionChoices.ACTION_PERMIT,
+                "source_type": ContentType.objects.get_for_model(self.prefix).pk,
+                "source": self.prefix.pk,
+            },
+            instance=rule,
+        )
+        self.assertEqual(form.initial["source"], self.prefix)
 
     def test_bulkedit_access_list_filtered_to_standard(self):
         """Guard the standard bulk-edit picker the extended form (#360) was copied from."""
@@ -82,3 +124,23 @@ class ACLStandardRuleFormTestCase(BulkEditFieldsetTestMixin, TestCase):
         )
         self.assertEqual(form.fields["source"].queryset.model, type(self.prefix))
         self.assertFalse(form.fields["source"].disabled)
+
+    def test_bulkedit_source_type_widget_swaps_the_form_fields(self):
+        """Test that the bulk-edit type picker posts and swaps, unlike the model form's picker."""
+        attrs = ACLStandardRuleBulkEditForm().fields["source_type"].widget.attrs
+        self.assertEqual(attrs["hx-post"], ".")
+        self.assertEqual(attrs["hx-select"], "#form_fields")
+
+    def test_bulkedit_source_label_follows_type(self):
+        """Test that the resolved label names the role and the selected model."""
+        form = ACLStandardRuleBulkEditForm(
+            data={"source_type": ContentType.objects.get_for_model(self.ip_range).pk},
+        )
+        self.assertEqual(form.fields["source"].label, "Source IP Range")
+
+    def test_bulkedit_nullable_fields(self):
+        """Test that no field moved to the shared mixin dropped out of the list."""
+        self.assertEqual(
+            ACLStandardRuleBulkEditForm.nullable_fields,
+            ("remark", "source_type", "source", "description", "comments"),
+        )

--- a/netbox_acls/tests/models/test_extendedrules.py
+++ b/netbox_acls/tests/models/test_extendedrules.py
@@ -7,6 +7,7 @@ from ...choices import (
     ACLActionChoices,
     ACLFamilyChoices,
     ACLProtocolChoices,
+    ACLRuleActionChoices,
     ACLTypeChoices,
 )
 from ...models import AccessList, ACLExtendedRule
@@ -1101,3 +1102,33 @@ class TestACLExtendedRule(BaseTestCase):
 
         with self.assertRaises(ValidationError):
             invalid_rule.full_clean()
+
+    def test_switching_the_destination_leaves_the_source_shadow_columns(self):
+        """Test that the two roles are independent, so switching one leaves the other."""
+        rule = ACLExtendedRule.objects.create(
+            access_list=self.extended_acl1,
+            sequence=920,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+            destination=self.aggregate1,
+        )
+        cached = self._cached_objects(rule)
+        self.assertEqual(cached["_source_prefix"], self.prefix1.pk)
+        self.assertEqual(cached["_destination_aggregate"], self.aggregate1.pk)
+
+        rule.destination = self.ip_range1
+        rule.save()
+
+        cached = self._cached_objects(rule)
+        self.assertEqual(cached["_source_prefix"], self.prefix1.pk)
+        self.assertIsNone(cached["_destination_aggregate"])
+        self.assertEqual(cached["_destination_iprange"], self.ip_range1.pk)
+
+    @staticmethod
+    def _cached_objects(rule):
+        """Read the shadow columns back from the database, which is what the filters query."""
+        return (
+            ACLExtendedRule.objects.filter(pk=rule.pk)
+            .values("_source_prefix", "_destination_aggregate", "_destination_iprange")
+            .get()
+        )

--- a/netbox_acls/tests/models/test_standardrules.py
+++ b/netbox_acls/tests/models/test_standardrules.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 
-from ...choices import ACLActionChoices, ACLFamilyChoices, ACLTypeChoices
+from ...choices import ACLActionChoices, ACLFamilyChoices, ACLRuleActionChoices, ACLTypeChoices
 from ...models import AccessList, ACLStandardRule
 from .base import BaseTestCase
 
@@ -388,3 +388,25 @@ class TestACLStandardRule(BaseTestCase):
         )
         with self.assertRaises(ValidationError):
             invalid_rule.full_clean()
+
+    def test_switching_the_source_clears_the_stale_shadow_column(self):
+        """Test that re-saving with a new source type nulls the column the old type filled."""
+        rule = ACLStandardRule.objects.create(
+            access_list=self.standard_acl1,
+            sequence=910,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+        )
+        self.assertEqual(self._cached_sources(rule)["_source_prefix"], self.prefix1.pk)
+
+        rule.source = self.ip_address1
+        rule.save()
+
+        cached = self._cached_sources(rule)
+        self.assertIsNone(cached["_source_prefix"])
+        self.assertEqual(cached["_source_ipaddress"], self.ip_address1.pk)
+
+    @staticmethod
+    def _cached_sources(rule):
+        """Read the shadow columns back from the database, which is what the filters query."""
+        return ACLStandardRule.objects.filter(pk=rule.pk).values("_source_prefix", "_source_ipaddress").get()


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #67

Supersedes #122.

## New Behavior

This PR reduces duplicate code across ACL rule serializers, filter sets, filter forms, tables, and model relation caching.

Shared behavior is moved into reusable base classes and helpers, while model validation becomes the single source of truth for API validation. Additional tests cover the refactored paths, partial updates, form configuration, and source and destination relation caching.

## Contrast to Current Behavior

Standard and Extended ACL Rules currently repeat many of the same serializer fields, filters, form fields, table columns, validation checks, and relation-caching logic.

After this change, the common definitions are maintained in one place and the concrete implementations contain only their rule-specific behavior.

The supported API fields and filters remain unchanged. Validation errors now come from the models, and the ordering of filter parameters in the generated OpenAPI schema may differ.

## Discussion: Benefits and Drawbacks

Sharing the common implementations reduces maintenance overhead and the risk of Standard and Extended Rule behavior drifting apart. The added regression coverage also makes future changes to these shared paths safer.

This supersedes the earlier draft in #122 and applies the refactoring to the current codebase with focused regression coverage.

No data migration is required. The change is backwards-compatible for stored data and supported API fields, but API clients may observe updated validation wording and, when multiple Access List restrictions are violated together, a different set of errors in a single response. The existing difference between the Standard and Extended Rule Access List filters is intentionally preserved.

## Changes to the Documentation

No user-facing documentation changes are required. Internal comments and docstrings have been updated where appropriate.

## Proposed Release Note Entry

Reduced duplicate ACL rule code by sharing serializer, filter, form, table, and relation-caching behavior, with additional regression coverage.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets `feature` (next minor release).