### PR TITLE
Closes #392: Add filtering of ACL Assignments by assigned object type

### DIFF
--- a/netbox_acls/filtersets.py
+++ b/netbox_acls/filtersets.py
@@ -6,6 +6,7 @@ when filtering the site list by status or region, for instance.
 import contextlib
 
 import django_filters
+from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
@@ -13,7 +14,12 @@ from dcim.models import Device, Interface, Region, Site, SiteGroup, VirtualChass
 from ipam.models import Aggregate, IPAddress, IPRange, Prefix
 from netbox.filtersets import NetBoxModelFilterSet, PrimaryModelFilterSet
 from users.filterset_mixins import OwnerFilterMixin
-from utilities.filters import ContentTypeFilter, MultiValueBigNumberFilter, MultiValueCharFilter
+from utilities.filters import (
+    ContentTypeFilter,
+    MultiValueBigNumberFilter,
+    MultiValueCharFilter,
+    MultiValueContentTypeFilter,
+)
 from utilities.filtersets import register_filterset
 from virtualization.models import VirtualMachine, VMInterface
 
@@ -78,6 +84,17 @@ class ACLAssignmentFilterSet(OwnerFilterMixin, NetBoxModelFilterSet):
         queryset=AccessList.objects.all(),
         to_field_name="id",
         label=_("Access List (ID)"),
+    )
+
+    # Assigned object
+    assigned_object_type = MultiValueContentTypeFilter(
+        label=_("Assigned Object Type"),
+    )
+    assigned_object_type_id = django_filters.ModelMultipleChoiceFilter(
+        field_name="assigned_object_type",
+        queryset=ContentType.objects.all(),
+        distinct=False,
+        label=_("Assigned Object Type (ID)"),
     )
 
     # Organization
@@ -186,6 +203,8 @@ class ACLAssignmentFilterSet(OwnerFilterMixin, NetBoxModelFilterSet):
         fields = (
             "id",
             "access_list",
+            "assigned_object_type",
+            "assigned_object_type_id",
             "family",
             "site",
             "site_id",

--- a/netbox_acls/forms/filtersets.py
+++ b/netbox_acls/forms/filtersets.py
@@ -3,6 +3,7 @@ Defines each django model's GUI filter/search options.
 """
 
 from django import forms
+from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import gettext_lazy as _
 
 from dcim.models import Device, Interface, Region, Site, SiteGroup, VirtualChassis
@@ -11,6 +12,7 @@ from netbox.forms import NetBoxModelFilterSetForm, PrimaryModelFilterSetForm
 from netbox.forms.mixins import OwnerFilterMixin
 from utilities.forms.constants import BOOLEAN_WITH_BLANK_CHOICES
 from utilities.forms.fields import (
+    ContentTypeMultipleChoiceField,
     DynamicModelChoiceField,
     DynamicModelMultipleChoiceField,
     TagFilterField,
@@ -28,6 +30,7 @@ from ..choices import (
     ACLRuleLogOptionChoices,
     ACLTypeChoices,
 )
+from ..constants import ACL_ASSIGNMENT_MODELS
 from ..models import (
     AccessList,
     ACLAssignment,
@@ -104,6 +107,7 @@ class ACLAssignmentFilterForm(OwnerFilterMixin, NetBoxModelFilterSetForm):
         ),
         FieldSet(
             "access_list_id",
+            "assigned_object_type_id",
             "family",
             "direction",
             name=_("ACL Details"),
@@ -137,6 +141,11 @@ class ACLAssignmentFilterForm(OwnerFilterMixin, NetBoxModelFilterSetForm):
         queryset=AccessList.objects.all(),
         required=False,
         label=_("Access List"),
+    )
+    assigned_object_type_id = ContentTypeMultipleChoiceField(
+        queryset=ContentType.objects.filter(ACL_ASSIGNMENT_MODELS),
+        required=False,
+        label=_("Assigned Object Type"),
     )
     family = forms.ChoiceField(
         choices=add_blank_choice(ACLFamilyChoices),

--- a/netbox_acls/tests/filtersets/test_aclassignments.py
+++ b/netbox_acls/tests/filtersets/test_aclassignments.py
@@ -13,6 +13,7 @@ from dcim.models import (
     SiteGroup,
     VirtualChassis,
 )
+from ipam.models import Prefix
 from utilities.testing import ChangeLoggedFilterSetTestMixin
 from virtualization.models import Cluster, ClusterType, VirtualMachine, VMInterface
 
@@ -167,6 +168,55 @@ class ACLAssignmentFilterSetTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {"access_list": [self.acl2.name]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_assigned_object_type(self):
+        params = {"assigned_object_type": ["dcim.interface"]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {"assigned_object_type": ["dcim.interface", "virtualization.vminterface"]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+        params = {
+            "assigned_object_type": [
+                "dcim.device",
+                "dcim.virtualchassis",
+                "virtualization.virtualmachine",
+            ],
+        }
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+
+    def test_assigned_object_type_id(self):
+        params = {"assigned_object_type_id": [ContentType.objects.get_for_model(Interface).pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {
+            "assigned_object_type_id": [
+                ContentType.objects.get_for_model(Device).pk,
+                ContentType.objects.get_for_model(VirtualMachine).pk,
+            ],
+        }
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_assigned_object_type_outside_whitelist_matches_nothing(self):
+        """limit_choices_to keeps unassignable types off the model, so none can ever match."""
+        filterset = self.filterset({"assigned_object_type": ["ipam.prefix"]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 0)
+
+    def test_assigned_object_type_id_outside_whitelist_matches_nothing(self):
+        """The pk filter is unrestricted, so an unassignable type matches nothing rather than erroring."""
+        params = {"assigned_object_type_id": [ContentType.objects.get_for_model(Prefix).pk]}
+        filterset = self.filterset(params, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 0)
+
+    def test_assigned_object_type_drops_unparseable_values(self):
+        """A key that is not <app_label>.<model> is skipped, and the remaining keys still filter."""
+        for params, expected in (
+            ({"assigned_object_type": ["dcim"]}, 0),
+            ({"assigned_object_type": ["dcim.interface", "dcim"]}, 2),
+        ):
+            with self.subTest(params=params):
+                filterset = self.filterset(params, self.queryset)
+                self.assertEqual(filterset.errors, {})
+                self.assertEqual(filterset.qs.count(), expected)
 
     def test_interface(self):
         params = {"interface_id": [self.interface1.pk]}

--- a/netbox_acls/tests/forms/test_aclassignments.py
+++ b/netbox_acls/tests/forms/test_aclassignments.py
@@ -122,6 +122,28 @@ class ACLAssignmentFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetTes
             transform=lambda ct: ct,
         )
 
+    def test_filterform_assigned_object_type_choices_limited(self):
+        """Test that the filter form's type picker offers only the assignable models."""
+        form = ACLAssignmentFilterForm()
+        self.assertQuerySetEqual(
+            form.fields["assigned_object_type_id"].queryset.order_by("pk"),
+            ContentType.objects.filter(ACL_ASSIGNMENT_MODELS).order_by("pk"),
+            transform=lambda ct: ct,
+        )
+
+    def test_filterform_assigned_object_type_cleans_to_content_types(self):
+        """Test that the filter form's type picker resolves primary keys, not natural keys."""
+        interface_type = ContentType.objects.get_for_model(Interface)
+        vminterface_type = ContentType.objects.get_for_model(VMInterface)
+        form = ACLAssignmentFilterForm(
+            data={"assigned_object_type_id": [interface_type.pk, vminterface_type.pk]},
+        )
+        self.assertTrue(form.is_valid(), msg=form.errors.as_text())
+        self.assertCountEqual(
+            form.cleaned_data["assigned_object_type_id"],
+            [interface_type, vminterface_type],
+        )
+
     def test_unresolvable_content_type_is_survivable(self):
         """
         Test that a content type id which no longer resolves leaves the form usable.

--- a/netbox_acls/tests/query_counts.json
+++ b/netbox_acls/tests/query_counts.json
@@ -2,7 +2,7 @@
   "accesslist:api_list_objects": 12,
   "accesslist:list_objects_with_permission": 18,
   "aclassignment:api_list_objects": 18,
-  "aclassignment:list_objects_with_permission": 21,
+  "aclassignment:list_objects_with_permission": 22,
   "aclextendedrule:api_list_objects": 17,
   "aclextendedrule:list_objects_with_permission": 27,
   "aclstandardrule:api_list_objects": 15,


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #392

## New Behavior

Adds `assigned_object_type` and `assigned_object_type_id` filters for ACL assignments.

The natural-key filter accepts one or more values in `<app_label>.<model>` format, while the ID filter accepts content type IDs. The ACL Assignment filter form provides a multi-select limited to the supported assignment target models.

## Contrast to Current Behavior

Previously, assignments could be filtered by a specific device, interface, virtual chassis, or virtual machine, but not by the type of their assigned object.

This change makes it possible to find broader groups such as all interface assignments, all host assignments, or all assignments targeting virtual machines.

## Discussion: Benefits and Drawbacks

This makes inventory and auditing queries available consistently through the UI, REST API, and saved filters.

The change is additive, does not alter existing filter behavior, and requires no database migration. Rendering the filter form requires one additional query to load the available object type choices.

## Changes to the Documentation

No standalone documentation changes are required. The new options are exposed through the existing ACL Assignment filter interfaces and follow the established NetBox filter naming conventions.

## Proposed Release Note Entry

Add filtering of ACL assignments by assigned object type.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets `feature` (next minor release).