### PR TITLE
Fixes #417: Fix missing Description filter for Access Lists

### DIFF
--- a/netbox_acls/forms/filtersets.py
+++ b/netbox_acls/forms/filtersets.py
@@ -87,6 +87,10 @@ class AccessListFilterForm(PrimaryModelFilterSetForm):
         required=False,
         label=_("Default Action"),
     )
+    description = forms.CharField(
+        required=False,
+        label=_("Description"),
+    )
 
     # Tag selector
     tag = TagFilterField(model)

--- a/netbox_acls/tests/forms/test_accesslists.py
+++ b/netbox_acls/tests/forms/test_accesslists.py
@@ -4,13 +4,14 @@ from django.test import TestCase
 from ...choices import ACLActionChoices, ACLFamilyChoices, ACLRuleActionChoices, ACLTypeChoices
 from ...forms import AccessListBulkEditForm, AccessListFilterForm, AccessListForm
 from ...models import AccessList, ACLStandardRule
-from .base import BulkEditFieldsetTestMixin
+from .base import BulkEditFieldsetTestMixin, FilterFormFieldsetTestMixin
 
 
-class AccessListFormTestCase(BulkEditFieldsetTestMixin, TestCase):
+class AccessListFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetTestMixin, TestCase):
     """Form tests for AccessList forms."""
 
     bulk_edit_form = AccessListBulkEditForm
+    filter_form = AccessListFilterForm
 
     @classmethod
     def setUpTestData(cls):
@@ -73,3 +74,12 @@ class AccessListFormTestCase(BulkEditFieldsetTestMixin, TestCase):
         for field_name in ("type", "family", "default_action"):
             with self.subTest(field_name=field_name):
                 self.assertIsInstance(form.fields[field_name], forms.MultipleChoiceField)
+
+    def test_description_filter_available(self):
+        """The Description filter needs both a field and a fieldset entry, or it never renders."""
+        form = AccessListFilterForm()
+        self.assertIn("description", form.fields)
+        self.assertIsInstance(form.fields["description"], forms.CharField)
+        self.assertFalse(form.fields["description"].required)
+        named = {item for fieldset in form.fieldsets for item in fieldset.items if isinstance(item, str)}
+        self.assertIn("description", named)


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #417

## New Behavior

Adds the missing **Description** field to the Access List filter form, making the existing description filter available through the UI.

The Access List form tests now also use `FilterFormFieldsetTestMixin` to verify that every field referenced by a fieldset is declared on the form.

## Contrast to Current Behavior

Previously, `description` was listed in the **ACL Details** fieldset without a corresponding form field. NetBox therefore omitted it silently, leaving the filter inaccessible from the UI.

## Discussion: Benefits and Drawbacks

This restores the expected Description filter and adds the same regression protection already used by the other filter form test cases.

The change is backwards-compatible and has no known drawbacks.

## Changes to the Documentation

No documentation changes are required.

## Proposed Release Note Entry

Fix missing Description field in the Access List filter form.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets `feature` (next minor release).
