### PR TITLE
Closes #352: Add GRE, EIGRP, OSPF, and PIM protocol choices for Extended ACL Rules

### DIFF
--- a/netbox_acls/choices.py
+++ b/netbox_acls/choices.py
@@ -10,7 +10,6 @@ __all__ = (
     "ACLAssignmentDirectionUIChoices",
     "ACLFamilyChoices",
     "ACLProtocolChoices",
-    "ACLProtocolChoices",
     "ACLRuleActionChoices",
     "ACLRuleLogOptionChoices",
     "ACLTypeChoices",
@@ -138,14 +137,35 @@ class ACLProtocolChoices(ChoiceSet):
     Defines the choices available for the Access Lists plugin specific to ACL Rule protocol.
     """
 
+    key = "ACLExtendedRule.protocol"
+
+    PROTOCOL_EIGRP = "eigrp"
+    PROTOCOL_GRE = "gre"
     PROTOCOL_ICMP = "icmp"
     PROTOCOL_IP = "ip"
+    PROTOCOL_OSPF = "ospf"
+    PROTOCOL_PIM = "pim"
     PROTOCOL_TCP = "tcp"
     PROTOCOL_UDP = "udp"
 
+    # The second group follows the IP protocol numbers 47, 88, 89 and 103.
     CHOICES = [
-        (PROTOCOL_ICMP, "ICMP", "purple"),
-        (PROTOCOL_IP, "IP", "cyan"),
-        (PROTOCOL_TCP, "TCP", "blue"),
-        (PROTOCOL_UDP, "UDP", "orange"),
+        (
+            "Common",
+            (
+                (PROTOCOL_ICMP, "ICMP", "purple"),
+                (PROTOCOL_IP, "IP", "cyan"),
+                (PROTOCOL_TCP, "TCP", "blue"),
+                (PROTOCOL_UDP, "UDP", "orange"),
+            ),
+        ),
+        (
+            "Routing and tunneling",
+            (
+                (PROTOCOL_GRE, "GRE", "teal"),
+                (PROTOCOL_EIGRP, "EIGRP", "yellow"),
+                (PROTOCOL_OSPF, "OSPF", "green"),
+                (PROTOCOL_PIM, "PIM", "indigo"),
+            ),
+        ),
     ]

--- a/netbox_acls/tests/api/test_access_list_rules.py
+++ b/netbox_acls/tests/api/test_access_list_rules.py
@@ -436,6 +436,17 @@ class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
                 "action": ACLRuleActionChoices.ACTION_REMARK,
                 "remark": "Remark 2",
             },
+            {
+                "access_list": access_list_vm.id,
+                "sequence": 40,
+                "description": "Rule 40",
+                "action": ACLRuleActionChoices.ACTION_PERMIT,
+                "protocol": ACLProtocolChoices.PROTOCOL_GRE,
+                "source_type": "ipam.prefix",
+                "source_id": prefix1.id,
+                "destination_type": "ipam.prefix",
+                "destination_id": prefix2.id,
+            },
         ]
         cls.bulk_update_data = {
             "description": "Rule bulk update",

--- a/netbox_acls/tests/forms/test_extendedrules.py
+++ b/netbox_acls/tests/forms/test_extendedrules.py
@@ -214,6 +214,12 @@ class ACLExtendedRuleFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetT
             {"type": ACLTypeChoices.TYPE_EXTENDED},
         )
 
+    def test_protocol_filter_form_accepts_a_grouped_value(self):
+        """add_blank_choice concatenates tuples, so the optgroups must survive into the field."""
+        form = ACLExtendedRuleFilterForm(data={"protocol": ACLProtocolChoices.PROTOCOL_GRE})
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["protocol"], ACLProtocolChoices.PROTOCOL_GRE)
+
     def test_logging_fields_are_present(self):
         """Test that the model form exposes both logging fields."""
         form = ACLExtendedRuleForm()

--- a/netbox_acls/tests/models/test_extendedrules.py
+++ b/netbox_acls/tests/models/test_extendedrules.py
@@ -471,6 +471,39 @@ class TestACLExtendedRule(BaseTestCase):
         self.assertEqual(isinstance(created_rule.access_list, AccessList), True)
         self.assertEqual(created_rule.access_list.type, self.acl_type)
 
+    def test_acl_extended_rule_routing_protocol_creation_success(self):
+        """
+        Test that ACLExtendedRule with a routing or tunneling protocol passes validation.
+        """
+        routing_protocols = (
+            ACLProtocolChoices.PROTOCOL_GRE,
+            ACLProtocolChoices.PROTOCOL_EIGRP,
+            ACLProtocolChoices.PROTOCOL_OSPF,
+            ACLProtocolChoices.PROTOCOL_PIM,
+        )
+
+        for protocol in routing_protocols:
+            with self.subTest(protocol=protocol):
+                created_rule = ACLExtendedRule(
+                    access_list=self.extended_acl1,
+                    sequence=140,
+                    action="permit",
+                    remark="",
+                    source=self.prefix1,
+                    source_port_ranges=None,
+                    destination=self.prefix2,
+                    destination_port_ranges=None,
+                    protocol=protocol,
+                    description=f"Created rule with {protocol} protocol",
+                )
+                created_rule.full_clean()
+
+                self.assertEqual(created_rule.protocol, protocol)
+                self.assertEqual(created_rule.source, self.prefix1)
+                self.assertEqual(created_rule.destination, self.prefix2)
+                self.assertEqual(created_rule.source_port_ranges, [])
+                self.assertEqual(created_rule.destination_port_ranges, [])
+
     def test_acl_extended_rule_complete_params_creation_success(self):
         """
         Test that ACLExtendedRule with complete parameters creation passes validation.
@@ -748,43 +781,32 @@ class TestACLExtendedRule(BaseTestCase):
         with self.assertRaises(ValidationError):
             invalid_rule.full_clean()
 
-    def test_acl_extended_rule_protocol_ip_with_source_port_ranges_fail(self):
+    def test_non_tcp_udp_protocols_reject_ports(self):
         """
-        Test that ACLExtendedRule with protocol 'ip' and source ports fails validation.
+        Test that ACLExtendedRule rejects ports on every protocol except TCP and UDP.
         """
-        invalid_rule = ACLExtendedRule(
-            access_list=self.extended_acl1,
-            sequence=10,
-            action="permit",
-            remark="",
-            source=None,
-            source_port_ranges=string_to_ranges("80, 443"),
-            destination=None,
-            destination_port_ranges=None,
-            protocol=ACLProtocolChoices.PROTOCOL_IP,
-            description="Invalid rule with protocol 'ip' and source ports set",
-        )
-        with self.assertRaises(ValidationError):
-            invalid_rule.full_clean()
+        portless_protocols = [
+            protocol
+            for protocol in ACLProtocolChoices.values()
+            if protocol not in {ACLProtocolChoices.PROTOCOL_TCP, ACLProtocolChoices.PROTOCOL_UDP}
+        ]
+        for new_protocol in ("gre", "eigrp", "ospf", "pim"):
+            self.assertIn(new_protocol, portless_protocols)
 
-    def test_acl_extended_rule_protocol_icmp_with_destination_port_ranges_fail(self):
-        """
-        Test that ACLExtendedRule with protocol 'icmp' and destination ports fails validation.
-        """
-        invalid_rule = ACLExtendedRule(
-            access_list=self.extended_acl1,
-            sequence=10,
-            action="permit",
-            remark="",
-            source=None,
-            source_port_ranges=None,
-            destination=None,
-            destination_port_ranges=string_to_ranges("80, 443"),
-            protocol=ACLProtocolChoices.PROTOCOL_ICMP,
-            description="Invalid rule with protocol 'icmp' and destination ports set",
-        )
-        with self.assertRaises(ValidationError):
-            invalid_rule.full_clean()
+        for protocol in portless_protocols:
+            for field_name in ("source_port_ranges", "destination_port_ranges"):
+                with self.subTest(protocol=protocol, field=field_name):
+                    invalid_rule = ACLExtendedRule(
+                        access_list=self.extended_acl1,
+                        sequence=10,
+                        action="permit",
+                        remark="",
+                        protocol=protocol,
+                        description=f"Invalid rule with protocol '{protocol}' and {field_name} set",
+                        **{field_name: string_to_ranges("80, 443")},
+                    )
+                    with self.assertRaises(ValidationError):
+                        invalid_rule.full_clean()
 
     def test_acl_extended_rule_with_invalid_source_port_ranges_fail(self):
         """
@@ -898,17 +920,18 @@ class TestACLExtendedRule(BaseTestCase):
         """
         Test ACLExtendedRule protocol choices using VALID choices.
         """
-        valid_acl_rule_protocol_choices = ["icmp", "ip", "tcp", "udp"]
+        valid_acl_rule_protocol_choices = ["icmp", "ip", "tcp", "udp", "gre", "eigrp", "ospf", "pim"]
 
         for protocol_choice in valid_acl_rule_protocol_choices:
-            valid_acl_rule_protocol = ACLExtendedRule(
-                access_list=self.extended_acl1,
-                sequence=10,
-                action=self.default_action,
-                protocol=protocol_choice,
-                description=f"VALID ACL RULE PROTOCOL CHOICES USED: protocol={protocol_choice}",
-            )
-            valid_acl_rule_protocol.full_clean()
+            with self.subTest(protocol=protocol_choice):
+                valid_acl_rule_protocol = ACLExtendedRule(
+                    access_list=self.extended_acl1,
+                    sequence=10,
+                    action=self.default_action,
+                    protocol=protocol_choice,
+                    description=f"VALID ACL RULE PROTOCOL CHOICES USED: protocol={protocol_choice}",
+                )
+                valid_acl_rule_protocol.full_clean()
 
     def test_invalid_acl_rule_protocol_choices(self):
         """


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #352

## New Behavior

Extended ACL rules now support GRE, EIGRP, OSPF, and PIM as protocol choices. Protocols are organized into **Common** and **Routing and tunneling** groups, and the new choices reject source and destination ports like the existing IP and ICMP choices.

## Contrast to Current Behavior

Previously, these protocols had to be represented using the generic `ip` choice, which lost useful protocol-specific intent. Existing protocol values and their validation behavior remain unchanged.

## Discussion: Benefits and Drawbacks

This allows routing and tunneling rules to be documented more accurately while remaining vendor-neutral. The grouped choices also keep the protocol selector easier to navigate as it grows.

The change is additive and backwards-compatible, does not alter existing rules or stored values, and introduces no database schema changes. It intentionally does not add vendor-specific rendering or other protocol-specific attributes.

## Changes to the Documentation

No standalone documentation changes are required. The new choices are exposed through the existing UI and API field metadata, and the user-visible change is covered by the release note below.

## Proposed Release Note Entry

Added GRE, EIGRP, OSPF, and PIM protocol choices for extended ACL rules. (#352)

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets `feature` (next minor release).
