### PR TITLE
Closes #422: Remove deprecated type arguments from `StrFilterLookup` annotations

### DIFF
--- a/netbox_acls/graphql/filters/access_list_rules.py
+++ b/netbox_acls/graphql/filters/access_list_rules.py
@@ -45,7 +45,7 @@ class ACLRuleFilterMixin(PrimaryModelFilter):
     )
 
     # Remark
-    remark: StrFilterLookup[str] | None = strawberry_django.filter_field()
+    remark: StrFilterLookup | None = strawberry_django.filter_field()
 
     # Source
     source_type: Annotated["ContentTypeFilter", strawberry.lazy("core.graphql.filters")] | None = (

--- a/netbox_acls/graphql/filters/access_lists.py
+++ b/netbox_acls/graphql/filters/access_lists.py
@@ -31,7 +31,7 @@ class AccessListFilter(PrimaryModelFilter):
     GraphQL filter definition for the AccessList model.
     """
 
-    name: StrFilterLookup[str] | None = strawberry_django.filter_field()
+    name: StrFilterLookup | None = strawberry_django.filter_field()
     type: BaseFilterLookup[Annotated["ACLTypeEnum", strawberry.lazy("netbox_acls.graphql.enums")]] | None = (
         strawberry_django.filter_field()
     )
@@ -63,4 +63,4 @@ class ACLAssignmentFilter(NetBoxModelFilter):
     family: BaseFilterLookup[Annotated["ACLFamilyEnum", strawberry.lazy("netbox_acls.graphql.enums")]] | None = (
         strawberry_django.filter_field()
     )
-    comments: StrFilterLookup[str] | None = strawberry_django.filter_field()
+    comments: StrFilterLookup | None = strawberry_django.filter_field()


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #422

## New Behavior

Removes the ignored `str` type argument from the three `StrFilterLookup` annotations used by the GraphQL filters.

This also prevents strawberry-django from emitting deprecation warnings for these annotations.

## Contrast to Current Behavior

The affected fields currently use `StrFilterLookup[str]`. However, `StrFilterLookup` is already specialized for strings, so strawberry-django ignores the supplied type argument and warns that this usage is deprecated.

The fields now use the bare `StrFilterLookup` class instead. The generated GraphQL schema remains byte-identical.

## Discussion: Benefits and Drawbacks

This change aligns the plugin with the current strawberry-django API and removes deprecated, ineffective type arguments. It also avoids a potential future compatibility issue if the deprecation becomes an error.

There are no known drawbacks or behavioral changes. The change is backwards-compatible with the NetBox 4.7 compatibility floor targeted by v2.1.0.

## Changes to the Documentation

No documentation changes are required because this is an internal annotation cleanup with no user-facing behavior change.

## Proposed Release Note Entry

Removed deprecated type arguments from GraphQL `StrFilterLookup` annotations.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets `feature` (next minor release).