### PR TITLE
Closes #57: Add per-rule logging controls for Standard and Extended ACL Rules

### DIFF
--- a/netbox_acls/api/serializers.py
+++ b/netbox_acls/api/serializers.py
@@ -19,6 +19,7 @@ from ..models import (
     ACLExtendedRule,
     ACLStandardRule,
 )
+from ..utils import normalize_log_options
 
 __all__ = [
     "ACLAssignmentSerializer",
@@ -152,6 +153,14 @@ class ACLRuleSerializerMixin(serializers.Serializer):
             "sequence",
         )
 
+    def validate_log_options(self, value):
+        """
+        Store log options canonically.
+        """
+        # ValidatedModelSerializer does not copy the cleaned instance back, so the model's
+        # normalization never reaches validated_data.
+        return normalize_log_options(value)
+
 
 class ACLStandardRuleSerializer(ACLRuleSerializerMixin, PrimaryModelSerializer):
     """
@@ -179,6 +188,8 @@ class ACLStandardRuleSerializer(ACLRuleSerializerMixin, PrimaryModelSerializer):
             "source_type",
             "source_id",
             "source",
+            "log_matches",
+            "log_options",
             "description",
             "owner",
             "comments",
@@ -239,6 +250,8 @@ class ACLExtendedRuleSerializer(ACLRuleSerializerMixin, PrimaryModelSerializer):
             "destination",
             "destination_port_ranges",
             "destination_port_terms",
+            "log_matches",
+            "log_options",
             "description",
             "owner",
             "comments",

--- a/netbox_acls/choices.py
+++ b/netbox_acls/choices.py
@@ -12,6 +12,7 @@ __all__ = (
     "ACLProtocolChoices",
     "ACLProtocolChoices",
     "ACLRuleActionChoices",
+    "ACLRuleLogOptionChoices",
     "ACLTypeChoices",
 )
 
@@ -63,6 +64,28 @@ class ACLRuleActionChoices(ChoiceSet):
         (ACTION_DENY, "Deny", "red"),
         (ACTION_PERMIT, "Permit", "green"),
         (ACTION_REMARK, "Remark", "blue"),
+    ]
+
+
+class ACLRuleLogOptionChoices(ChoiceSet):
+    """
+    Logging options available to ACL rules.
+    """
+
+    key = "ACLRule.log_options"
+
+    OPTION_SYSLOG = "syslog"
+    OPTION_CISCO_LOG_INPUT = "cisco-log-input"
+
+    CHOICES = [
+        (
+            "Generic",
+            ((OPTION_SYSLOG, "Syslog", "blue"),),
+        ),
+        (
+            "Cisco",
+            ((OPTION_CISCO_LOG_INPUT, "Log-input", "purple"),),
+        ),
     ]
 
 

--- a/netbox_acls/filtersets.py
+++ b/netbox_acls/filtersets.py
@@ -307,6 +307,12 @@ class ACLRuleFilterSetMixin(django_filters.FilterSet):
         label=_("Access List (ID)"),
     )
 
+    # Logging
+    log_options = MultiValueCharFilter(
+        method="filter_log_options",
+        label=_("Log Options"),
+    )
+
     # Source
     source_type = ContentTypeFilter(
         label=_("Source Type"),
@@ -377,6 +383,12 @@ class ACLRuleFilterSetMixin(django_filters.FilterSet):
             query |= Q(sequence=int(value.strip()))
         return queryset.filter(query)
 
+    def filter_log_options(self, queryset, name, value):
+        """
+        Match rules carrying any of the given log options.
+        """
+        return queryset.filter(log_options__overlap=value)
+
 
 @register_filterset
 class ACLStandardRuleFilterSet(ACLRuleFilterSetMixin, PrimaryModelFilterSet):
@@ -398,6 +410,7 @@ class ACLStandardRuleFilterSet(ACLRuleFilterSetMixin, PrimaryModelFilterSet):
             "remark",
             "source_type",
             "source_id",
+            "log_matches",
             "description",
             "comments",
         )
@@ -506,6 +519,7 @@ class ACLExtendedRuleFilterSet(ACLRuleFilterSetMixin, PrimaryModelFilterSet):
             "destination_type",
             "destination_id",
             "destination_port",
+            "log_matches",
             "description",
             "comments",
         )

--- a/netbox_acls/forms/bulk_edit.py
+++ b/netbox_acls/forms/bulk_edit.py
@@ -14,7 +14,7 @@ from netbox.forms.mixins import OwnerMixin
 from utilities.forms.fields import CommentField, ContentTypeChoiceField, DynamicModelChoiceField, NumericRangeArrayField
 from utilities.forms.rendering import FieldSet
 from utilities.forms.utils import add_blank_choice, get_field_value
-from utilities.forms.widgets import HTMXSelect
+from utilities.forms.widgets import BulkEditNullBooleanSelect, HTMXSelect
 from utilities.templatetags.builtins.filters import bettertitle
 from virtualization.models import VMInterface
 
@@ -24,10 +24,15 @@ from ..choices import (
     ACLFamilyChoices,
     ACLProtocolChoices,
     ACLRuleActionChoices,
+    ACLRuleLogOptionChoices,
     ACLTypeChoices,
 )
 from ..constants import ACL_ASSIGNMENT_MODELS, ACL_RULE_SOURCE_DESTINATION_MODELS
 from ..models import AccessList, ACLAssignment, ACLExtendedRule, ACLStandardRule
+from ..models.access_list_rules import (
+    ERROR_MESSAGE_LOG_OPTIONS_WITHOUT_LOG_MATCHES,
+    HELP_TEXT_ACL_RULE_LOG_OPTIONS,
+)
 
 __all__ = (
     "ACLAssignmentBulkEditForm",
@@ -35,6 +40,8 @@ __all__ = (
     "ACLStandardRuleBulkEditForm",
     "AccessListBulkEditForm",
 )
+
+ERROR_MESSAGE_CLEAR_LOG_OPTIONS_WITH_SELECTION = _("Clear log options cannot be combined with a log option selection.")
 
 
 class AccessListBulkEditForm(PrimaryModelBulkEditForm):
@@ -147,7 +154,54 @@ class ACLAssignmentBulkEditForm(OwnerMixin, NetBoxModelBulkEditForm):
                 pass
 
 
-class ACLStandardRuleBulkEditForm(PrimaryModelBulkEditForm):
+class ACLRuleLoggingBulkEditMixin(forms.Form):
+    """
+    Logging controls shared by both rule bulk edit forms.
+    """
+
+    log_matches = forms.NullBooleanField(
+        required=False,
+        widget=BulkEditNullBooleanSelect(),
+        label=_("Log matches"),
+        help_text=_("Setting this to No also removes every log option from the selected rules."),
+    )
+    log_options = forms.MultipleChoiceField(
+        choices=ACLRuleLogOptionChoices,
+        required=False,
+        label=_("Log options"),
+        help_text=HELP_TEXT_ACL_RULE_LOG_OPTIONS,
+    )
+    clear_log_options = forms.BooleanField(
+        required=False,
+        label=_("Clear log options"),
+        help_text=_("Remove every log option while leaving Log matches as it is."),
+    )
+
+    def clean(self):
+        """
+        Apply the clear control, which exists because a blank selection means unchanged.
+        """
+        cleaned_data = super().clean()
+
+        if cleaned_data.get("log_options"):
+            if cleaned_data.get("clear_log_options"):
+                raise forms.ValidationError(
+                    {"clear_log_options": ERROR_MESSAGE_CLEAR_LOG_OPTIONS_WITH_SELECTION},
+                )
+            if cleaned_data.get("log_matches") is False:
+                raise forms.ValidationError(
+                    {"log_options": ERROR_MESSAGE_LOG_OPTIONS_WITHOUT_LOG_MATCHES},
+                )
+
+        if cleaned_data.get("log_matches") is False or cleaned_data.get("clear_log_options"):
+            cleaned_data["log_options"] = []
+            if "log_options" not in self.changed_data:
+                self.changed_data.append("log_options")
+
+        return cleaned_data
+
+
+class ACLStandardRuleBulkEditForm(ACLRuleLoggingBulkEditMixin, PrimaryModelBulkEditForm):
     """
     Form for bulk editing multiple ACLStandardRule instances.
     """
@@ -210,6 +264,12 @@ class ACLStandardRuleBulkEditForm(PrimaryModelBulkEditForm):
             "source",
             name=_("Source Definition"),
         ),
+        FieldSet(
+            "log_matches",
+            "log_options",
+            "clear_log_options",
+            name=_("Logging"),
+        ),
     )
     nullable_fields = (
         "remark",
@@ -240,7 +300,7 @@ class ACLStandardRuleBulkEditForm(PrimaryModelBulkEditForm):
                 pass
 
 
-class ACLExtendedRuleBulkEditForm(PrimaryModelBulkEditForm):
+class ACLExtendedRuleBulkEditForm(ACLRuleLoggingBulkEditMixin, PrimaryModelBulkEditForm):
     """
     Form for bulk editing multiple ACLExtendedRule instances.
     """
@@ -343,6 +403,12 @@ class ACLExtendedRuleBulkEditForm(PrimaryModelBulkEditForm):
             "destination",
             "destination_port_ranges",
             name=_("Destination Definition"),
+        ),
+        FieldSet(
+            "log_matches",
+            "log_options",
+            "clear_log_options",
+            name=_("Logging"),
         ),
     )
     nullable_fields = (

--- a/netbox_acls/forms/filtersets.py
+++ b/netbox_acls/forms/filtersets.py
@@ -14,6 +14,7 @@ try:
 except ImportError:  # NetBox < 4.5.2 keeps it alongside the filter set forms
     from netbox.forms.filtersets import OwnerFilterMixin
 
+from utilities.forms.constants import BOOLEAN_WITH_BLANK_CHOICES
 from utilities.forms.fields import (
     DynamicModelChoiceField,
     DynamicModelMultipleChoiceField,
@@ -29,6 +30,7 @@ from ..choices import (
     ACLFamilyChoices,
     ACLProtocolChoices,
     ACLRuleActionChoices,
+    ACLRuleLogOptionChoices,
     ACLTypeChoices,
 )
 from ..models import (
@@ -239,6 +241,18 @@ class ACLRuleFilterFormMixin(forms.Form):
         label=_("Remark"),
     )
 
+    # Logging
+    log_matches = forms.NullBooleanField(
+        required=False,
+        widget=forms.Select(choices=BOOLEAN_WITH_BLANK_CHOICES),
+        label=_("Log matches"),
+    )
+    log_options = forms.MultipleChoiceField(
+        choices=ACLRuleLogOptionChoices,
+        required=False,
+        label=_("Log options"),
+    )
+
     # Source selectors
     source_aggregate_id = DynamicModelMultipleChoiceField(
         queryset=Aggregate.objects.all(),
@@ -287,6 +301,11 @@ class ACLStandardRuleFilterForm(ACLRuleFilterFormMixin, PrimaryModelFilterSetFor
             "source_iprange_id",
             "source_prefix_id",
             name=_("Source Details"),
+        ),
+        FieldSet(
+            "log_matches",
+            "log_options",
+            name=_("Logging"),
         ),
         FieldSet(
             "owner_group_id",
@@ -343,6 +362,11 @@ class ACLExtendedRuleFilterForm(ACLRuleFilterFormMixin, PrimaryModelFilterSetFor
             "destination_prefix_id",
             "destination_port",
             name=_("Destination Details"),
+        ),
+        FieldSet(
+            "log_matches",
+            "log_options",
+            name=_("Logging"),
         ),
         FieldSet(
             "owner_group_id",

--- a/netbox_acls/forms/models.py
+++ b/netbox_acls/forms/models.py
@@ -30,6 +30,7 @@ from virtualization.models import VMInterface
 from ..choices import (
     ACLAssignmentDirectionChoices,
     ACLAssignmentDirectionUIChoices,
+    ACLRuleLogOptionChoices,
     ACLTypeChoices,
 )
 from ..constants import ACL_ASSIGNMENT_MODELS, ACL_RULE_SOURCE_DESTINATION_MODELS
@@ -39,6 +40,7 @@ from ..models import (
     ACLExtendedRule,
     ACLStandardRule,
 )
+from ..models.access_list_rules import HELP_TEXT_ACL_RULE_LOG_OPTIONS
 
 __all__ = (
     "ACLAssignmentForm",
@@ -260,6 +262,13 @@ class ACLStandardRuleForm(PrimaryModelForm):
         disabled=True,
     )
 
+    log_options = forms.MultipleChoiceField(
+        choices=ACLRuleLogOptionChoices,
+        required=False,
+        label=_("Log options"),
+        help_text=HELP_TEXT_ACL_RULE_LOG_OPTIONS,
+    )
+
     fieldsets = (
         FieldSet(
             "access_list",
@@ -281,6 +290,11 @@ class ACLStandardRuleForm(PrimaryModelForm):
             "source",
             name=_("Source Definition"),
         ),
+        FieldSet(
+            "log_matches",
+            "log_options",
+            name=_("Logging"),
+        ),
     )
 
     class Meta:
@@ -291,6 +305,8 @@ class ACLStandardRuleForm(PrimaryModelForm):
             "action",
             "remark",
             "source_type",
+            "log_matches",
+            "log_options",
             "description",
             "owner",
             "comments",
@@ -410,6 +426,13 @@ class ACLExtendedRuleForm(PrimaryModelForm):
         help_text=(help_text_acl_rule_port_logic + " " + help_text_acl_rule_port_ranges),
     )
 
+    log_options = forms.MultipleChoiceField(
+        choices=ACLRuleLogOptionChoices,
+        required=False,
+        label=_("Log options"),
+        help_text=HELP_TEXT_ACL_RULE_LOG_OPTIONS,
+    )
+
     fieldsets = (
         FieldSet(
             "access_list",
@@ -442,6 +465,11 @@ class ACLExtendedRuleForm(PrimaryModelForm):
             "destination_port_ranges",
             name=_("Destination Definition"),
         ),
+        FieldSet(
+            "log_matches",
+            "log_options",
+            name=_("Logging"),
+        ),
     )
 
     class Meta:
@@ -456,6 +484,8 @@ class ACLExtendedRuleForm(PrimaryModelForm):
             "destination_type",
             "destination_port_ranges",
             "protocol",
+            "log_matches",
+            "log_options",
             "description",
             "owner",
             "comments",

--- a/netbox_acls/graphql/filters/access_list_rules.py
+++ b/netbox_acls/graphql/filters/access_list_rules.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Annotated
 import strawberry
 import strawberry_django
 from strawberry.scalars import ID
-from strawberry_django import BaseFilterLookup
+from strawberry_django import BaseFilterLookup, FilterLookup
 
 from core.graphql.filters import ContentTypeFilter
 from netbox.graphql.filters import PrimaryModelFilter
@@ -17,7 +17,7 @@ except ImportError:
 from ... import models
 
 if TYPE_CHECKING:
-    from netbox.graphql.filter_lookups import IntegerLookup, IntegerRangeArrayLookup
+    from netbox.graphql.filter_lookups import IntegerLookup, IntegerRangeArrayLookup, StringArrayLookup
 
     from ..enums import (
         ACLProtocolEnum,
@@ -57,6 +57,12 @@ class ACLRuleFilterMixin(PrimaryModelFilter):
         strawberry_django.filter_field()
     )
     source_id: ID | None = strawberry_django.filter_field()
+
+    # Logging
+    log_matches: FilterLookup[bool] | None = strawberry_django.filter_field()
+    log_options: Annotated["StringArrayLookup", strawberry.lazy("netbox.graphql.filter_lookups")] | None = (
+        strawberry_django.filter_field()
+    )
 
 
 @strawberry_django.filter_type(models.ACLStandardRule, lookups=True)

--- a/netbox_acls/graphql/types.py
+++ b/netbox_acls/graphql/types.py
@@ -101,6 +101,7 @@ class ACLStandardRuleType(PrimaryObjectType):
         ]
         | None
     )
+    log_options: list[str] | None
 
     # Cached related source objects
     _source_aggregate: Annotated["AggregateType", strawberry.lazy("ipam.graphql.types")] | None
@@ -151,6 +152,7 @@ class ACLExtendedRuleType(PrimaryObjectType):
         | None
     )
     destination_port_ranges: list[str] | None
+    log_options: list[str] | None
 
     # Cached related source objects
     _source_aggregate: Annotated["AggregateType", strawberry.lazy("ipam.graphql.types")] | None

--- a/netbox_acls/migrations/0014_acl_rule_logging.py
+++ b/netbox_acls/migrations/0014_acl_rule_logging.py
@@ -1,0 +1,35 @@
+import django.contrib.postgres.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_acls", "0001_squashed_0013_acl_owner"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="aclextendedrule",
+            name="log_matches",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="aclextendedrule",
+            name="log_options",
+            field=django.contrib.postgres.fields.ArrayField(
+                base_field=models.CharField(max_length=100), blank=True, default=list
+            ),
+        ),
+        migrations.AddField(
+            model_name="aclstandardrule",
+            name="log_matches",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="aclstandardrule",
+            name="log_options",
+            field=django.contrib.postgres.fields.ArrayField(
+                base_field=models.CharField(max_length=100), blank=True, default=list
+            ),
+        ),
+    ]

--- a/netbox_acls/models/access_list_rules.py
+++ b/netbox_acls/models/access_list_rules.py
@@ -17,10 +17,11 @@ from ..choices import (
     ACLFamilyChoices,
     ACLProtocolChoices,
     ACLRuleActionChoices,
+    ACLRuleLogOptionChoices,
     ACLTypeChoices,
 )
 from ..constants import ACL_RULE_SOURCE_DESTINATION_MODELS
-from ..utils import infer_family_from_object, normalize_port_ranges
+from ..utils import infer_family_from_object, normalize_log_options, normalize_port_ranges
 from ..validators import validate_port_ranges
 from .access_lists import AccessList
 from .managers import ACLRuleManager
@@ -49,6 +50,15 @@ ERROR_MESSAGE_ACTION_REMARK_DESTINATION_PORTS_SET = _("When the action is 'remar
 # Error message when the action is 'remark', but the protocol is set.
 ERROR_MESSAGE_ACTION_REMARK_PROTOCOL_SET = _("When the action is 'remark', Protocol must not be set.")
 
+# Error message when log options are set but logging is disabled.
+ERROR_MESSAGE_LOG_OPTIONS_WITHOUT_LOG_MATCHES = _("Log options require Log matches to be enabled.")
+
+# Error message when the action is 'remark', but logging is enabled.
+ERROR_MESSAGE_ACTION_REMARK_LOG_MATCHES_SET = _("When the action is 'remark', Log matches must not be enabled.")
+
+# Error message when the action is 'remark', but log options are set.
+ERROR_MESSAGE_ACTION_REMARK_LOG_OPTIONS_SET = _("When the action is 'remark', Log options must not be set.")
+
 # Error message when the protocol is not 'TCP' or 'UDP', but the source ports are set.
 ERROR_MESSAGE_PROTOCOL_NOT_TCP_OR_UDP_WITH_SOURCE_PORTS_SET = _(
     "Source Ports can only be set when the protocol is TCP or UDP."
@@ -57,6 +67,12 @@ ERROR_MESSAGE_PROTOCOL_NOT_TCP_OR_UDP_WITH_SOURCE_PORTS_SET = _(
 # Error message when the protocol is not 'TCP' or 'UDP', but the destination ports are set.
 ERROR_MESSAGE_PROTOCOL_NOT_TCP_OR_UDP_WITH_DESTINATION_PORTS_SET = _(
     "Destination Ports can only be set when the protocol is TCP or UDP."
+)
+
+# Help text for the log options field, shared by the model and both form modules.
+HELP_TEXT_ACL_RULE_LOG_OPTIONS = _(
+    "Optional logging attributes. Leave empty for the target platform's default. "
+    "Vendor-specific options are grouped by vendor and are platform-dependent."
 )
 
 
@@ -146,6 +162,23 @@ class ACLRule(PrimaryModel):
         null=True,
     )
 
+    # Logging
+    log_matches = models.BooleanField(
+        verbose_name=_("Log matches"),
+        default=False,
+        help_text=_("Request logging for packets matching this rule."),
+    )
+    log_options = ArrayField(
+        base_field=models.CharField(
+            max_length=100,
+            choices=ACLRuleLogOptionChoices,
+        ),
+        verbose_name=_("Log options"),
+        default=list,
+        blank=True,
+        help_text=HELP_TEXT_ACL_RULE_LOG_OPTIONS,
+    )
+
     objects = ACLRuleManager()
 
     clone_fields = (
@@ -153,6 +186,8 @@ class ACLRule(PrimaryModel):
         "action",
         "source_id",
         "source_type",
+        "log_matches",
+        "log_options",
     )
     prerequisite_models: tuple = ("netbox_acls.AccessList",)
 
@@ -289,6 +324,39 @@ class ACLRule(PrimaryModel):
         objectchange.related_object = self.access_list
         return objectchange
 
+    @property
+    def log_options_badges(self) -> list[tuple[str, str | None]]:
+        """
+        Return the display label and badge color of each stored log option.
+        """
+        labels = dict(self._meta.get_field("log_options").base_field.flatchoices)
+        colors = ACLRuleLogOptionChoices.colors
+        return [(str(labels.get(value, value)), colors.get(value)) for value in self.log_options]
+
+    @property
+    def log_options_list(self) -> list[str]:
+        """
+        Return the display labels, passing through values no longer configured.
+        """
+        return [label for label, _color in self.log_options_badges]
+
+    def _validate_logging(self):
+        """
+        Return field errors for an inconsistent logging state.
+        """
+        errors = {}
+
+        if not self.log_matches and self.log_options:
+            errors["log_options"] = ERROR_MESSAGE_LOG_OPTIONS_WITHOUT_LOG_MATCHES
+
+        if self.action == ACLRuleActionChoices.ACTION_REMARK:
+            if self.log_matches:
+                errors["log_matches"] = ERROR_MESSAGE_ACTION_REMARK_LOG_MATCHES_SET
+            if self.log_options:
+                errors["log_options"] = ERROR_MESSAGE_ACTION_REMARK_LOG_OPTIONS_SET
+
+        return errors
+
 
 class ACLStandardRule(ACLRule):
     """
@@ -325,6 +393,9 @@ class ACLStandardRule(ACLRule):
 
         super().clean()
         errors = {}
+
+        self.log_options = normalize_log_options(self.log_options or [])
+        errors.update(self._validate_logging())
 
         # Validate that only the remark field is filled
         if self.action == ACLRuleActionChoices.ACTION_REMARK:
@@ -430,11 +501,7 @@ class ACLExtendedRule(ACLRule):
         null=True,
     )
 
-    clone_fields = (
-        "access_list",
-        "action",
-        "source_id",
-        "source_type",
+    clone_fields = ACLRule.clone_fields + (
         "source_port_ranges",
         "destination_id",
         "destination_type",
@@ -484,6 +551,9 @@ class ACLExtendedRule(ACLRule):
         super().clean()
 
         errors = {}
+
+        self.log_options = normalize_log_options(self.log_options or [])
+        errors.update(self._validate_logging())
 
         # Validate that only the remark field is filled
         if self.action == ACLRuleActionChoices.ACTION_REMARK:

--- a/netbox_acls/tables.py
+++ b/netbox_acls/tables.py
@@ -9,6 +9,28 @@ from netbox.tables import NetBoxTable, PrimaryModelTable, columns
 
 from .models import AccessList, ACLAssignment, ACLExtendedRule, ACLStandardRule
 
+
+class LogOptionsColumn(columns.TemplateColumn):
+    """
+    Display each log option as a colored badge.
+    """
+
+    template_code = """
+    {% for label, color in record.log_options_badges %}
+      {% badge label bg_color=color %}
+    {% empty %}
+      {{ ''|placeholder }}
+    {% endfor %}
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(template_code=self.template_code, orderable=False, **kwargs)
+
+    def value(self, value):
+        """Export the labels rather than the rendered badges."""
+        return ", ".join(value)
+
+
 __all__ = (
     "ACLAssignmentTable",
     "ACLExtendedRuleTable",
@@ -158,6 +180,14 @@ class ACLRuleTable(PrimaryModelTable):
         linkify=True,
     )
 
+    # Logging
+    log_matches = columns.BooleanColumn(
+        verbose_name=_("Log Matches"),
+    )
+    log_options_list = LogOptionsColumn(
+        verbose_name=_("Log Options"),
+    )
+
     class Meta(PrimaryModelTable.Meta):
         fields = (
             "pk",
@@ -168,6 +198,8 @@ class ACLRuleTable(PrimaryModelTable):
             "remark",
             "source",
             "source_type",
+            "log_matches",
+            "log_options_list",
             "description",
             "tags",
             "comments",
@@ -178,6 +210,7 @@ class ACLRuleTable(PrimaryModelTable):
             "action",
             "remark",
             "source",
+            "log_matches",
         )
 
 
@@ -243,4 +276,5 @@ class ACLExtendedRuleTable(ACLRuleTable):
             "source_port_ranges_list",
             "destination",
             "destination_port_ranges_list",
+            "log_matches",
         )

--- a/netbox_acls/templates/netbox_acls/aclextendedrule.html
+++ b/netbox_acls/templates/netbox_acls/aclextendedrule.html
@@ -57,6 +57,22 @@
             <th scope="row">Destination Port Ranges</th>
             <td>{{ object.destination_port_ranges_list|join:", "|placeholder }}</td>
           </tr>
+          <tr>
+            <th scope="row">Log Matches</th>
+            <td>{% checkmark object.log_matches %}</td>
+          </tr>
+          <tr>
+            <th scope="row">Log Options</th>
+            <td>
+              <div class="d-flex flex-wrap gap-1">
+                {% for label, color in object.log_options_badges %}
+                  {% badge label bg_color=color %}
+                {% empty %}
+                  {{ ''|placeholder }}
+                {% endfor %}
+              </div>
+            </td>
+          </tr>
         </table>
       </div>
     </div>

--- a/netbox_acls/templates/netbox_acls/aclstandardrule.html
+++ b/netbox_acls/templates/netbox_acls/aclstandardrule.html
@@ -40,6 +40,22 @@
             <th scope="row">Source</th>
             <td>{{ object.source|linkify|placeholder }}</td>
           </tr>
+          <tr>
+            <th scope="row">Log Matches</th>
+            <td>{% checkmark object.log_matches %}</td>
+          </tr>
+          <tr>
+            <th scope="row">Log Options</th>
+            <td>
+              <div class="d-flex flex-wrap gap-1">
+                {% for label, color in object.log_options_badges %}
+                  {% badge label bg_color=color %}
+                {% empty %}
+                  {{ ''|placeholder }}
+                {% endfor %}
+              </div>
+            </td>
+          </tr>
         </table>
       </div>
     </div>

--- a/netbox_acls/tests/api/test_access_list_rules.py
+++ b/netbox_acls/tests/api/test_access_list_rules.py
@@ -1,3 +1,5 @@
+from django.test import override_settings
+from django.urls import reverse
 from rest_framework import status
 
 from ipam.models import Prefix
@@ -6,6 +8,7 @@ from netbox_acls.choices import (
     ACLFamilyChoices,
     ACLProtocolChoices,
     ACLRuleActionChoices,
+    ACLRuleLogOptionChoices,
     ACLTypeChoices,
 )
 from utilities.testing import APIViewTestCases
@@ -162,6 +165,172 @@ class ACLStandardRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
             **self.header,
         )
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
+
+    def test_create_with_logging(self):
+        """Test that a rule can be created with logging enabled."""
+        self.add_permissions("netbox_acls.add_aclstandardrule")
+        data = {**self.create_data[0], "sequence": 500, "log_matches": True, "log_options": ["syslog"]}
+        response = self.client.post(self._get_list_url(), data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        self.assertTrue(response.data["log_matches"])
+        self.assertEqual(response.data["log_options"], ["syslog"])
+
+    def test_create_rejects_options_without_log_matches(self):
+        """Test that the API rejects options while logging is disabled."""
+        self.add_permissions("netbox_acls.add_aclstandardrule")
+        data = {**self.create_data[0], "sequence": 510, "log_matches": False, "log_options": ["syslog"]}
+        response = self.client.post(self._get_list_url(), data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_patch_disabling_logging_requires_clearing_options(self):
+        """Test that disabling logging does not silently discard the options."""
+        rule = ACLStandardRule.objects.create(
+            access_list=self.access_list_device,
+            sequence=520,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            log_matches=True,
+            log_options=[ACLRuleLogOptionChoices.OPTION_SYSLOG],
+        )
+        self.add_permissions("netbox_acls.change_aclstandardrule")
+        url = self._get_detail_url(rule)
+        self.assertHttpStatus(
+            self.client.patch(url, {"log_matches": False}, format="json", **self.header),
+            status.HTTP_400_BAD_REQUEST,
+        )
+        self.assertHttpStatus(
+            self.client.patch(url, {"log_matches": False, "log_options": []}, format="json", **self.header),
+            status.HTTP_200_OK,
+        )
+
+    def test_create_normalizes_duplicate_and_unordered_options(self):
+        """Test that REST create stores options canonically, as model clean does."""
+        self.add_permissions("netbox_acls.add_aclstandardrule")
+        data = {
+            **self.create_data[0],
+            "sequence": 530,
+            "log_matches": True,
+            "log_options": [
+                ACLRuleLogOptionChoices.OPTION_SYSLOG,
+                ACLRuleLogOptionChoices.OPTION_CISCO_LOG_INPUT,
+                ACLRuleLogOptionChoices.OPTION_SYSLOG,
+            ],
+        }
+        response = self.client.post(self._get_list_url(), data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["log_options"], ["cisco-log-input", "syslog"])
+
+        rule = ACLStandardRule.objects.get(pk=response.data["id"])
+        self.assertEqual(rule.log_options, ["cisco-log-input", "syslog"])
+
+    def test_patch_normalizes_duplicate_and_unordered_options(self):
+        """Test that REST update stores options canonically rather than as posted."""
+        rule = ACLStandardRule.objects.create(
+            access_list=self.access_list_device,
+            sequence=540,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            log_matches=True,
+            log_options=[ACLRuleLogOptionChoices.OPTION_SYSLOG],
+        )
+        self.add_permissions("netbox_acls.change_aclstandardrule")
+        response = self.client.patch(
+            self._get_detail_url(rule),
+            {
+                "log_options": [
+                    ACLRuleLogOptionChoices.OPTION_SYSLOG,
+                    ACLRuleLogOptionChoices.OPTION_CISCO_LOG_INPUT,
+                    ACLRuleLogOptionChoices.OPTION_SYSLOG,
+                ]
+            },
+            format="json",
+            **self.header,
+        )
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
+        rule.refresh_from_db()
+        self.assertEqual(rule.log_options, ["cisco-log-input", "syslog"])
+
+    def _post_graphql_query(self, query):
+        """Return the data payload of a successful GraphQL query."""
+        response = self.client.post(
+            reverse("graphql"),
+            data={"query": query},
+            format="json",
+            **self.header,
+        )
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+        payload = response.json()
+        self.assertNotIn("errors", payload)
+        return payload["data"]
+
+    @override_settings(LOGIN_REQUIRED=True)
+    def test_graphql_filters_narrow_by_logging_state(self):
+        """Test that each logging filter narrows the result set on its own."""
+        self.add_permissions("netbox_acls.view_aclstandardrule")
+
+        # Negative control, logging disabled.
+        ACLStandardRule.objects.create(
+            access_list=self.access_list_device,
+            sequence=600,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+        )
+        default_logging_rule = ACLStandardRule.objects.create(
+            access_list=self.access_list_device,
+            sequence=610,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            log_matches=True,
+        )
+        syslog_rule = ACLStandardRule.objects.create(
+            access_list=self.access_list_device,
+            sequence=620,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            log_matches=True,
+            log_options=[ACLRuleLogOptionChoices.OPTION_SYSLOG],
+        )
+        cisco_rule = ACLStandardRule.objects.create(
+            access_list=self.access_list_device,
+            sequence=630,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            log_matches=True,
+            log_options=[ACLRuleLogOptionChoices.OPTION_CISCO_LOG_INPUT],
+        )
+
+        with self.subTest(filter="log_matches"):
+            data = self._post_graphql_query(
+                """
+                {
+                    acl_standard_rule_list(filters: {log_matches: {exact: true}}) {
+                        id
+                    }
+                }
+                """
+            )
+            self.assertEqual(
+                sorted(rule["id"] for rule in data["acl_standard_rule_list"]),
+                sorted(str(rule.pk) for rule in (default_logging_rule, syslog_rule, cisco_rule)),
+            )
+
+        with self.subTest(filter="log_options"):
+            data = self._post_graphql_query(
+                """
+                {
+                    acl_standard_rule_list(filters: {log_options: {overlap: ["syslog"]}}) {
+                        id
+                        log_matches
+                        log_options
+                    }
+                }
+                """
+            )
+            self.assertEqual(
+                data["acl_standard_rule_list"],
+                [
+                    {
+                        "id": str(syslog_rule.pk),
+                        "log_matches": True,
+                        "log_options": [ACLRuleLogOptionChoices.OPTION_SYSLOG],
+                    },
+                ],
+            )
 
 
 class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
@@ -346,3 +515,86 @@ class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
             response.data["source_port_ranges"],
             ["When the action is 'remark', Source Ports must not be set."],
         )
+
+    def test_create_with_logging(self):
+        """Test that a rule can be created with logging enabled."""
+        self.add_permissions("netbox_acls.add_aclextendedrule")
+        data = {**self.create_data[0], "sequence": 500, "log_matches": True, "log_options": ["syslog"]}
+        response = self.client.post(self._get_list_url(), data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        self.assertTrue(response.data["log_matches"])
+        self.assertEqual(response.data["log_options"], ["syslog"])
+
+    def test_create_rejects_options_without_log_matches(self):
+        """Test that the API rejects options while logging is disabled."""
+        self.add_permissions("netbox_acls.add_aclextendedrule")
+        data = {**self.create_data[0], "sequence": 510, "log_matches": False, "log_options": ["syslog"]}
+        response = self.client.post(self._get_list_url(), data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_patch_disabling_logging_requires_clearing_options(self):
+        """Test that disabling logging does not silently discard the options."""
+        rule = ACLExtendedRule.objects.create(
+            access_list=self.access_list_device,
+            sequence=520,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            log_matches=True,
+            log_options=[ACLRuleLogOptionChoices.OPTION_SYSLOG],
+        )
+        self.add_permissions("netbox_acls.change_aclextendedrule")
+        url = self._get_detail_url(rule)
+        self.assertHttpStatus(
+            self.client.patch(url, {"log_matches": False}, format="json", **self.header),
+            status.HTTP_400_BAD_REQUEST,
+        )
+        self.assertHttpStatus(
+            self.client.patch(url, {"log_matches": False, "log_options": []}, format="json", **self.header),
+            status.HTTP_200_OK,
+        )
+
+    def test_create_normalizes_duplicate_and_unordered_options(self):
+        """Test that REST create stores options canonically, as model clean does."""
+        self.add_permissions("netbox_acls.add_aclextendedrule")
+        data = {
+            **self.create_data[0],
+            "sequence": 530,
+            "log_matches": True,
+            "log_options": [
+                ACLRuleLogOptionChoices.OPTION_SYSLOG,
+                ACLRuleLogOptionChoices.OPTION_CISCO_LOG_INPUT,
+                ACLRuleLogOptionChoices.OPTION_SYSLOG,
+            ],
+        }
+        response = self.client.post(self._get_list_url(), data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["log_options"], ["cisco-log-input", "syslog"])
+
+        rule = ACLExtendedRule.objects.get(pk=response.data["id"])
+        self.assertEqual(rule.log_options, ["cisco-log-input", "syslog"])
+
+    def test_patch_normalizes_duplicate_and_unordered_options(self):
+        """Test that REST update stores options canonically rather than as posted."""
+        rule = ACLExtendedRule.objects.create(
+            access_list=self.access_list_device,
+            sequence=540,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            log_matches=True,
+            log_options=[ACLRuleLogOptionChoices.OPTION_SYSLOG],
+        )
+        self.add_permissions("netbox_acls.change_aclextendedrule")
+        response = self.client.patch(
+            self._get_detail_url(rule),
+            {
+                "log_options": [
+                    ACLRuleLogOptionChoices.OPTION_SYSLOG,
+                    ACLRuleLogOptionChoices.OPTION_CISCO_LOG_INPUT,
+                    ACLRuleLogOptionChoices.OPTION_SYSLOG,
+                ]
+            },
+            format="json",
+            **self.header,
+        )
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
+        rule.refresh_from_db()
+        self.assertEqual(rule.log_options, ["cisco-log-input", "syslog"])

--- a/netbox_acls/tests/filtersets/test_extendedrules.py
+++ b/netbox_acls/tests/filtersets/test_extendedrules.py
@@ -10,6 +10,7 @@ from ...choices import (
     ACLFamilyChoices,
     ACLProtocolChoices,
     ACLRuleActionChoices,
+    ACLRuleLogOptionChoices,
     ACLTypeChoices,
 )
 from ...filtersets import ACLExtendedRuleFilterSet
@@ -70,6 +71,8 @@ class ACLExtendedRuleFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
             destination_port_ranges=normalize_port_ranges([NumericRange(80, 80, bounds="[]")]),
             description="permit web",
             comments="reviewed quarterly",
+            log_matches=True,
+            log_options=[ACLRuleLogOptionChoices.OPTION_SYSLOG],
         )
         ACLExtendedRule.objects.create(
             access_list=cls.access_list,
@@ -274,4 +277,12 @@ class ACLExtendedRuleFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {"protocol": ACLProtocolChoices.PROTOCOL_TCP}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
         params = {"protocol": ACLProtocolChoices.PROTOCOL_UDP}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_log_matches(self):
+        params = {"log_matches": True}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_log_options(self):
+        params = {"log_options": ["syslog"]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)

--- a/netbox_acls/tests/filtersets/test_standardrules.py
+++ b/netbox_acls/tests/filtersets/test_standardrules.py
@@ -4,7 +4,13 @@ from netaddr import IPNetwork
 from ipam.models import RIR, Aggregate, IPAddress, IPRange, Prefix
 from utilities.testing import ChangeLoggedFilterSetTests
 
-from ...choices import ACLActionChoices, ACLFamilyChoices, ACLRuleActionChoices, ACLTypeChoices
+from ...choices import (
+    ACLActionChoices,
+    ACLFamilyChoices,
+    ACLRuleActionChoices,
+    ACLRuleLogOptionChoices,
+    ACLTypeChoices,
+)
 from ...filtersets import ACLStandardRuleFilterSet
 from ...models import AccessList, ACLStandardRule
 
@@ -48,6 +54,8 @@ class ACLStandardRuleFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
             source=cls.prefix,
             description="permit the prefix",
             comments="reviewed quarterly",
+            log_matches=True,
+            log_options=[ACLRuleLogOptionChoices.OPTION_SYSLOG],
         )
         ACLStandardRule.objects.create(
             access_list=cls.access_list,
@@ -183,4 +191,12 @@ class ACLStandardRuleFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {"action": ACLRuleActionChoices.ACTION_PERMIT}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {"action": ACLRuleActionChoices.ACTION_REMARK}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_log_matches(self):
+        params = {"log_matches": True}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_log_options(self):
+        params = {"log_options": ["syslog"]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)

--- a/netbox_acls/tests/forms/test_extendedrules.py
+++ b/netbox_acls/tests/forms/test_extendedrules.py
@@ -9,6 +9,7 @@ from ...choices import (
     ACLFamilyChoices,
     ACLProtocolChoices,
     ACLRuleActionChoices,
+    ACLRuleLogOptionChoices,
     ACLTypeChoices,
 )
 from ...constants import ACL_RULE_SOURCE_DESTINATION_MODELS
@@ -212,3 +213,48 @@ class ACLExtendedRuleFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetT
             form.fields["access_list_id"].query_params,
             {"type": ACLTypeChoices.TYPE_EXTENDED},
         )
+
+    def test_logging_fields_are_present(self):
+        """Test that the model form exposes both logging fields."""
+        form = ACLExtendedRuleForm()
+        self.assertIn("log_matches", form.fields)
+        self.assertIn("log_options", form.fields)
+
+    def test_form_rejects_options_without_log_matches(self):
+        """Test that the model form surfaces the consistency error per field."""
+        form = self._bound_form(log_options=[ACLRuleLogOptionChoices.OPTION_SYSLOG])
+        self.assertFalse(form.is_valid())
+        self.assertIn("log_options", form.errors)
+
+    def test_bulkedit_disabling_logging_clears_the_options(self):
+        """Test that turning logging off also drops the options."""
+        form = ACLExtendedRuleBulkEditForm(
+            data={"log_matches": "False", "pk": [self._rule(10).pk]},
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["log_options"], [])
+        self.assertIn("log_options", form.changed_data)
+
+    def test_bulkedit_clear_rejects_an_explicit_selection(self):
+        """Test that clearing and selecting log options at once is rejected."""
+        form = ACLExtendedRuleBulkEditForm(
+            data={
+                "clear_log_options": True,
+                "log_options": [ACLRuleLogOptionChoices.OPTION_SYSLOG],
+                "pk": [self._rule(20).pk],
+            },
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("clear_log_options", form.errors)
+
+    def test_bulkedit_disabling_logging_rejects_a_selection(self):
+        """Test that disabling logging while selecting options is rejected."""
+        form = ACLExtendedRuleBulkEditForm(
+            data={
+                "log_matches": "False",
+                "log_options": [ACLRuleLogOptionChoices.OPTION_SYSLOG],
+                "pk": [self._rule(30).pk],
+            },
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("log_options", form.errors)

--- a/netbox_acls/tests/forms/test_standardrules.py
+++ b/netbox_acls/tests/forms/test_standardrules.py
@@ -1,7 +1,13 @@
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
-from ...choices import ACLActionChoices, ACLFamilyChoices, ACLRuleActionChoices, ACLTypeChoices
+from ...choices import (
+    ACLActionChoices,
+    ACLFamilyChoices,
+    ACLRuleActionChoices,
+    ACLRuleLogOptionChoices,
+    ACLTypeChoices,
+)
 from ...constants import ACL_RULE_SOURCE_DESTINATION_MODELS
 from ...forms import ACLStandardRuleBulkEditForm, ACLStandardRuleFilterForm, ACLStandardRuleForm
 from ...models import AccessList, ACLStandardRule
@@ -162,3 +168,70 @@ class ACLStandardRuleFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetT
             form.fields["access_list_id"].query_params,
             {"type": ACLTypeChoices.TYPE_STANDARD},
         )
+
+    def test_logging_fields_are_present(self):
+        """Test that the model form exposes both logging fields."""
+        form = ACLStandardRuleForm()
+        self.assertIn("log_matches", form.fields)
+        self.assertIn("log_options", form.fields)
+
+    def test_log_options_group_vendor_specific_choices(self):
+        """Test that a vendor-specific option is offered under its vendor's group."""
+        form = ACLStandardRuleForm()
+        groups = {
+            group: [value for value, _label in options]
+            for group, options in form.fields["log_options"].choices
+            if isinstance(options, (list, tuple))
+        }
+        self.assertEqual(
+            groups["Cisco"],
+            [ACLRuleLogOptionChoices.OPTION_CISCO_LOG_INPUT],
+        )
+
+    def test_form_rejects_options_without_log_matches(self):
+        """Test that the model form surfaces the consistency error per field."""
+        form = ACLStandardRuleForm(
+            data={
+                "access_list": self.access_list.pk,
+                "sequence": 10,
+                "action": ACLRuleActionChoices.ACTION_PERMIT,
+                "source_type": ContentType.objects.get_for_model(type(self.prefix)).pk,
+                "source": self.prefix.pk,
+                "log_options": [ACLRuleLogOptionChoices.OPTION_SYSLOG],
+            },
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("log_options", form.errors)
+
+    def test_bulkedit_disabling_logging_clears_the_options(self):
+        """Test that turning logging off also drops the options."""
+        form = ACLStandardRuleBulkEditForm(
+            data={"log_matches": "False", "pk": [self._rule(10).pk]},
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["log_options"], [])
+        self.assertIn("log_options", form.changed_data)
+
+    def test_bulkedit_clear_rejects_an_explicit_selection(self):
+        """Test that clearing and selecting log options at once is rejected."""
+        form = ACLStandardRuleBulkEditForm(
+            data={
+                "clear_log_options": True,
+                "log_options": [ACLRuleLogOptionChoices.OPTION_SYSLOG],
+                "pk": [self._rule(20).pk],
+            },
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("clear_log_options", form.errors)
+
+    def test_bulkedit_disabling_logging_rejects_a_selection(self):
+        """Test that disabling logging while selecting options is rejected."""
+        form = ACLStandardRuleBulkEditForm(
+            data={
+                "log_matches": "False",
+                "log_options": [ACLRuleLogOptionChoices.OPTION_SYSLOG],
+                "pk": [self._rule(30).pk],
+            },
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("log_options", form.errors)

--- a/netbox_acls/tests/models/test_extendedrules.py
+++ b/netbox_acls/tests/models/test_extendedrules.py
@@ -8,6 +8,7 @@ from ...choices import (
     ACLFamilyChoices,
     ACLProtocolChoices,
     ACLRuleActionChoices,
+    ACLRuleLogOptionChoices,
     ACLTypeChoices,
 )
 from ...models import AccessList, ACLExtendedRule
@@ -1131,4 +1132,174 @@ class TestACLExtendedRule(BaseTestCase):
             ACLExtendedRule.objects.filter(pk=rule.pk)
             .values("_source_prefix", "_destination_aggregate", "_destination_iprange")
             .get()
+        )
+
+    def test_logging_defaults_to_disabled(self):
+        """Test that a new rule logs nothing until asked to."""
+        rule = ACLExtendedRule(
+            access_list=self.extended_acl1,
+            sequence=10,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+        )
+        self.assertFalse(rule.log_matches)
+        self.assertEqual(rule.log_options, [])
+
+    def test_log_options_require_log_matches(self):
+        """Test that options are rejected while logging is disabled."""
+        rule = ACLExtendedRule(
+            access_list=self.extended_acl1,
+            sequence=30,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+            log_matches=False,
+            log_options=[ACLRuleLogOptionChoices.OPTION_SYSLOG],
+        )
+        with self.assertRaises(ValidationError) as ctx:
+            rule.full_clean()
+        self.assertIn("log_options", ctx.exception.message_dict)
+
+    def test_remark_rule_rejects_logging(self):
+        """Test that a remark cannot request logging, since it matches nothing."""
+        rule = ACLExtendedRule(
+            access_list=self.extended_acl1,
+            sequence=40,
+            action=ACLRuleActionChoices.ACTION_REMARK,
+            remark="Remark",
+            log_matches=True,
+        )
+        with self.assertRaises(ValidationError) as ctx:
+            rule.full_clean()
+        self.assertIn("log_matches", ctx.exception.message_dict)
+
+    def test_remark_logging_errors_accumulate_with_other_remark_errors(self):
+        """Test that a malformed remark reports every offending field at once."""
+        rule = ACLExtendedRule(
+            access_list=self.extended_acl1,
+            sequence=50,
+            action=ACLRuleActionChoices.ACTION_REMARK,
+            remark="",
+            log_matches=True,
+        )
+        with self.assertRaises(ValidationError) as ctx:
+            rule.full_clean()
+        self.assertIn("remark", ctx.exception.message_dict)
+        self.assertIn("log_matches", ctx.exception.message_dict)
+
+    def test_log_matches_without_options_is_valid(self):
+        """Test that enabling logging without naming a destination is allowed."""
+        rule = ACLExtendedRule(
+            access_list=self.extended_acl1,
+            sequence=70,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+            log_matches=True,
+        )
+        rule.full_clean()
+
+    def test_logging_defaults_persist_as_disabled(self):
+        """Test that the stored default is disabled with no options."""
+        rule = ACLExtendedRule.objects.create(
+            access_list=self.extended_acl1,
+            sequence=80,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+        )
+        rule.refresh_from_db()
+        self.assertFalse(rule.log_matches)
+        self.assertEqual(rule.log_options, [])
+
+    def test_clone_carries_the_logging_state(self):
+        """Test that cloning reproduces the logging values, not just the field names."""
+        rule = ACLExtendedRule(
+            access_list=self.extended_acl1,
+            sequence=90,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+            log_matches=True,
+            log_options=[
+                ACLRuleLogOptionChoices.OPTION_SYSLOG,
+                ACLRuleLogOptionChoices.OPTION_CISCO_LOG_INPUT,
+            ],
+        )
+        rule.full_clean()
+        rule.save()
+
+        attrs = rule.clone()
+        self.assertTrue(attrs["log_matches"])
+        self.assertEqual(attrs["log_options"], ["cisco-log-input", "syslog"])
+
+    def test_unsupported_log_option_is_rejected(self):
+        """Test that a value outside the choice set fails validation."""
+        rule = ACLExtendedRule(
+            access_list=self.extended_acl1,
+            sequence=95,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+            log_matches=True,
+            log_options=["not-a-real-option"],
+        )
+        with self.assertRaises(ValidationError) as ctx:
+            rule.full_clean()
+        self.assertIn("log_options", ctx.exception.message_dict)
+
+    def test_log_options_list_renders_display_values(self):
+        """Test that the display helper resolves labels and passes through unknown values."""
+        rule = ACLExtendedRule(
+            log_options=["syslog", "vendor-x-future-option"],
+        )
+        self.assertEqual(
+            rule.log_options_list,
+            ["Syslog", "vendor-x-future-option"],
+        )
+
+    def test_log_options_badges_pair_labels_with_colors(self):
+        """Test that the badge helper pairs each label with its color, leaving unknown values uncolored."""
+        rule = ACLExtendedRule(
+            log_options=["syslog", "vendor-x-future-option"],
+        )
+        self.assertEqual(
+            rule.log_options_badges,
+            [("Syslog", "blue"), ("vendor-x-future-option", None)],
+        )
+
+    def test_remark_rule_rejects_log_options(self):
+        """Test that a remark reports the remark error rather than the master-switch one."""
+        rule = ACLExtendedRule(
+            access_list=self.extended_acl1,
+            sequence=45,
+            action=ACLRuleActionChoices.ACTION_REMARK,
+            remark="Remark",
+            log_options=[ACLRuleLogOptionChoices.OPTION_SYSLOG],
+        )
+        with self.assertRaises(ValidationError) as ctx:
+            rule.full_clean()
+        self.assertEqual(
+            ctx.exception.message_dict["log_options"],
+            ["When the action is 'remark', Log options must not be set."],
+        )
+
+    def test_log_options_are_composable_and_canonicalized(self):
+        """Test that options combine, deduplicate and reach the database sorted."""
+        rule = ACLExtendedRule(
+            access_list=self.extended_acl1,
+            sequence=20,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+            log_matches=True,
+            log_options=[
+                ACLRuleLogOptionChoices.OPTION_SYSLOG,
+                ACLRuleLogOptionChoices.OPTION_CISCO_LOG_INPUT,
+                ACLRuleLogOptionChoices.OPTION_SYSLOG,
+            ],
+        )
+        rule.full_clean()
+        rule.save()
+        rule.refresh_from_db()
+        self.assertEqual(
+            rule.log_options,
+            [
+                ACLRuleLogOptionChoices.OPTION_CISCO_LOG_INPUT,
+                ACLRuleLogOptionChoices.OPTION_SYSLOG,
+            ],
         )

--- a/netbox_acls/tests/models/test_standardrules.py
+++ b/netbox_acls/tests/models/test_standardrules.py
@@ -1,6 +1,12 @@
 from django.core.exceptions import ValidationError
 
-from ...choices import ACLActionChoices, ACLFamilyChoices, ACLRuleActionChoices, ACLTypeChoices
+from ...choices import (
+    ACLActionChoices,
+    ACLFamilyChoices,
+    ACLRuleActionChoices,
+    ACLRuleLogOptionChoices,
+    ACLTypeChoices,
+)
 from ...models import AccessList, ACLStandardRule
 from .base import BaseTestCase
 
@@ -410,3 +416,173 @@ class TestACLStandardRule(BaseTestCase):
     def _cached_sources(rule):
         """Read the shadow columns back from the database, which is what the filters query."""
         return ACLStandardRule.objects.filter(pk=rule.pk).values("_source_prefix", "_source_ipaddress").get()
+
+    def test_logging_defaults_to_disabled(self):
+        """Test that a new rule logs nothing until asked to."""
+        rule = ACLStandardRule(
+            access_list=self.standard_acl1,
+            sequence=10,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+        )
+        self.assertFalse(rule.log_matches)
+        self.assertEqual(rule.log_options, [])
+
+    def test_log_options_require_log_matches(self):
+        """Test that options are rejected while logging is disabled."""
+        rule = ACLStandardRule(
+            access_list=self.standard_acl1,
+            sequence=30,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+            log_matches=False,
+            log_options=[ACLRuleLogOptionChoices.OPTION_SYSLOG],
+        )
+        with self.assertRaises(ValidationError) as ctx:
+            rule.full_clean()
+        self.assertIn("log_options", ctx.exception.message_dict)
+
+    def test_remark_rule_rejects_logging(self):
+        """Test that a remark cannot request logging, since it matches nothing."""
+        rule = ACLStandardRule(
+            access_list=self.standard_acl1,
+            sequence=40,
+            action=ACLRuleActionChoices.ACTION_REMARK,
+            remark="Remark",
+            log_matches=True,
+        )
+        with self.assertRaises(ValidationError) as ctx:
+            rule.full_clean()
+        self.assertIn("log_matches", ctx.exception.message_dict)
+
+    def test_remark_logging_errors_accumulate_with_other_remark_errors(self):
+        """Test that a malformed remark reports every offending field at once."""
+        rule = ACLStandardRule(
+            access_list=self.standard_acl1,
+            sequence=50,
+            action=ACLRuleActionChoices.ACTION_REMARK,
+            remark="",
+            log_matches=True,
+        )
+        with self.assertRaises(ValidationError) as ctx:
+            rule.full_clean()
+        self.assertIn("remark", ctx.exception.message_dict)
+        self.assertIn("log_matches", ctx.exception.message_dict)
+
+    def test_log_matches_without_options_is_valid(self):
+        """Test that enabling logging without naming a destination is allowed."""
+        rule = ACLStandardRule(
+            access_list=self.standard_acl1,
+            sequence=70,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+            log_matches=True,
+        )
+        rule.full_clean()
+
+    def test_logging_defaults_persist_as_disabled(self):
+        """Test that the stored default is disabled with no options."""
+        rule = ACLStandardRule.objects.create(
+            access_list=self.standard_acl1,
+            sequence=80,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+        )
+        rule.refresh_from_db()
+        self.assertFalse(rule.log_matches)
+        self.assertEqual(rule.log_options, [])
+
+    def test_clone_carries_the_logging_state(self):
+        """Test that cloning reproduces the logging values, not just the field names."""
+        rule = ACLStandardRule(
+            access_list=self.standard_acl1,
+            sequence=90,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+            log_matches=True,
+            log_options=[
+                ACLRuleLogOptionChoices.OPTION_SYSLOG,
+                ACLRuleLogOptionChoices.OPTION_CISCO_LOG_INPUT,
+            ],
+        )
+        rule.full_clean()
+        rule.save()
+
+        attrs = rule.clone()
+        self.assertTrue(attrs["log_matches"])
+        self.assertEqual(attrs["log_options"], ["cisco-log-input", "syslog"])
+
+    def test_unsupported_log_option_is_rejected(self):
+        """Test that a value outside the choice set fails validation."""
+        rule = ACLStandardRule(
+            access_list=self.standard_acl1,
+            sequence=95,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+            log_matches=True,
+            log_options=["not-a-real-option"],
+        )
+        with self.assertRaises(ValidationError) as ctx:
+            rule.full_clean()
+        self.assertIn("log_options", ctx.exception.message_dict)
+
+    def test_log_options_list_renders_display_values(self):
+        """Test that the display helper resolves labels and passes through unknown values."""
+        rule = ACLStandardRule(
+            log_options=["syslog", "vendor-x-future-option"],
+        )
+        self.assertEqual(
+            rule.log_options_list,
+            ["Syslog", "vendor-x-future-option"],
+        )
+
+    def test_log_options_badges_pair_labels_with_colors(self):
+        """Test that the badge helper pairs each label with its color, leaving unknown values uncolored."""
+        rule = ACLStandardRule(
+            log_options=["syslog", "vendor-x-future-option"],
+        )
+        self.assertEqual(
+            rule.log_options_badges,
+            [("Syslog", "blue"), ("vendor-x-future-option", None)],
+        )
+
+    def test_remark_rule_rejects_log_options(self):
+        """Test that a remark reports the remark error rather than the master-switch one."""
+        rule = ACLStandardRule(
+            access_list=self.standard_acl1,
+            sequence=45,
+            action=ACLRuleActionChoices.ACTION_REMARK,
+            remark="Remark",
+            log_options=[ACLRuleLogOptionChoices.OPTION_SYSLOG],
+        )
+        with self.assertRaises(ValidationError) as ctx:
+            rule.full_clean()
+        self.assertEqual(
+            ctx.exception.message_dict["log_options"],
+            ["When the action is 'remark', Log options must not be set."],
+        )
+
+    def test_log_options_are_composable_and_canonicalized(self):
+        """Test that options combine, deduplicate and reach the database sorted."""
+        rule = ACLStandardRule(
+            access_list=self.standard_acl1,
+            sequence=20,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix1,
+            log_matches=True,
+            log_options=[
+                ACLRuleLogOptionChoices.OPTION_SYSLOG,
+                ACLRuleLogOptionChoices.OPTION_CISCO_LOG_INPUT,
+                ACLRuleLogOptionChoices.OPTION_SYSLOG,
+            ],
+        )
+        rule.full_clean()
+        rule.save()
+        rule.refresh_from_db()
+        self.assertEqual(
+            rule.log_options,
+            [
+                ACLRuleLogOptionChoices.OPTION_CISCO_LOG_INPUT,
+                ACLRuleLogOptionChoices.OPTION_SYSLOG,
+            ],
+        )

--- a/netbox_acls/tests/tables/test_extendedrules.py
+++ b/netbox_acls/tests/tables/test_extendedrules.py
@@ -1,6 +1,29 @@
+from ...models import ACLExtendedRule
 from ...tables import ACLExtendedRuleTable
 from . import base
 
 
 class ACLExtendedRuleTableTestCase(base.StandardTableTestCase):
     table = ACLExtendedRuleTable
+
+    def test_logging_columns_are_available_and_log_matches_is_default(self):
+        """Test that both logging columns exist and only the master switch shows by default."""
+        self.assertIn("log_matches", ACLExtendedRuleTable.base_columns)
+        self.assertIn("log_options_list", ACLExtendedRuleTable.base_columns)
+        self.assertIn("log_matches", ACLExtendedRuleTable.Meta.default_columns)
+        self.assertNotIn("log_options_list", ACLExtendedRuleTable.Meta.default_columns)
+
+    def test_log_options_column_renders_colored_badges(self):
+        """Test that the column badges each option and exports the plain labels."""
+        rule = ACLExtendedRule(log_options=["syslog", "cisco-log-input"])
+        table = ACLExtendedRuleTable([rule])
+        cell = table.rows[0].get_cell("log_options_list")
+        self.assertInHTML('<span class="badge text-bg-blue">Syslog</span>', cell)
+        self.assertInHTML(
+            '<span class="badge text-bg-purple">Log-input</span>',
+            cell,
+        )
+        self.assertEqual(
+            table.rows[0].get_cell_value("log_options_list"),
+            "Syslog, Log-input",
+        )

--- a/netbox_acls/tests/tables/test_standardrules.py
+++ b/netbox_acls/tests/tables/test_standardrules.py
@@ -1,6 +1,29 @@
+from ...models import ACLStandardRule
 from ...tables import ACLStandardRuleTable
 from . import base
 
 
 class ACLStandardRuleTableTestCase(base.StandardTableTestCase):
     table = ACLStandardRuleTable
+
+    def test_logging_columns_are_available_and_log_matches_is_default(self):
+        """Test that both logging columns exist and only the master switch shows by default."""
+        self.assertIn("log_matches", ACLStandardRuleTable.base_columns)
+        self.assertIn("log_options_list", ACLStandardRuleTable.base_columns)
+        self.assertIn("log_matches", ACLStandardRuleTable.Meta.default_columns)
+        self.assertNotIn("log_options_list", ACLStandardRuleTable.Meta.default_columns)
+
+    def test_log_options_column_renders_colored_badges(self):
+        """Test that the column badges each option and exports the plain labels."""
+        rule = ACLStandardRule(log_options=["syslog", "cisco-log-input"])
+        table = ACLStandardRuleTable([rule])
+        cell = table.rows[0].get_cell("log_options_list")
+        self.assertInHTML('<span class="badge text-bg-blue">Syslog</span>', cell)
+        self.assertInHTML(
+            '<span class="badge text-bg-purple">Log-input</span>',
+            cell,
+        )
+        self.assertEqual(
+            table.rows[0].get_cell_value("log_options_list"),
+            "Syslog, Log-input",
+        )

--- a/netbox_acls/tests/views/test_accesslists.py
+++ b/netbox_acls/tests/views/test_accesslists.py
@@ -132,3 +132,6 @@ class AccessListViewTestCase(PluginTestCases.ObjectViewTestCase):
                 # The column is redundant on an access list's own detail page.
                 visible = [column.name for column in table.columns.itervisible()]
                 self.assertNotIn("access_list", visible)
+                # The embedded table is the page's subject, so it shows the full logging state.
+                self.assertIn("log_matches", visible)
+                self.assertIn("log_options_list", visible)

--- a/netbox_acls/tests/views/test_extendedrules.py
+++ b/netbox_acls/tests/views/test_extendedrules.py
@@ -10,6 +10,7 @@ from ...choices import (
     ACLFamilyChoices,
     ACLProtocolChoices,
     ACLRuleActionChoices,
+    ACLRuleLogOptionChoices,
     ACLTypeChoices,
 )
 from ...models import AccessList, ACLExtendedRule
@@ -105,6 +106,8 @@ class ACLExtendedRuleViewTestCase(ACLRuleSequenceTestsMixin, PluginTestCases.Obj
             "destination_type": ContentType.objects.get_for_model(Prefix).pk,
             "destination": cls.destination_prefix.pk,
             "destination_port_ranges": "8080-8081",
+            "log_matches": True,
+            "log_options": [ACLRuleLogOptionChoices.OPTION_SYSLOG],
             "description": "A new extended rule",
             "comments": "",
             "tags": [t.pk for t in tags],
@@ -113,3 +116,82 @@ class ACLExtendedRuleViewTestCase(ACLRuleSequenceTestsMixin, PluginTestCases.Obj
         cls.bulk_edit_data = {
             "description": "Bulk edited",
         }
+
+    def test_detail_view_renders_log_option_labels(self):
+        """Test that the detail page shows option labels rather than stored values."""
+        rule = ACLExtendedRule.objects.create(
+            access_list=self.access_list,
+            sequence=200,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.source_prefix,
+            log_matches=True,
+            log_options=[
+                ACLRuleLogOptionChoices.OPTION_SYSLOG,
+                ACLRuleLogOptionChoices.OPTION_CISCO_LOG_INPUT,
+            ],
+        )
+        self.add_permissions("netbox_acls.view_aclextendedrule")
+
+        response = self.client.get(rule.get_absolute_url())
+        self.assertHttpStatus(response, 200)
+        self.assertContains(response, "Syslog")
+        self.assertContains(response, "Log-input")
+        self.assertContains(response, 'class="badge text-bg-blue"')
+        self.assertContains(response, 'class="badge text-bg-purple"')
+
+    def test_bulk_edit_clears_options_while_logging_stays_enabled(self):
+        """Test that options can be cleared without also disabling logging."""
+        rules = [
+            ACLExtendedRule.objects.create(
+                access_list=self.access_list,
+                sequence=sequence,
+                action=ACLRuleActionChoices.ACTION_PERMIT,
+                source=self.source_prefix,
+                log_matches=True,
+                log_options=[ACLRuleLogOptionChoices.OPTION_SYSLOG],
+            )
+            for sequence in (210, 220)
+        ]
+        self.add_permissions("netbox_acls.change_aclextendedrule", "netbox_acls.view_aclextendedrule")
+
+        response = self.client.post(
+            self._get_url("bulk_edit"),
+            {
+                "pk": [rule.pk for rule in rules],
+                "_apply": True,
+                "clear_log_options": True,
+            },
+        )
+        self.assertHttpStatus(response, 302)
+
+        for rule in rules:
+            rule.refresh_from_db()
+            self.assertTrue(rule.log_matches)
+            self.assertEqual(rule.log_options, [])
+
+    def test_bulk_edit_cannot_enable_logging_on_a_remark(self):
+        """Test that the model's remark guard survives the bulk edit path."""
+        rule = ACLExtendedRule.objects.create(
+            access_list=self.access_list,
+            sequence=230,
+            action=ACLRuleActionChoices.ACTION_REMARK,
+            remark="Remark",
+        )
+        self.add_permissions(
+            "netbox_acls.change_aclextendedrule",
+            "netbox_acls.view_aclextendedrule",
+        )
+
+        response = self.client.post(
+            self._get_url("bulk_edit"),
+            {
+                "pk": [rule.pk],
+                "_apply": True,
+                "log_matches": "True",
+            },
+        )
+        self.assertHttpStatus(response, 200)
+        self.assertContains(response, "Log matches must not be enabled")
+
+        rule.refresh_from_db()
+        self.assertFalse(rule.log_matches)

--- a/netbox_acls/tests/views/test_standardrules.py
+++ b/netbox_acls/tests/views/test_standardrules.py
@@ -7,6 +7,7 @@ from ...choices import (
     ACLActionChoices,
     ACLFamilyChoices,
     ACLRuleActionChoices,
+    ACLRuleLogOptionChoices,
     ACLTypeChoices,
 )
 from ...models import AccessList, ACLStandardRule
@@ -83,6 +84,8 @@ class ACLStandardRuleViewTestCase(ACLRuleSequenceTestsMixin, PluginTestCases.Obj
             "remark": "",
             "source_type": ContentType.objects.get_for_model(Prefix).pk,
             "source": cls.prefix.pk,
+            "log_matches": True,
+            "log_options": [ACLRuleLogOptionChoices.OPTION_SYSLOG],
             "description": "A new standard rule",
             "comments": "",
             "tags": [t.pk for t in tags],
@@ -91,3 +94,82 @@ class ACLStandardRuleViewTestCase(ACLRuleSequenceTestsMixin, PluginTestCases.Obj
         cls.bulk_edit_data = {
             "description": "Bulk edited",
         }
+
+    def test_detail_view_renders_log_option_labels(self):
+        """Test that the detail page shows option labels rather than stored values."""
+        rule = ACLStandardRule.objects.create(
+            access_list=self.access_list,
+            sequence=200,
+            action=ACLRuleActionChoices.ACTION_PERMIT,
+            source=self.prefix,
+            log_matches=True,
+            log_options=[
+                ACLRuleLogOptionChoices.OPTION_SYSLOG,
+                ACLRuleLogOptionChoices.OPTION_CISCO_LOG_INPUT,
+            ],
+        )
+        self.add_permissions("netbox_acls.view_aclstandardrule")
+
+        response = self.client.get(rule.get_absolute_url())
+        self.assertHttpStatus(response, 200)
+        self.assertContains(response, "Syslog")
+        self.assertContains(response, "Log-input")
+        self.assertContains(response, 'class="badge text-bg-blue"')
+        self.assertContains(response, 'class="badge text-bg-purple"')
+
+    def test_bulk_edit_clears_options_while_logging_stays_enabled(self):
+        """Test that options can be cleared without also disabling logging."""
+        rules = [
+            ACLStandardRule.objects.create(
+                access_list=self.access_list,
+                sequence=sequence,
+                action=ACLRuleActionChoices.ACTION_PERMIT,
+                source=self.prefix,
+                log_matches=True,
+                log_options=[ACLRuleLogOptionChoices.OPTION_SYSLOG],
+            )
+            for sequence in (210, 220)
+        ]
+        self.add_permissions("netbox_acls.change_aclstandardrule", "netbox_acls.view_aclstandardrule")
+
+        response = self.client.post(
+            self._get_url("bulk_edit"),
+            {
+                "pk": [rule.pk for rule in rules],
+                "_apply": True,
+                "clear_log_options": True,
+            },
+        )
+        self.assertHttpStatus(response, 302)
+
+        for rule in rules:
+            rule.refresh_from_db()
+            self.assertTrue(rule.log_matches)
+            self.assertEqual(rule.log_options, [])
+
+    def test_bulk_edit_cannot_enable_logging_on_a_remark(self):
+        """Test that the model's remark guard survives the bulk edit path."""
+        rule = ACLStandardRule.objects.create(
+            access_list=self.access_list,
+            sequence=230,
+            action=ACLRuleActionChoices.ACTION_REMARK,
+            remark="Remark",
+        )
+        self.add_permissions(
+            "netbox_acls.change_aclstandardrule",
+            "netbox_acls.view_aclstandardrule",
+        )
+
+        response = self.client.post(
+            self._get_url("bulk_edit"),
+            {
+                "pk": [rule.pk],
+                "_apply": True,
+                "log_matches": "True",
+            },
+        )
+        self.assertHttpStatus(response, 200)
+        self.assertContains(response, "Log matches must not be enabled")
+
+        rule.refresh_from_db()
+        self.assertFalse(rule.log_matches)

--- a/netbox_acls/utils.py
+++ b/netbox_acls/utils.py
@@ -12,6 +12,7 @@ from .choices import ACLFamilyChoices
 
 __all__ = (
     "infer_family_from_object",
+    "normalize_log_options",
     "normalize_port_ranges",
 )
 
@@ -32,6 +33,13 @@ def infer_family_from_object(obj):
     if version == 6:
         return ACLFamilyChoices.FAMILY_IPV6
     return None
+
+
+def normalize_log_options(options: Iterable[str]) -> list[str]:
+    """
+    Deduplicate log options and order them for stable storage and change logging.
+    """
+    return sorted(set(options))
 
 
 def normalize_port_ranges(ranges: Iterable[NumericRange], field_name: str = "__all__") -> list[NumericRange]:

--- a/netbox_acls/views.py
+++ b/netbox_acls/views.py
@@ -134,8 +134,12 @@ class AccessListView(generic.ObjectView):
             table = None
 
         if table:
-            table.columns.hide("access_list")
             table.configure(request)
+            # Visibility is set after configure(), which resets columns from the user's
+            # preference or the table defaults.
+            table.columns.hide("access_list")
+            table.columns.show("log_matches")
+            table.columns.show("log_options_list")
 
             return {
                 "rules_table": table,


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #57

## New Behavior

Standard and Extended ACL rules can now document whether matching traffic should be logged and optionally record additional logging attributes.

Logging options initially include explicit syslog logging and the platform-dependent Cisco `log-input` behavior. The new fields are supported across the UI, bulk editing, REST API, GraphQL, filtering, tables, detail views, and rule cloning.

Logging options are normalized and validated: options require logging to be enabled, and remark rules cannot contain logging configuration.

## Contrast to Current Behavior

ACL rules currently have no structured way to document per-rule logging requirements.

This change distinguishes between disabled logging, platform-default logging, explicit syslog intent, and optional vendor-specific logging behavior. Existing rules remain unchanged and default to logging being disabled.

## Discussion: Benefits and Drawbacks

This provides structured logging intent for documentation, automation, and integrations such as SIEM workflows without storing raw vendor configuration. Logging enablement is kept separate from optional logging attributes: `log_matches` records whether matching traffic should be logged, while `log_options` records composable details such as an explicit syslog destination or the platform-dependent Cisco `log-input` behavior. An enabled rule without options represents platform-default logging.

The logging options use an expandable ChoiceSet, allowing additional explicitly identified options to be added when needed. Vendor-specific options remain platform-dependent, so downstream tooling is responsible for validating or translating them for a particular target.

The change is backwards-compatible and additive. It does not add vendor configuration rendering.

## Changes to the Documentation

No standalone documentation changes are included. The new fields provide inline labels and help text explaining platform-default and vendor-specific behavior.

## Proposed Release Note Entry

Added per-rule logging controls and logging options for Standard and Extended ACL rules across the UI and APIs. (#57)

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets `feature` (next minor release).
