### PR TITLE
Fixes #428: Prevent interface ACL Assignments from using the `none` direction

### DIFF
--- a/netbox_acls/forms/bulk_import.py
+++ b/netbox_acls/forms/bulk_import.py
@@ -261,7 +261,10 @@ class ACLAssignmentImportForm(ObjectImportMixin, OwnerCSVMixin, NetBoxModelImpor
     direction = CSVChoiceField(
         label=_("Direction"),
         choices=ACLAssignmentDirectionChoices,
-        help_text=_("Device, virtual chassis and virtual machine assignments are always stored as none."),
+        help_text=_(
+            "Device, virtual chassis and virtual machine assignments are always stored as none. "
+            "Interface assignments require ingress or egress."
+        ),
     )
 
     object_roles = ("assigned_object",)

--- a/netbox_acls/models/access_lists.py
+++ b/netbox_acls/models/access_lists.py
@@ -377,6 +377,16 @@ class ACLAssignment(OwnerMixin, NetBoxModel):
         """
         return f"{self.access_list}: Object {self.assigned_object}"
 
+    @property
+    def _is_host_assignment(self) -> bool:
+        """
+        Returns whether the assigned object type carries no directional semantics.
+        """
+        host_assigned_object_type_ids = {
+            ContentType.objects.get_for_model(model).pk for model in (Device, VirtualChassis, VirtualMachine)
+        }
+        return self.assigned_object_type_id in host_assigned_object_type_ids
+
     def clean(self) -> None:
         """
         Override the model's clean method for custom validation.
@@ -402,14 +412,24 @@ class ACLAssignment(OwnerMixin, NetBoxModel):
             self.family = self.access_list.family
 
         # Host types carry no directional semantics, so direction is forced to "none".
-        host_assigned_object_type_ids = {
-            ContentType.objects.get_for_model(model).pk for model in (Device, VirtualChassis, VirtualMachine)
-        }
-        if self.assigned_object_type_id in host_assigned_object_type_ids:
+        if self._is_host_assignment:
             self.direction = ACLAssignmentDirectionChoices.DIRECTION_NONE
             self._validate_unique_acl_name_per_assigned_object()
-        elif self.assigned_object_type_id and self.access_list_id:
-            self._validate_unique_acl_assignment_per_assigned_interface()
+        elif self.assigned_object_type_id:
+            self._validate_interface_direction()
+            if self.access_list_id:
+                self._validate_unique_acl_assignment_per_assigned_interface()
+
+    def _validate_interface_direction(self) -> None:
+        """
+        Validates that an interface assignment carries a real direction.
+        """
+        if self.direction == ACLAssignmentDirectionChoices.DIRECTION_NONE:
+            raise ValidationError(
+                {
+                    "direction": _("Interface assignments require an ingress or egress direction."),
+                },
+            )
 
     def _validate_unique_acl_name_per_assigned_object(self) -> None:
         """
@@ -479,19 +499,6 @@ class ACLAssignment(OwnerMixin, NetBoxModel):
         """
         self.family = self.access_list.family
 
-        host_assigned_object_types = [
-            ContentType.objects.get_for_model(Device),
-            ContentType.objects.get_for_model(VirtualChassis),
-            ContentType.objects.get_for_model(VirtualMachine),
-        ]
-
-        # If the assigned object is a host type (device, virtual chassis,
-        # or virtual machine), directional semantics (ingress/egress) are
-        # not applicable.
-        # Therefore, the direction field is set to "none" in these cases.
-        if self.assigned_object_type in host_assigned_object_types:
-            self.direction = ACLAssignmentDirectionChoices.DIRECTION_NONE
-
         # family is a denormalized copy of access_list.family, so persist them together.
         # direction is derived only for host targets, so it is never promoted here.
         update_fields = kwargs.get("update_fields")
@@ -500,6 +507,12 @@ class ACLAssignment(OwnerMixin, NetBoxModel):
             if update_fields & {"access_list", "access_list_id"}:
                 update_fields |= {"family"}
             kwargs["update_fields"] = update_fields
+
+        # Host types carry no directional semantics, so direction is forced to "none".
+        if self._is_host_assignment:
+            self.direction = ACLAssignmentDirectionChoices.DIRECTION_NONE
+        elif self.assigned_object_type_id and (update_fields is None or "direction" in update_fields):
+            self._validate_interface_direction()
 
         super().save(*args, **kwargs)
 

--- a/netbox_acls/tests/api/test_access_lists.py
+++ b/netbox_acls/tests/api/test_access_lists.py
@@ -277,3 +277,34 @@ class ACLAssignmentAPIViewTestCase(APIViewTestCases.APIViewTestCase):
         cls.bulk_update_invalid_data = {
             "direction": "sideways",
         }
+
+    def test_interface_assignment_rejects_direction_none(self):
+        """
+        The GUI's narrowed choices never reach the API, so the model rule is the only guard here.
+        """
+        self.add_permissions("netbox_acls.add_aclassignment")
+        access_list = AccessList.objects.get(name="testacl1")
+
+        for assigned_object in (
+            Interface.objects.get(name="DeviceInterface3"),
+            VMInterface.objects.get(name="eth2"),
+        ):
+            with self.subTest(assigned_object_type=assigned_object._meta.label_lower):
+                response = self.client.post(
+                    self._get_list_url(),
+                    {
+                        "access_list": access_list.pk,
+                        "assigned_object_type": assigned_object._meta.label_lower,
+                        "assigned_object_id": assigned_object.pk,
+                        "direction": ACLAssignmentDirectionChoices.DIRECTION_NONE,
+                    },
+                    format="json",
+                    **self.header,
+                )
+
+                self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+                self.assertEqual(list(response.data), ["direction"])
+                self.assertEqual(
+                    response.data["direction"],
+                    ["Interface assignments require an ingress or egress direction."],
+                )

--- a/netbox_acls/tests/forms/test_aclassignments.py
+++ b/netbox_acls/tests/forms/test_aclassignments.py
@@ -9,6 +9,7 @@ from virtualization.models import Cluster, ClusterType, VirtualMachine, VMInterf
 from ...choices import (
     ACLActionChoices,
     ACLAssignmentDirectionChoices,
+    ACLAssignmentDirectionUIChoices,
     ACLFamilyChoices,
     ACLTypeChoices,
 )
@@ -113,6 +114,17 @@ class ACLAssignmentFormTestCase(BulkEditFieldsetTestMixin, FilterFormFieldsetTes
                 form = self._bound_form(model, obj)
                 self.assertFalse(form.fields["direction"].disabled)
                 self.assertTrue(form.fields["direction"].required)
+
+    def test_ui_direction_choices_mirror_the_model_set(self):
+        """Test the narrowed GUI choices stay the model set without the host-only value."""
+        self.assertEqual(
+            set(ACLAssignmentDirectionUIChoices),
+            {
+                choice
+                for choice in ACLAssignmentDirectionChoices
+                if choice[0] != ACLAssignmentDirectionChoices.DIRECTION_NONE
+            },
+        )
 
     def test_direction_disabled_for_host_types(self):
         """Test that the direction is disabled for host assignments."""
@@ -419,6 +431,21 @@ class ACLAssignmentImportFormTestCase(TestCase):
         form = self._form(direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS)
         self.assertTrue(form.is_valid(), form.errors)
         self.assertEqual(form.save().direction, ACLAssignmentDirectionChoices.DIRECTION_NONE)
+
+    def test_interface_row_with_direction_none_is_rejected(self):
+        """Test that the model's interface direction rule fires through the import form."""
+        form = self._form(
+            assigned_object_type="dcim.interface",
+            assigned_object=self.spare.name,
+            assigned_object_parent=self.device1.name,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertEqual(set(form.errors), {"direction"})
+        self.assertEqual(
+            list(form.errors["direction"]),
+            ["Interface assignments require an ingress or egress direction."],
+        )
 
     def test_update_without_object_columns_keeps_the_target(self):
         """Test that an update omitting every object column preserves the stored target."""

--- a/netbox_acls/tests/models/test_aclassignments.py
+++ b/netbox_acls/tests/models/test_aclassignments.py
@@ -1,3 +1,4 @@
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 
 from dcim.models import Device, Interface, VirtualChassis
@@ -182,6 +183,110 @@ class TestACLAssignment(BaseTestCase):
         self.assertEqual(isinstance(virtual_machine_interface_assignment.assigned_object, VMInterface), True)
         self.assertEqual(virtual_machine_interface_assignment.assigned_object, self.vm_interface1)
         self.assertEqual(virtual_machine_interface_assignment.direction, "ingress")
+
+    def test_interface_assignment_rejects_direction_none(self):
+        """
+        Test that an interface assignment cannot store a direction of "none".
+        """
+        for assigned_object in (self.device_interface1, self.vm_interface1):
+            with self.subTest(assigned_object=assigned_object._meta.label_lower):
+                assignment = ACLAssignment(
+                    access_list=self.acl_standard1,
+                    direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+                    assigned_object=assigned_object,
+                )
+
+                with self.assertRaises(ValidationError) as context:
+                    assignment.full_clean()
+
+                self.assertEqual(
+                    context.exception.message_dict,
+                    {"direction": ["Interface assignments require an ingress or egress direction."]},
+                )
+
+    def test_interface_assignment_rejects_direction_none_on_save(self):
+        """
+        Test that the direction guard also fires for a caller skipping full_clean().
+        """
+        assignment = ACLAssignment(
+            access_list=self.acl_standard1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+            assigned_object=self.device_interface1,
+        )
+
+        with self.assertRaises(ValidationError):
+            assignment.save()
+
+        self.assertIsNone(assignment.pk)
+
+    def test_partial_save_excluding_direction_skips_the_interface_guard(self):
+        """
+        Test that a comments-only save is not rejected for an unwritten direction.
+        """
+        assignment = ACLAssignment.objects.create(
+            access_list=self.acl_standard1,
+            assigned_object=self.device_interface1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+
+        assignment.direction = ACLAssignmentDirectionChoices.DIRECTION_NONE
+        assignment.comments = "Updated"
+        assignment.save(update_fields={"comments"})
+
+        assignment.refresh_from_db()
+        self.assertEqual(assignment.direction, ACLAssignmentDirectionChoices.DIRECTION_INGRESS)
+
+    def test_partial_save_naming_direction_still_hits_the_interface_guard(self):
+        """
+        Test that a partial save writing the direction is validated.
+        """
+        assignment = ACLAssignment.objects.create(
+            access_list=self.acl_standard1,
+            assigned_object=self.device_interface1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+        )
+
+        assignment.direction = ACLAssignmentDirectionChoices.DIRECTION_NONE
+        with self.assertRaises(ValidationError):
+            assignment.save(update_fields={"direction"})
+
+        assignment.refresh_from_db()
+        self.assertEqual(assignment.direction, ACLAssignmentDirectionChoices.DIRECTION_INGRESS)
+
+    def test_a_stored_interface_row_with_direction_none_fails_revalidation(self):
+        """
+        Test that a row predating the guard is rejected on its next validated write.
+        """
+        ACLAssignment.objects.bulk_create(
+            [
+                ACLAssignment(
+                    access_list=self.acl_standard1,
+                    assigned_object_type=ContentType.objects.get_for_model(Interface),
+                    assigned_object_id=self.device_interface1.pk,
+                    direction=ACLAssignmentDirectionChoices.DIRECTION_NONE,
+                    family=self.acl_standard1.family,
+                ),
+            ],
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            ACLAssignment.objects.get().full_clean()
+
+        self.assertIn("direction", context.exception.message_dict)
+
+    def test_host_assignment_normalizes_a_direction_on_save(self):
+        """
+        Test that a host assignment saved with a direction still stores "none".
+        """
+        assignment = ACLAssignment(
+            access_list=self.acl_standard1,
+            direction=ACLAssignmentDirectionChoices.DIRECTION_INGRESS,
+            assigned_object=self.device1,
+        )
+        assignment.save()
+        assignment.refresh_from_db()
+
+        self.assertEqual(assignment.direction, ACLAssignmentDirectionChoices.DIRECTION_NONE)
 
     def test_acl_assignment_with_duplicate_name_per_device_fail(self):
         """


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes #428

## New Behavior

Interface and VM Interface ACL Assignments now require an ingress or egress direction.

Model validation rejects `direction="none"` for interface targets in both `clean()` and the normal `save()` path. Assignments to Devices, Virtual Chassis, and Virtual Machines continue to normalize their direction to `none`.

The change also adds regression coverage for model validation, REST API requests, and bulk imports.

## Contrast to Current Behavior

Previously, `direction="none"` could be stored for an Interface or VM Interface through write paths that did not use the GUI form. This produced assignments that displayed an inapplicable direction and could not be saved unchanged through the GUI.

The model now enforces the same direction requirements already presented by the interface assignment forms.

## Discussion: Benefits and Drawbacks

This keeps ACL Assignment validation consistent across the GUI, API, bulk import, and direct model usage, and prevents interface assignments from entering an invalid state.

The change is backwards-compatible for valid assignments. Existing interface assignments stored with `direction="none"` will need to be corrected to ingress or egress before they can be saved again.

## Changes to the Documentation

No documentation changes are required. This aligns model validation with the behavior already exposed by the GUI.

## Proposed Release Note Entry

Prevent interface ACL Assignments from using the `none` direction.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets `feature` (next minor release).
