### PR TITLE
Release v2.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,14 +21,14 @@ body:
     attributes:
       label: NetBox ACLs Plugin version
       description: What version of NetBox ACLs are you currently running?
-      placeholder: v2.0.3
+      placeholder: v2.1.0
     validations:
       required: true
   - type: input
     attributes:
       label: NetBox version
       description: What version of NetBox are you currently running?
-      placeholder: v4.5.0
+      placeholder: v4.7.0
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -17,14 +17,14 @@ body:
     attributes:
       label: NetBox ACLs Plugin version
       description: What version of NetBox ACLs are you currently running?
-      placeholder: v2.0.3
+      placeholder: v2.1.0
     validations:
       required: true
   - type: input
     attributes:
       label: NetBox version
       description: What version of NetBox are you currently running?
-      placeholder: v4.5.0
+      placeholder: v4.7.0
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
-          version: "0.16.3"
+          version: "0.16.5"
           args: "check --output-format=github"
           src: "netbox_acls/"
 
@@ -33,7 +33,7 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
-          version: "0.16.3"
+          version: "0.16.5"
           args: "format --check --diff"
           src: "netbox_acls/"
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         # yamllint disable-line rule:line-length
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in
@@ -62,7 +62,7 @@ jobs:
       # (see below).
       - name: Autobuild
         # yamllint disable-line rule:line-length
-        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See:
@@ -78,4 +78,4 @@ jobs:
 
       - name: Perform CodeQL Analysis
         # yamllint disable-line rule:line-length
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.16.3"
+    rev: "v0.16.5"
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NETBOX_VARIANT=v4.7.0-beta2
+ARG NETBOX_VARIANT=v4.7
 
 FROM netboxcommunity/netbox:${NETBOX_VARIANT}
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include README.md
-include LICENSE
+include LICENSE.txt
 recursive-include netbox_acls/templates *

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following table details the tested plugin versions for each NetBox version:
 
 |   NetBox Version    | Plugin Version |
 |:-------------------:|:--------------:|
+|        4.7.x        |     2.1.0      |
 |        4.6.x        |     2.0.3      |
 |        4.5.x        |     2.0.3      |
 |        4.4.x        |     1.9.1      |
@@ -65,7 +66,7 @@ for Docker setups, modify `/configuration/plugins.py`:
 
 ```python
 PLUGINS = [
-    "netbox_acls"
+    "netbox_acls",
 ]
 
 PLUGINS_CONFIG = {

--- a/netbox_acls/__init__.py
+++ b/netbox_acls/__init__.py
@@ -19,7 +19,7 @@ class NetBoxACLsConfig(PluginConfig):
     version = version("netbox-acls")
     description = "Manage Access Control Lists (ACL) in NetBox"
     base_url = "access-lists"
-    min_version = "4.7.0-beta2"
+    min_version = "4.7.0"
     max_version = "4.7.99"
     default_settings = {
         "rule_sequence_step": 10,

--- a/netbox_acls/navigation.py
+++ b/netbox_acls/navigation.py
@@ -24,6 +24,12 @@ accesslist_item = PluginMenuItem(
             icon_class="mdi mdi-plus-thick",
             permissions=["netbox_acls.add_accesslist"],
         ),
+        PluginMenuButton(
+            link="plugins:netbox_acls:accesslist_bulk_import",
+            title="Import",
+            icon_class="mdi mdi-upload",
+            permissions=["netbox_acls.add_accesslist"],
+        ),
     ),
 )
 
@@ -37,6 +43,12 @@ aclstandardrule_item = PluginMenuItem(
             link="plugins:netbox_acls:aclstandardrule_add",
             title="Add",
             icon_class="mdi mdi-plus-thick",
+            permissions=["netbox_acls.add_aclstandardrule"],
+        ),
+        PluginMenuButton(
+            link="plugins:netbox_acls:aclstandardrule_bulk_import",
+            title="Import",
+            icon_class="mdi mdi-upload",
             permissions=["netbox_acls.add_aclstandardrule"],
         ),
     ),
@@ -54,6 +66,12 @@ aclextendedrule_item = PluginMenuItem(
             icon_class="mdi mdi-plus-thick",
             permissions=["netbox_acls.add_aclextendedrule"],
         ),
+        PluginMenuButton(
+            link="plugins:netbox_acls:aclextendedrule_bulk_import",
+            title="Import",
+            icon_class="mdi mdi-upload",
+            permissions=["netbox_acls.add_aclextendedrule"],
+        ),
     ),
 )
 
@@ -67,6 +85,12 @@ aclassignment_item = PluginMenuItem(
             link="plugins:netbox_acls:aclassignment_add",
             title="Add",
             icon_class="mdi mdi-plus-thick",
+            permissions=["netbox_acls.add_aclassignment"],
+        ),
+        PluginMenuButton(
+            link="plugins:netbox_acls:aclassignment_bulk_import",
+            title="Import",
+            icon_class="mdi mdi-upload",
             permissions=["netbox_acls.add_aclassignment"],
         ),
     ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,16 @@ Issues = "https://github.com/netbox-community/netbox-acls/issues"
 Changelog = "https://github.com/netbox-community/netbox-acls/releases"
 
 [tool.setuptools]
-packages = ["netbox_acls"]
-package-data = {"netbox_acls" = ["**/*", "templates/**"]}
+include-package-data = false
+
+[tool.setuptools.packages.find]
+include = ["netbox_acls*"]
+exclude = ["netbox_acls.tests*"]
+namespaces = false
+
+[tool.setuptools.package-data]
+netbox_acls = [
+    "templates/**",
+    "static/**",
+    "locale/**/*.mo",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-acls"
-version = "2.0.3"
+version = "2.1.0"
 requires-python = ">=3.12.0"
 description = "NetBox plugin for managing Access Control Lists (ACLs)."
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,19 @@ description = "NetBox plugin for managing Access Control Lists (ACLs)."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "Apache-2.0"
 license-files = ["LICENSE.txt"]
-keywords = ["netbox", "netbox-plugin"]
+keywords = [
+    "netbox",
+    "netbox-plugin",
+    "access-lists",
+    "network-automation",
+    "source-of-truth",
+]
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Framework :: Django",
     "Framework :: Django :: 6.1",
     "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
     "Intended Audience :: System Administrators",
     "Natural Language :: English",
     "Operating System :: OS Independent",
@@ -28,8 +35,8 @@ classifiers=[
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Topic :: System :: Networking",
     "Topic :: Internet",
+    "Topic :: System :: Networking",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = [
     "check-manifest==0.51",
     "pre-commit==4.6.2",
     "pytest==9.1.1",
-    "ruff==0.16.3",
+    "ruff==0.16.5",
     "yamllint==1.38.0",
 ]
 


### PR DESCRIPTION
This release adds NetBox 4.7 support, per-rule logging, bulk import for all plugin objects, related ACL Rules on IPAM objects, and refreshed detail views.

### Compatibility

* NetBox 4.7.x

**Breaking:** NetBox 4.7.0 through 4.7.99 is required. NetBox 4.5.x and 4.6.x are no longer supported. Upgrade NetBox before upgrading the plugin.

### Added

* Added logging controls to Standard and Extended ACL Rules. Logging is not allowed on remark rules, and logging options require `log_matches` to be enabled. Options are stored in a consistent order and displayed as coloured badges. (#57)
* Added CSV, JSON, and YAML bulk import for Access Lists, ACL Assignments, Standard Rules, and Extended Rules. Related objects can be referenced by natural value where supported or by numeric ID. IP ranges require an ID. Interface names can be qualified by their parent object, and omitted fields keep their existing values during partial updates. (#390)
* Added Standard and Extended ACL Rule tabs to Aggregate, Prefix, IP Address, and IP Range views. Extended Rules show whether the object is used as a source, destination, or both. (#354)
* Added ACL relationships to NetBox core GraphQL types for assignment targets and referenced IPAM objects. (#391)
* Added GRE, EIGRP, OSPF, and PIM protocol choices for Extended ACL Rules. These protocols do not allow port configuration. (#352)
* Added filtering of ACL Assignments by assigned object type using `assigned_object_type` or `assigned_object_type_id`. (#392)

### Changed

* **Breaking:** Removed compatibility support for NetBox versions before 4.7 and updated the Django classifier from 5.2 to 6.1. (#391)
* Choice filters now accept multiple values across all four filtersets. Existing single-value queries remain supported. (#393)
* Rebuilt ACL detail views and Assignment controls using NetBox's declarative UI framework. This restores standard pagination, permissions, and queryset restrictions. Assignment creation from an object view now preselects that object and returns to the originating tab. (#386)
* Consolidated shared ACL Rule code and aligned REST API validation with model validation. Invalid payloads may now return updated wording or multiple applicable errors together. (#67)
* Removed deprecated type arguments from the GraphQL `StrFilterLookup` annotations without changing the generated schema. (#422)

### Bug Fixes

* Prevented interface ACL Assignments from using a direction of `none`. Interface assignments now require ingress or egress, while assignments to Devices, Virtual Chassis, and Virtual Machines continue to use `none`. See the upgrade notes below. (#428)
* Restored the missing Description filter on the Access List filter form. (#417)

### Other Changes

* Added tests for ACL Rule generic relations. (#412)
* Cleaned up release packaging so tests, compiled bytecode, and a misplaced `CODEOWNERS` file are no longer included.
* Updated package metadata, pinned dependencies, and GitHub Actions.

### Upgrade Notes

This release includes two migrations:

* `0014_acl_rule_logging` adds logging fields to both rule models.
* `0015_acl_owner_related_name` updates the `owner` relation for NetBox 4.7 without changing the database schema.

**Existing interface assignments with a direction of `none` are not changed automatically.** There is no safe default direction, and silently deleting an assignment would be worse than leaving it visible.

These assignments continue to display `N/A`, but editing them will fail until ingress or egress is selected. This also applies when bulk-editing an unrelated field. One invalid assignment can cause the whole operation to fail. Review and correct these assignments before or shortly after upgrading.