### PR TITLE
Closes #393: Add multi-value support for choice-based ACL filters

### DIFF
--- a/netbox_acls/filtersets.py
+++ b/netbox_acls/filtersets.py
@@ -23,7 +23,14 @@ from utilities.filters import (
 from utilities.filtersets import register_filterset
 from virtualization.models import VirtualMachine, VMInterface
 
-from .choices import ACLTypeChoices
+from .choices import (
+    ACLActionChoices,
+    ACLAssignmentDirectionChoices,
+    ACLFamilyChoices,
+    ACLProtocolChoices,
+    ACLRuleActionChoices,
+    ACLTypeChoices,
+)
 from .constants import ACL_ASSIGNMENT_SITE_TRAVERSAL_PATHS
 from .models import AccessList, ACLAssignment, ACLExtendedRule, ACLStandardRule
 
@@ -40,6 +47,19 @@ class AccessListFilterSet(PrimaryModelFilterSet):
     """
     Define the filter set for the django model AccessList.
     """
+
+    type = django_filters.MultipleChoiceFilter(
+        choices=ACLTypeChoices,
+        distinct=False,
+    )
+    family = django_filters.MultipleChoiceFilter(
+        choices=ACLFamilyChoices,
+        distinct=False,
+    )
+    default_action = django_filters.MultipleChoiceFilter(
+        choices=ACLActionChoices,
+        distinct=False,
+    )
 
     class Meta:
         """
@@ -95,6 +115,16 @@ class ACLAssignmentFilterSet(OwnerFilterMixin, NetBoxModelFilterSet):
         queryset=ContentType.objects.all(),
         distinct=False,
         label=_("Assigned Object Type (ID)"),
+    )
+
+    # Assignment
+    family = django_filters.MultipleChoiceFilter(
+        choices=ACLFamilyChoices,
+        distinct=False,
+    )
+    direction = django_filters.MultipleChoiceFilter(
+        choices=ACLAssignmentDirectionChoices,
+        distinct=False,
     )
 
     # Organization
@@ -331,6 +361,12 @@ class ACLRuleFilterSetMixin(django_filters.FilterSet):
         label=_("Access List (ID)"),
     )
 
+    # Rule
+    action = django_filters.MultipleChoiceFilter(
+        choices=ACLRuleActionChoices,
+        distinct=False,
+    )
+
     # Logging
     log_options = MultiValueCharFilter(
         method="filter_log_options",
@@ -457,6 +493,12 @@ class ACLExtendedRuleFilterSet(ACLRuleFilterSetMixin, PrimaryModelFilterSet):
         queryset=AccessList.objects.filter(type=ACLTypeChoices.TYPE_EXTENDED),
         to_field_name="id",
         label=_("Access List (ID)"),
+    )
+
+    # Rule
+    protocol = django_filters.MultipleChoiceFilter(
+        choices=ACLProtocolChoices,
+        distinct=False,
     )
 
     # Source

--- a/netbox_acls/forms/filtersets.py
+++ b/netbox_acls/forms/filtersets.py
@@ -18,7 +18,6 @@ from utilities.forms.fields import (
     TagFilterField,
 )
 from utilities.forms.rendering import FieldSet
-from utilities.forms.utils import add_blank_choice
 from virtualization.models import VirtualMachine, VMInterface
 
 from ..choices import (
@@ -73,18 +72,18 @@ class AccessListFilterForm(PrimaryModelFilterSetForm):
     )
 
     # ACL selector
-    type = forms.ChoiceField(
-        choices=add_blank_choice(ACLTypeChoices),
+    type = forms.MultipleChoiceField(
+        choices=ACLTypeChoices,
         required=False,
         label=_("Type"),
     )
-    family = forms.ChoiceField(
-        choices=add_blank_choice(ACLFamilyChoices),
+    family = forms.MultipleChoiceField(
+        choices=ACLFamilyChoices,
         required=False,
         label=_("Family"),
     )
-    default_action = forms.ChoiceField(
-        choices=add_blank_choice(ACLActionChoices),
+    default_action = forms.MultipleChoiceField(
+        choices=ACLActionChoices,
         required=False,
         label=_("Default Action"),
     )
@@ -147,13 +146,13 @@ class ACLAssignmentFilterForm(OwnerFilterMixin, NetBoxModelFilterSetForm):
         required=False,
         label=_("Assigned Object Type"),
     )
-    family = forms.ChoiceField(
-        choices=add_blank_choice(ACLFamilyChoices),
+    family = forms.MultipleChoiceField(
+        choices=ACLFamilyChoices,
         required=False,
         label=_("Family"),
     )
-    direction = forms.ChoiceField(
-        choices=add_blank_choice(ACLAssignmentDirectionChoices),
+    direction = forms.MultipleChoiceField(
+        choices=ACLAssignmentDirectionChoices,
         required=False,
         label=_("Direction"),
     )
@@ -235,8 +234,8 @@ class ACLRuleFilterFormMixin(forms.Form):
         required=False,
         label=_("Sequence"),
     )
-    action = forms.ChoiceField(
-        choices=add_blank_choice(ACLRuleActionChoices),
+    action = forms.MultipleChoiceField(
+        choices=ACLRuleActionChoices,
         required=False,
         label=_("Action"),
     )
@@ -387,8 +386,8 @@ class ACLExtendedRuleFilterForm(ACLRuleFilterFormMixin, PrimaryModelFilterSetFor
         required=False,
         label=_("Access List"),
     )
-    protocol = forms.ChoiceField(
-        choices=add_blank_choice(ACLProtocolChoices),
+    protocol = forms.MultipleChoiceField(
+        choices=ACLProtocolChoices,
         required=False,
         label=_("Protocol"),
     )

--- a/netbox_acls/tests/api/test_access_list_rules.py
+++ b/netbox_acls/tests/api/test_access_list_rules.py
@@ -335,6 +335,18 @@ class ACLStandardRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
                 ],
             )
 
+    def test_filter_accepts_repeated_action_parameters(self):
+        """Repeated parameters must reach the filter set and be ORed, not overwrite each other."""
+        self.add_permissions("netbox_acls.view_aclstandardrule")
+        url = (
+            f"{self._get_list_url()}"
+            f"?action={ACLRuleActionChoices.ACTION_PERMIT}"
+            f"&action={ACLRuleActionChoices.ACTION_DENY}"
+        )
+        response = self.client.get(url, **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+
 
 class ACLExtendedRuleAPIViewTestCase(APIViewTestCases.APIViewTestCase):
     """

--- a/netbox_acls/tests/filtersets/test_accesslists.py
+++ b/netbox_acls/tests/filtersets/test_accesslists.py
@@ -74,24 +74,37 @@ class AccessListFilterSetTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
         params = {"comments__ic": "managed by"}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
-    # type, family and default_action are single-valued ChoiceFilters, matching the
-    # single-select widgets in AccessListFilterForm. Passing a list silently matches
-    # everything, so these must be asserted one value at a time.
+    # Assert errors too: an invalid value is dropped rather than applied, so a count that
+    # equals the whole fixture would pass for the wrong reason.
 
     def test_type(self):
-        params = {"type": ACLTypeChoices.TYPE_EXTENDED}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-        params = {"type": ACLTypeChoices.TYPE_STANDARD}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        filterset = self.filterset({"type": [ACLTypeChoices.TYPE_EXTENDED]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 2)
+        params = {"type": [ACLTypeChoices.TYPE_STANDARD, ACLTypeChoices.TYPE_EXTENDED]}
+        filterset = self.filterset(params, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 3)
 
     def test_family(self):
-        params = {"family": ACLFamilyChoices.FAMILY_IPV4}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
-        params = {"family": ACLFamilyChoices.FAMILY_DUAL}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        filterset = self.filterset({"family": [ACLFamilyChoices.FAMILY_IPV4]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 1)
+        params = {"family": [ACLFamilyChoices.FAMILY_IPV4, ACLFamilyChoices.FAMILY_IPV6]}
+        filterset = self.filterset(params, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 2)
 
     def test_default_action(self):
-        params = {"default_action": ACLActionChoices.ACTION_DENY}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
-        params = {"default_action": ACLActionChoices.ACTION_PERMIT}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        filterset = self.filterset({"default_action": [ACLActionChoices.ACTION_DENY]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 1)
+        params = {"default_action": [ACLActionChoices.ACTION_DENY, ACLActionChoices.ACTION_PERMIT]}
+        filterset = self.filterset(params, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 2)
+
+    def test_choice_filters_reject_an_unknown_value(self):
+        """An unknown value must fail validation rather than widen the result set."""
+        filterset = self.filterset({"type": ["sideways"]}, self.queryset)
+        self.assertIn("type", filterset.errors)

--- a/netbox_acls/tests/filtersets/test_aclassignments.py
+++ b/netbox_acls/tests/filtersets/test_aclassignments.py
@@ -410,16 +410,29 @@ class ACLAssignmentFilterSetTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
             with self.subTest(params=params):
                 self.assertEqual(self.filterset(params, self.queryset).qs.count(), 0)
 
-    # direction and family are single-valued ChoiceFilters, so assert one value at a time.
+    # Assert errors too: family covers the whole fixture, so the count alone would pass
+    # even if nothing were applied.
 
     def test_direction(self):
-        params = {"direction": ACLAssignmentDirectionChoices.DIRECTION_EGRESS}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-        params = {"direction": ACLAssignmentDirectionChoices.DIRECTION_INGRESS}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"direction": [ACLAssignmentDirectionChoices.DIRECTION_EGRESS]}
+        filterset = self.filterset(params, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 2)
+        params = {
+            "direction": [
+                ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+                ACLAssignmentDirectionChoices.DIRECTION_EGRESS,
+            ],
+        }
+        filterset = self.filterset(params, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 3)
 
     def test_family(self):
-        params = {"family": ACLFamilyChoices.FAMILY_IPV4}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
-        params = {"family": ACLFamilyChoices.FAMILY_IPV6}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        filterset = self.filterset({"family": [ACLFamilyChoices.FAMILY_IPV4]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 4)
+        params = {"family": [ACLFamilyChoices.FAMILY_IPV4, ACLFamilyChoices.FAMILY_IPV6]}
+        filterset = self.filterset(params, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 6)

--- a/netbox_acls/tests/filtersets/test_extendedrules.py
+++ b/netbox_acls/tests/filtersets/test_extendedrules.py
@@ -265,19 +265,31 @@ class ACLExtendedRuleFilterSetTestCase(TestCase, ChangeLoggedFilterSetTestMixin)
         params = {"destination_port": 81}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 0)
 
-    # action and protocol are single-valued ChoiceFilters, so assert one value at a time.
-
     def test_action(self):
-        params = {"action": ACLRuleActionChoices.ACTION_PERMIT}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-        params = {"action": ACLRuleActionChoices.ACTION_DENY}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {"action": [ACLRuleActionChoices.ACTION_PERMIT]}
+        filterset = self.filterset(params, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 2)
+        params = {"action": [ACLRuleActionChoices.ACTION_PERMIT, ACLRuleActionChoices.ACTION_DENY]}
+        filterset = self.filterset(params, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 4)
 
     def test_protocol(self):
-        params = {"protocol": ACLProtocolChoices.PROTOCOL_TCP}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
-        params = {"protocol": ACLProtocolChoices.PROTOCOL_UDP}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"protocol": [ACLProtocolChoices.PROTOCOL_TCP]}
+        filterset = self.filterset(params, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 1)
+        params = {"protocol": [ACLProtocolChoices.PROTOCOL_TCP, ACLProtocolChoices.PROTOCOL_UDP]}
+        filterset = self.filterset(params, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 2)
+
+    def test_protocol_accepts_a_grouped_value(self):
+        """ACLProtocolChoices is optgrouped, so the flattened values must still validate."""
+        filterset = self.filterset({"protocol": [ACLProtocolChoices.PROTOCOL_GRE]}, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 0)
 
     def test_log_matches(self):
         params = {"log_matches": True}

--- a/netbox_acls/tests/filtersets/test_standardrules.py
+++ b/netbox_acls/tests/filtersets/test_standardrules.py
@@ -185,13 +185,15 @@ class ACLStandardRuleFilterSetTestCase(TestCase, ChangeLoggedFilterSetTestMixin)
         params = {"comments": "reviewed quarterly"}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
-    # action is a single-valued ChoiceFilter, so assert one value at a time.
-
     def test_action(self):
-        params = {"action": ACLRuleActionChoices.ACTION_PERMIT}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-        params = {"action": ACLRuleActionChoices.ACTION_REMARK}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"action": [ACLRuleActionChoices.ACTION_PERMIT]}
+        filterset = self.filterset(params, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 2)
+        params = {"action": [ACLRuleActionChoices.ACTION_PERMIT, ACLRuleActionChoices.ACTION_DENY]}
+        filterset = self.filterset(params, self.queryset)
+        self.assertEqual(filterset.errors, {})
+        self.assertEqual(filterset.qs.count(), 4)
 
     def test_log_matches(self):
         params = {"log_matches": True}

--- a/netbox_acls/tests/forms/test_accesslists.py
+++ b/netbox_acls/tests/forms/test_accesslists.py
@@ -1,7 +1,8 @@
+from django import forms
 from django.test import TestCase
 
 from ...choices import ACLActionChoices, ACLFamilyChoices, ACLRuleActionChoices, ACLTypeChoices
-from ...forms import AccessListBulkEditForm, AccessListForm
+from ...forms import AccessListBulkEditForm, AccessListFilterForm, AccessListForm
 from ...models import AccessList, ACLStandardRule
 from .base import BulkEditFieldsetTestMixin
 
@@ -65,3 +66,10 @@ class AccessListFormTestCase(BulkEditFieldsetTestMixin, TestCase):
         )
         self.assertFalse(form.is_valid())
         self.assertIn("family", form.errors)
+
+    def test_choice_filters_accept_multiple_values(self):
+        """The filter form's choice fields must be multi-selects, matching the filter set."""
+        form = AccessListFilterForm()
+        for field_name in ("type", "family", "default_action"):
+            with self.subTest(field_name=field_name):
+                self.assertIsInstance(form.fields[field_name], forms.MultipleChoiceField)

--- a/netbox_acls/tests/forms/test_aclassignments.py
+++ b/netbox_acls/tests/forms/test_aclassignments.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
@@ -183,3 +184,10 @@ class ACLAssignmentFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetTes
         )
         self.assertIs(form.fields["assigned_object"].selected_model, Device)
         self.assertTrue(form.fields["direction"].disabled)
+
+    def test_choice_filters_accept_multiple_values(self):
+        """The filter form's choice fields must be multi-selects, matching the filter set."""
+        form = ACLAssignmentFilterForm()
+        for field_name in ("family", "direction"):
+            with self.subTest(field_name=field_name):
+                self.assertIsInstance(form.fields[field_name], forms.MultipleChoiceField)

--- a/netbox_acls/tests/forms/test_extendedrules.py
+++ b/netbox_acls/tests/forms/test_extendedrules.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from netaddr import IPNetwork
@@ -212,11 +213,18 @@ class ACLExtendedRuleFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetT
             {"type": ACLTypeChoices.TYPE_EXTENDED},
         )
 
+    def test_choice_filters_accept_multiple_values(self):
+        """The filter form's choice fields must be multi-selects, matching the filter set."""
+        form = ACLExtendedRuleFilterForm()
+        for field_name in ("action", "protocol"):
+            with self.subTest(field_name=field_name):
+                self.assertIsInstance(form.fields[field_name], forms.MultipleChoiceField)
+
     def test_protocol_filter_form_accepts_a_grouped_value(self):
-        """add_blank_choice concatenates tuples, so the optgroups must survive into the field."""
-        form = ACLExtendedRuleFilterForm(data={"protocol": ACLProtocolChoices.PROTOCOL_GRE})
+        """ACLProtocolChoices is optgrouped, so the groups must survive into the field."""
+        form = ACLExtendedRuleFilterForm(data={"protocol": [ACLProtocolChoices.PROTOCOL_GRE]})
         self.assertTrue(form.is_valid(), form.errors)
-        self.assertEqual(form.cleaned_data["protocol"], ACLProtocolChoices.PROTOCOL_GRE)
+        self.assertEqual(form.cleaned_data["protocol"], [ACLProtocolChoices.PROTOCOL_GRE])
 
     def test_logging_fields_are_present(self):
         """Test that the model form exposes both logging fields."""

--- a/netbox_acls/tests/forms/test_standardrules.py
+++ b/netbox_acls/tests/forms/test_standardrules.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
@@ -257,3 +258,8 @@ class ACLStandardRuleFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetT
         )
         self.assertFalse(form.is_valid())
         self.assertIn("log_options", form.errors)
+
+    def test_choice_filters_accept_multiple_values(self):
+        """The filter form's action field must be a multi-select, matching the filter set."""
+        form = ACLStandardRuleFilterForm()
+        self.assertIsInstance(form.fields["action"], forms.MultipleChoiceField)


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #393

## New Behavior

Choice-based filters now support selecting multiple values across Access Lists, ACL Assignments, Standard Rules, and Extended Rules.

The corresponding filter forms use multi-select fields, and the test coverage has been updated to verify multi-value filtering and validation behavior.

## Contrast to Current Behavior

Previously, these filters accepted only a single value at a time. Multiple selected values are now combined using OR logic, while existing single-value filtering continues to work unchanged.

## Discussion: Benefits and Drawbacks

This makes the filtering experience more flexible and consistent with other NetBox filters, particularly when users need to view objects matching several types, families, actions, directions, or protocols.

The change is backwards-compatible because existing single-value query parameters remain supported. The main UI difference is that the affected fields are now rendered as multi-select controls.

## Changes to the Documentation

No documentation changes are required. The available filter values and their meaning remain unchanged.

## Proposed Release Note Entry

Added support for selecting multiple values in choice-based ACL filters.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets `feature` (next minor release).
